### PR TITLE
feat: Use centralised preview generator to generate preview

### DIFF
--- a/builder/html_preview_image.py
+++ b/builder/html_preview_image.py
@@ -1,13 +1,25 @@
 import frappe
-from install_playwright import install
-from playwright.sync_api import sync_playwright
+import requests
+import html as html_parser
+
+# TODO: Find better alternative
+# Note: while working locally, "preview.frappe.cloud" won't be able to generate preview properly since it can't access local server for assets
+# So, for local development, better to use local server for preview generation
+# (https://github.com/frappe/preview_generator)
+PREVIEW_GENERATOR_URL = (
+	frappe.conf.preview_generator_url
+	or "https://preview.frappe.cloud/api/method/preview_generator.api.generate_preview"
+)
 
 
 def generate_preview(html, output_path):
-	with sync_playwright() as p:
-		browser = p.chromium.launch()
-		page = browser.new_page()
-		page.set_content(html)
-		page.wait_for_load_state('networkidle')
-		page.screenshot(path=output_path, quality=30, type='jpeg')
-		browser.close()
+	escaped_html = html_parser.escape(html)
+	response = requests.post(PREVIEW_GENERATOR_URL, json={
+		'html': escaped_html,
+	})
+	if response.status_code == 200:
+		with open(output_path, 'wb') as f:
+			f.write(response.content)
+	else:
+		exception = response.json().get('exc')
+		raise Exception(frappe.parse_json(exception)[0])

--- a/builder/install.py
+++ b/builder/install.py
@@ -3,5 +3,4 @@ from frappe.core.api.file import create_new_folder
 
 
 def after_install():
-	frappe.utils.execute_in_shell("PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium")
 	create_new_folder("Builder Uploads", "Home")

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<base href="{{ base_url }}">
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,7 +10,7 @@
 	<link rel="icon" href="{{ favicon_dark or favicon or '/assets/builder/images/frappe_white.png' }}"  media="(prefers-color-scheme: dark)"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	{% block meta_block %}{% include "templates/includes/meta_block.html" %}{% endblock %}
-	<link rel="stylesheet" href="{{ base_url }}assets/builder/reset.css?v=1" media="screen">
+	<link rel="stylesheet" href="/assets/builder/reset.css?v=1" media="screen">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	{% for (font, options) in fonts.items() %}<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ font }}:wght@{{ ";".join(options.weights) }}&display=swap" media="screen">{% endfor %}
 	{{ style }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
-playwright
-install-playwright

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
-import os
-import atexit
-import subprocess
 from setuptools import find_packages, setup
-from setuptools.command.develop import develop
 
 with open("requirements.txt") as f:
 	install_requires = f.read().strip().split("\n")
@@ -10,30 +6,13 @@ with open("requirements.txt") as f:
 # get version from __version__ variable in builder/__init__.py
 from builder import __version__ as version
 
-
-def install_playwright():
-	python_path = os.path.join("..", "..", "env", "bin", "python")
-	print(subprocess.run(f"{python_path} -m playwright install chromium", shell=True))
-
-
-class RunDevelopCommand(develop):
-	def __init__(self, *args, **kwargs):
-		super(RunDevelopCommand, self).__init__(*args, **kwargs)
-		# This is a hack to ensure that the command is run
-		# after all the dependencies are installed
-		atexit.register(install_playwright)
-
-
 setup(
 	name="builder",
 	version=version,
 	author="Suraj Shetty",
-	author_email="surajshetty3416@gmail.com",
+	author_email="suraj@frappe.io",
 	packages=find_packages(),
 	zip_safe=False,
 	include_package_data=True,
 	install_requires=install_requires,
-	cmdclass={
-		"develop": RunDevelopCommand,
-	},
 )


### PR DESCRIPTION
- Many users are unable to set dependencies for playwright properly which is why they have no preview.

We are using "preview.frappe.cloud" which is a frappe site with [preview_generator](https://github.com/frappe/preview_generator) app.