### PR TITLE
chore: Fix installation step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Credit: [Web Page design source](https://www.figma.com/community/file/9492664364
 	```
 3. Create a site with builder app
 	```sh
-	$ bench --site sitename.localhost install-app builder
+	$ bench --site sitename.localhost install-app website_builder
 	```
 4. Once the site is setup, use bench browse command to open the site in browser
 	```sh


### PR DESCRIPTION
can not install App using command

> bench --site sitename.localhost install-app builder

instead use

> bench --site sitename.localhost install-app website_builder

fixes https://github.com/frappe/builder/issues/3