### PR TITLE
chore: cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@ node_modules
 builder/public/frontend
 builder/public/page_scripts
 builder/public/page_styles
-builder/www/index.html
-builder/www/p.html
 builder/www/builder.html


### PR DESCRIPTION
# Context
I used the gitignore file to infer the build artifacts.

But these entries looked like legacy and where not intelligible in the context of the published build pipeline.
