### PR TITLE
master

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -65,7 +65,6 @@
    "fieldname": "preview",
    "fieldtype": "Data",
    "label": "Page Preview",
-   "options": "URL",
    "read_only": 1
   },
   {


### PR DESCRIPTION
- fix: let save again

This is a hotfix for v1.10.2

`/files/...` don't have a netloc:

```py
def validate_url(
	txt: str,
	throw: bool = False,
	valid_schemes: str | Container[str] | None = None,
) -> bool:
	"""
	Checks whether `txt` has a valid URL string

	Parameters:
	        throw (`bool`): throws a validationError if URL is not valid
	        valid_schemes (`str` or `list`): if provided checks the given URL's scheme against this

	Returns:
	        bool: if `txt` represents a valid URL
	"""
	url = urlparse(txt)
	is_valid = bool(url.netloc)

	# Handle scheme validation
	if isinstance(valid_schemes, str):
		is_valid = is_valid and (url.scheme == valid_schemes)
	elif isinstance(valid_schemes, list | tuple | set):
		is_valid = is_valid and (url.scheme in valid_schemes)

	if not is_valid and throw:
		frappe.throw(frappe._("'{0}' is not a valid URL").format(frappe.bold(txt)))

	return is_valid
```
