### PR TITLE
fix: generate the route value only if self.route is empty

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -82,9 +82,10 @@ class BuilderPage(WebsiteGenerator):
 			self.preview = "/assets/builder/images/fallback.png"
 		if not self.page_title:
 			self.page_title = "My Page"
-		self.route = (
-			f"pages/{camel_case_to_kebab_case(self.page_title, True)}-{frappe.generate_hash(length=4)}"
-		)
+		if not self.route:
+			self.route = (
+				f"pages/{camel_case_to_kebab_case(self.page_title, True)}-{frappe.generate_hash(length=4)}"
+			)
 
 	def on_update(self):
 		if self.has_value_changed("dynamic_route") or self.has_value_changed("route"):


### PR DESCRIPTION
Creating this PR to allow route auto-generation only if the route is not already set.

To maintain all the builder pages in the repository we used the `bench export-fixtures` option.
Upon using the `bench migrate` on production environment all the routes auto-generated. Routes from the fixtures are not picked up.
To resolve the issue added a check in the `before_insert` method of `builder_page.py`.
This is to ensure that the fixtures import doesn't mess up the routes.