### PR TITLE
perf: Remove frappe-builder from class names to save some KBs

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -350,7 +350,7 @@ def get_block_html(blocks):
 					tag[key] = value
 
 			if block.get("baseStyles", {}):
-				style_class = f"frappe-builder-{frappe.generate_hash(length=8)}"
+				style_class = f"fb-{frappe.generate_hash(length=8)}"
 				base_styles = block.get("baseStyles", {})
 				mobile_styles = block.get("mobileStyles", {})
 				tablet_styles = block.get("tabletStyles", {})

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Made with Frappe Builder -->
 <html lang="en">
 <head>
 	<base href="{{ base_url }}">


### PR DESCRIPTION
Removed frappe-builder from class names to save some KBs. It also makes the DOM look cleaner ✨

On bigger pages with 500+ element the difference is noticeable!

**Before:**
![Screenshot 2024-08-28 at 1 54 16 PM](https://github.com/user-attachments/assets/2f2dbd86-3942-4b33-b707-8911f8eaff29)

**After:** (**-15KB** almost a size of small library!)
![Screenshot 2024-08-28 at 1 53 51 PM](https://github.com/user-attachments/assets/8663061b-101a-4e95-a604-a8cd09a9d141)
