### PR TITLE
fix: Instantly unpublish page on unpublishing from builder

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -82,6 +82,7 @@ class BuilderPage(WebsiteGenerator):
 			find_page_with_path.clear_cache()
 
 		if self.has_value_changed("published") and not self.published:
+			find_page_with_path.clear_cache()
 			clear_cache(self.route)
 			# if this is homepage then clear homepage from builder settings
 			if frappe.get_cached_value("Builder Settings", None, "home_page") == self.route:

--- a/frontend/src/components/BlockContextMenu.vue
+++ b/frontend/src/components/BlockContextMenu.vue
@@ -45,8 +45,9 @@ import blockController from "@/utils/blockController";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { confirm, detachBlockFromComponent, getBlockCopy } from "@/utils/helpers";
 import { vOnClickOutside } from "@vueuse/components";
+import { useStorage } from "@vueuse/core";
 import { Dialog } from "frappe-ui";
-import { nextTick, ref } from "vue";
+import { Ref, nextTick, ref } from "vue";
 import { toast } from "vue-sonner";
 import ContextMenu from "./ContextMenu.vue";
 const store = useStore();
@@ -81,15 +82,17 @@ const handleContextMenuSelect = (action: CallableFunction) => {
 	contextMenuVisible.value = false;
 };
 
+const copiedStyle = useStorage("copiedStyle", { blockId: "", style: {} }, sessionStorage) as Ref<StyleCopy>;
+
 const copyStyle = () => {
-	store.copiedStyle = {
+	copiedStyle.value = {
 		blockId: props.block.blockId,
 		style: props.block.getStylesCopy(),
 	};
 };
 
 const pasteStyle = () => {
-	props.block.updateStyles(store.copiedStyle?.style as BlockStyleObjects);
+	props.block.updateStyles(copiedStyle.value?.style as BlockStyleObjects);
 };
 
 const duplicateBlock = () => {
@@ -129,7 +132,7 @@ const contextMenuOptions: ContextMenuOption[] = [
 	{
 		label: "Paste Style",
 		action: pasteStyle,
-		condition: () => Boolean(store.copiedStyle && store.copiedStyle.blockId !== props.block.blockId),
+		condition: () => Boolean(copiedStyle.value.blockId && copiedStyle.value?.blockId !== props.block.blockId),
 	},
 	{ label: "Duplicate", action: duplicateBlock },
 	{

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -107,9 +107,9 @@ import {
 	isJSONString,
 	isTargetEditable,
 } from "@/utils/helpers";
-import { useActiveElement, useDebounceFn, useEventListener, useMagicKeys } from "@vueuse/core";
+import { useActiveElement, useDebounceFn, useEventListener, useMagicKeys, useStorage } from "@vueuse/core";
 import { Dialog } from "frappe-ui";
-import { computed, nextTick, onActivated, provide, ref, watch, watchEffect } from "vue";
+import { Ref, computed, nextTick, onActivated, provide, ref, watch, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 import CodeEditor from "../components/CodeEditor.vue";
@@ -489,7 +489,12 @@ useEventListener(document, "keydown", (e) => {
 		if (blockController.isBLockSelected() && !blockController.multipleBlocksSelected()) {
 			e.preventDefault();
 			const block = blockController.getSelectedBlocks()[0];
-			store.copiedStyle = {
+			const copiedStyle = useStorage(
+				"copiedStyle",
+				{ blockId: "", style: {} },
+				sessionStorage
+			) as Ref<StyleCopy>;
+			copiedStyle.value = {
 				blockId: block.blockId,
 				style: block.getStylesCopy(),
 			};

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -52,7 +52,6 @@ const useStore = defineStore("store", {
 		rightPanelActiveTab: <RightSidebarTabOption>"Properties",
 		showRightPanel: <boolean>true,
 		showLeftPanel: <boolean>true,
-		copiedStyle: <StyleCopy | null>null,
 		components: <BlockComponent[]>[],
 		showHTMLDialog: false,
 		activePage: <BuilderPage | null>null,


### PR DESCRIPTION
- Due to cache, unpublished pages were visible for some time
- Unrelated fix: Allow copying style across pages