### PR TITLE
refactor: enable change tracking on Builder Pages

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -170,5 +170,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "title_field": "page_title"
+ "title_field": "page_title",
+ "track_changes": 1
 }


### PR DESCRIPTION
In the future, it would be great to have a UI for versioning management, but for now, I think we should start tracking changes, so there's some kind of fallback when things to awry.