### PR TITLE
fix: Update build root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "ace-builds": "^1.22.0",
     "autoprefixer": "^10.4.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "^0.1.36",
+    "frappe-ui": "^0.1.43",
     "pinia": "^2.0.28",
     "postcss": "^8.4.5",
     "tailwindcss": "^3.3.2",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
 		},
 	},
 	build: {
-		outDir: `../${path.basename(path.resolve(".."))}/public/frontend`,
+		outDir: `../builder/public/frontend`,
 		emptyOutDir: true,
 		target: "es2015",
 		sourcemap: true,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,18 +1,14 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import path from "path";
-import { webserver_port } from "../../../sites/common_site_config.json";
+import frappeui from "frappe-ui/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
 	define: {
 		__VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
 	},
-	plugins: [vue()],
-	server: {
-		port: 8080,
-		proxy: getProxyOptions({ port: webserver_port }),
-	},
+	plugins: [frappeui({ regex: "^/(app|login|api|assets|files|pages)" }), vue()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),
@@ -28,16 +24,3 @@ export default defineConfig({
 		include: ["frappe-ui > feather-icons", "showdown", "engine.io-client"],
 	},
 });
-
-function getProxyOptions({ port }) {
-	return {
-		"^/(app|login|api|assets|files|pages)": {
-			target: `http://127.0.0.1:${port}`,
-			ws: true,
-			router: function (req) {
-				const site_name = req.headers.host.split(":")[0];
-				return `http://${site_name}:${port}`;
-			},
-		},
-	};
-}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
 	define: {
 		__VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
 	},
-	plugins: [frappeui({ regex: "^/(app|login|api|assets|files|pages)" }), vue()],
+	plugins: [frappeui({ source: "^/(app|login|api|assets|files|pages)" }), vue()],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
- fix: update prettier
- fix: build issue in alternative build root
- fix: repo folder can be distinct from app name

fixes: https://github.com/frappe/builder/issues/117

This uses the same strategy as `frappe-ui`.
