### PR TITLE
fix: consider configured builder app path in builder page link

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.js
+++ b/builder/builder/doctype/builder_page/builder_page.js
@@ -5,10 +5,16 @@ frappe.ui.form.on("Builder Page", {
   refresh(frm) {
     // only show in developer mode
     if (frappe.boot.developer_mode || !frm.doc.is_template) {
-      frm.sidebar
-        .add_user_action(__("Open in Builder"))
-        .attr("href", `/builder/page/${frm.doc.name}`)
-        .attr("target", "_blank");
+      frappe
+        .call(
+          "builder.builder.doctype.builder_page.builder_page.get_builder_path",
+        )
+        .then((r) => {
+          frm.sidebar
+            .add_user_action(__("Open in Builder"))
+            .attr("href", `/${r.message}/page/${frm.doc.name}`)
+            .attr("target", "_blank");
+        });
     }
   },
   onload(frm) {

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -156,7 +156,7 @@ class BuilderPage(WebsiteGenerator):
 		context.fonts = fonts
 		context.content = content
 		context.style = render_template(style, page_data)
-		builder_path = frappe.conf.builder_path or "builder"
+		builder_path = get_builder_path()
 		context.editor_link = f"/{builder_path}/page/{self.name}"
 
 		if self.dynamic_route and hasattr(frappe.local, "request"):
@@ -234,6 +234,11 @@ class BuilderPage(WebsiteGenerator):
 			local_path,
 		)
 		self.db_set("preview", public_path, commit=True, update_modified=False)
+
+
+@frappe.whitelist()
+def get_builder_path() -> str:
+	return frappe.conf.builder_path or "builder"
 
 
 def save_as_template(page_doc: BuilderPage):


### PR DESCRIPTION
The "Open in Builder" link does not honor configured builder path from site config

https://github.com/user-attachments/assets/8b740a3f-3dc5-4826-aeea-a0dde0c22252

