### PR TITLE
fix: Load csrf_token to the page regardless of view_tracking flag

### DIFF
--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -40,9 +40,9 @@
 		<img src="/assets/builder/frontend/builder_logo.png" style="box-shadow: #bdbdbd 0px 0px 5px; border-radius: 10px;" alt="Frappe" />
 	</a>
 	<script>window.page_data = {{ (page_data or {})|tojson|safe }}</script>
-	{% if enable_view_tracking and not preview %}
 	<script>if (!window.frappe) window.frappe = {};</script>
 	<!-- csrf_token -->
+	{% if enable_view_tracking and not preview %}
 	<script async>
 		if (navigator.doNotTrack != 1) {document.addEventListener("DOMContentLoaded", function() {let b=getBrowser(),q=getQueryParams();import('https://openfpcdn.io/fingerprintjs/v3').then(f=>f.load()).then(fp=>fp.get()).then(r=>{const d={referrer:document.referrer,browser:b.name,version:b.version,user_tz:Intl.DateTimeFormat().resolvedOptions().timeZone,source:q.source,medium:q.medium,campaign:q.campaign,visitor_id:r.visitorId};makeViewLog(d)})})}function getBrowser(){const ua=navigator.userAgent,b={};if(ua.indexOf("Chrome")!==-1){b.name="Chrome";b.version=parseInt(ua.split("Chrome/")[1])}else if(ua.indexOf("Firefox")!==-1){b.name="Firefox";b.version=parseInt(ua.split("Firefox/")[1])}else{b.name="Unknown";b.version="Unknown"}return b}function getQueryParams(){const q={},p=window.location.search.substring(1).split("&");p.forEach(p=>{const [k,v]=p.split("=");q[k]=v});return q}function makeViewLog(d){fetch('/api/method/frappe.website.doctype.web_page_view.web_page_view.make_view_log',{method:'POST',headers:{'Content-Type':'application/json',"X-Frappe-CSRF-Token": frappe.csrf_token},body:JSON.stringify(d)})}
 	</script>


### PR DESCRIPTION
Load `csrf_token` to the page regardless of view_tracking flag