### PR TITLE
feat: Rudimentary support for JS to make page interactive

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -19,6 +19,7 @@
   "draft_blocks",
   "preview",
   "scripting_tab",
+  "client_script",
   "page_data_script",
   "settings_tab",
   "meta_column",
@@ -122,11 +123,17 @@
    "fieldname": "meta_description",
    "fieldtype": "Small Text",
    "label": "Description"
+  },
+  {
+   "fieldname": "client_script",
+   "fieldtype": "Code",
+   "label": "Client Script",
+   "options": "Javascript"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-28 15:51:19.458047",
+ "modified": "2023-10-26 10:49:44.127249",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Page",

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -77,6 +77,7 @@ class BuilderPage(WebsiteGenerator):
 		context.content = content
 		context.style = style
 		context.style_file_path = get_style_file_path()
+		context.script = self.client_script
 		context.update(page_data)
 		self.set_meta_tags(context=context)
 		try:

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -22,5 +22,10 @@
 	{% block page_content %}
 	{{ content }}
 	{% endblock %}
+	{% block script %}
+		{%- if script -%}
+			<script>{{ script }}</script>
+		{%- endif -%}
+	{%- endblock %}
 </body>
 </html>

--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -84,9 +84,7 @@
 									{{ store.activeBreakpoint }}
 								</span>
 							</span>
-							<div
-								v-show="isExpanded(element) && element.isVisible()"
-								v-if="!element.isImage() && !element.isSVG()">
+							<div v-show="isExpanded(element) && element.isVisible()">
 								<BlockLayers :blocks="element.children" class="ml-3" />
 							</div>
 						</div>

--- a/frontend/src/components/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor.vue
@@ -23,7 +23,7 @@ const props = defineProps({
 		type: [Object, String, Array],
 	},
 	type: {
-		type: String as PropType<"JSON" | "HTML" | "Python">,
+		type: String as PropType<"JSON" | "HTML" | "Python" | "JavaScript">,
 		default: "JSON",
 	},
 	label: {
@@ -56,7 +56,11 @@ onMounted(() => {
 		useWorker: false,
 		showGutter: props.showLineNumbers,
 	});
-	if (props.type === "Python") {
+	if (props.type === "JavaScript") {
+		import("ace-builds/src-noconflict/mode-javascript").then(() => {
+			aceEditor.session.setMode("ace/mode/javascript");
+		});
+	} else if (props.type === "Python") {
 		import("ace-builds/src-noconflict/mode-python").then(() => {
 			aceEditor.session.setMode("ace/mode/python");
 		});

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -1,0 +1,37 @@
+<template>
+	<div class="absolute bottom-0 z-50 h-fit w-full bg-white dark:bg-gray-900">
+		<CodeEditor
+			v-model="page.client_script"
+			type="JavaScript"
+			height="400px"
+			:show-line-numbers="true"></CodeEditor>
+	</div>
+</template>
+<script setup lang="ts">
+import { webPages } from "@/data/webPage";
+import useStore from "@/store";
+import { BuilderPage } from "@/types/Builder/BuilderPage";
+import { watchDebounced } from "@vueuse/core";
+import { ref } from "vue";
+import CodeEditor from "./CodeEditor.vue";
+
+const store = useStore();
+const page = ref<BuilderPage>(store.getActivePage());
+
+watchDebounced(
+	() => page.value.client_script,
+	() => {
+		if (!page.value) return;
+		webPages.setValue
+			.submit({
+				name: page.value.name,
+				client_script: page.value.client_script,
+			})
+			.then(() => {
+				close();
+				store.setPageData();
+			});
+	},
+	{ deep: true }
+);
+</script>

--- a/frontend/src/data/webPage.ts
+++ b/frontend/src/data/webPage.ts
@@ -15,6 +15,7 @@ const webPages = createListResource({
 		"draft_blocks",
 		"published",
 		"dynamic_route",
+		"client_script",
 	],
 	cache: "pages",
 	orderBy: "creation desc",

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -39,6 +39,7 @@
 				v-show="store.showPanels"
 				class="fixed bottom-0 right-0 top-[var(--toolbar-height)] z-20 overflow-auto border-l-[1px] bg-white no-scrollbar dark:border-gray-800 dark:bg-zinc-900"></BuilderRightPanel>
 		</div>
+		<PageScript v-if="store.selectedPage" v-show="showPageScriptPanel"></PageScript>
 	</div>
 </template>
 
@@ -47,6 +48,7 @@ import BuilderCanvas from "@/components/BuilderCanvas.vue";
 import BuilderLeftPanel from "@/components/BuilderLeftPanel.vue";
 import BuilderRightPanel from "@/components/BuilderRightPanel.vue";
 import BuilderToolbar from "@/components/BuilderToolbar.vue";
+import PageScript from "@/components/PageScript.vue";
 import { webPages } from "@/data/webPage";
 import useStore from "@/store";
 import { BuilderComponent } from "@/types/Builder/BuilderComponent";
@@ -56,7 +58,7 @@ import blockController from "@/utils/blockController";
 import getBlockTemplate from "@/utils/blockTemplate";
 import convertHTMLToBlocks from "@/utils/convertHTMLToBlocks";
 import { copyToClipboard, isHTMLString, isJSONString, isTargetEditable } from "@/utils/helpers";
-import { useEventListener, watchDebounced } from "@vueuse/core";
+import { useEventListener, useMagicKeys, watchDebounced, whenever } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import { nextTick, onActivated, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -77,6 +79,14 @@ window.blockController = blockController;
 
 const blockEditor = ref<InstanceType<typeof BuilderCanvas> | null>(null);
 const componentEditor = ref<HTMLElement | null>(null);
+
+const showPageScriptPanel = ref(false);
+const keys = useMagicKeys();
+const CtrlBacktick = keys["Ctrl+`"];
+
+whenever(CtrlBacktick, () => {
+	showPageScriptPanel.value = !showPageScriptPanel.value;
+});
 
 // to disable page zoom
 useEventListener(

--- a/frontend/src/types/Builder/BuilderPage.ts
+++ b/frontend/src/types/Builder/BuilderPage.ts
@@ -1,37 +1,39 @@
-
-export interface BuilderPage{
-	creation: string
-	name: string
-	modified: string
-	owner: string
-	modified_by: string
-	docstatus: 0 | 1 | 2
-	parent?: string
-	parentfield?: string
-	parenttype?: string
-	idx?: number
+export interface BuilderPage {
+	creation: string;
+	name: string;
+	modified: string;
+	owner: string;
+	modified_by: string;
+	docstatus: 0 | 1 | 2;
+	parent?: string;
+	parentfield?: string;
+	parenttype?: string;
+	idx?: number;
 	/**	Published : Check	*/
-	published?: 0 | 1
+	published?: 0 | 1;
 	/**	Page Name : Data	*/
-	page_name?: string
+	page_name?: string;
 	/**	Route : Data	*/
-	route?: string
+	route?: string;
 	/**	Dynamic Route : Check - Map route parameters into form variables. Example <code>/profile/&lt;user&gt;</code>	*/
-	dynamic_route?: 0 | 1
+	dynamic_route?: 0 | 1;
 	/**	Blocks : JSON	*/
-	blocks?: any
+	blocks?: any;
 	/**	Draft Blocks : JSON	*/
-	draft_blocks?: any
+	draft_blocks?: any;
 	/**	Page Preview : Attach Image	*/
-	preview?: string
+	preview?: string;
 	/**	Page Data Script : Code - data.events = frappe.get_list("Event")
 <br>
 <b>Note:</b> Each key value of data should be a list.	*/
-	page_data_script?: string
+	page_data_script?: string;
+
+	client_script?: string;
 	/**	Title : Data	*/
-	page_title?: string
+
+	page_title?: string;
 	/**	Description : Small Text	*/
-	meta_description?: string
+	meta_description?: string;
 	/**	Image : Attach Image	*/
-	meta_image?: string
+	meta_image?: string;
 }


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2023-10-26 at 12 40 43 PM" src="https://github.com/frappe/builder/assets/13928957/ba7ae27e-5cf1-49b8-8392-093ed49d2083">

to open and close JS script panel, use "ctrl + `" shortcut (only way as of now.)