### PR TITLE
build: initial docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ Frappe Builder is a low-code website builder designed for simplicity, speed, and
 
 Get started with your personal or business site with a few clicks on [Frappe Cloud](https://frappecloud.com/builder/signup).
 
+### Docker (Recommended)
+
+The quickest way to set up Frappe Builder and take it for a test ride.
+
+Frappe framework is multi-tenant and supports multiple apps by default. This docker compose is just a standalone version with Frappe Builder pre-installed. Just put it behind your desired reverse-proxy if needed, and you're good to go.  
+  
+If you wish to use multiple Frappe apps or need multi-tenancy. Take a look at our production ready self-hosted workflow, or join us on Frappe Cloud to get first party support and hassle-free hosting.
+
+**Step 1**: Setup folder and download the required files
+
+    mkdir frappe-builder
+    cd frappe-builder
+
+**Step 2**: Download the required files
+
+Docker Compose File:
+
+    wget -O docker-compose.yml https://raw.githubusercontent.com/frappe/builder/develop/docker/docker-compose.yml
+
+Frappe Builder bench setup script
+
+    wget -O init.sh https://raw.githubusercontent.com/frappe/builder/develop/docker/init.sh
+
+**Step 3**: Run the container and daemonize it
+
+    docker compose up -d
+
+**Step 4**: The site [http://builder.localhost](http://builder.localhost) should now be available. The default credentials are:
+
+> username: administrator  
+> password: admin
+
 ### Self-hosting
 
 If you prefer self-hosting, follow the official [Frappe Bench Installation](https://github.com/frappe/bench#installation) instructions.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+services:
+  mariadb:
+    image: mariadb:10.8
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: 123
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+  redis:
+    image: redis:alpine
+
+  frappe:
+    image: frappe/bench:latest
+    command: bash /workspace/init.sh
+    environment:
+      - SHELL=/bin/bash
+    working_dir: /home/frappe
+    volumes:
+      - .:/workspace
+    ports:
+      - 8000:8000
+      - 9000:9000
+
+volumes:
+  mariadb-data:

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,39 @@
+#!bin/bash
+
+if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
+    echo "Bench already exists, skipping init"
+    cd frappe-bench
+    bench start
+else
+    echo "Creating new bench..."
+fi
+
+bench init --skip-redis-config-generation frappe-bench --version version-15
+
+cd frappe-bench
+
+# Use containers instead of localhost
+bench set-mariadb-host mariadb
+bench set-redis-cache-host redis:6379
+bench set-redis-queue-host redis:6379
+bench set-redis-socketio-host redis:6379
+
+# Remove redis, watch from Procfile
+sed -i '/redis/d' ./Procfile
+sed -i '/watch/d' ./Procfile
+
+bench get-app builder --branch develop
+
+bench new-site builder.localhost \
+--force \
+--mariadb-root-password 123 \
+--admin-password admin \
+--no-mariadb-socket
+
+bench --site builder.localhost install-app builder
+bench --site builder.localhost set-config developer_mode 1
+bench --site builder.localhost clear-cache
+bench --site builder.localhost set-config mute_emails 1
+bench use builder.localhost
+
+bench start


### PR DESCRIPTION
Basic docker compose. Same one as other new products. Need to look into shipping HTTPS with this. 

Steps:
https://docs.frappe.io/builder/setting-up