### PR TITLE
feat: Add custom history manager for canvas for more control

### DIFF
--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -15,11 +15,7 @@
 							:title="element.blockId"
 							@contextmenu.prevent.stop="onContextMenu"
 							class="min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7"
-							@click.stop="
-								store.activeCanvas?.history.pause();
-								store.selectBlock(element, $event, false, true);
-								store.activeCanvas?.history.resume();
-							"
+							@click.stop="selectBlock(element, $event)"
 							@mouseover.stop="store.hoveredBlock = element.blockId"
 							@mouseleave.stop="store.hoveredBlock = null">
 							<span
@@ -205,6 +201,12 @@ const blockExitsInTree = (block: Block) => {
 		}
 	}
 	return false;
+};
+
+const selectBlock = (block: Block, event: MouseEvent) => {
+	const pauseId = store.activeCanvas?.history?.pause();
+	store.selectBlock(block, event, false, true);
+	pauseId && store.activeCanvas?.history?.resume(pauseId);
 };
 
 defineExpose({

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -60,10 +60,10 @@ onMounted(() => {
 
 watch(resizing, () => {
 	if (resizing.value) {
-		store.activeCanvas?.history.pause();
+		store.activeCanvas?.history?.pause();
 		emit("resizing", true);
 	} else {
-		store.activeCanvas?.history.resume(true);
+		store.activeCanvas?.history?.resume(undefined, true, true);
 		emit("resizing", false);
 	}
 });

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -83,19 +83,12 @@ import {
 	addPxToNumber,
 	getBlockCopy,
 	getBlockInstance,
-	getBlockObject,
 	getNumberFromPx,
 	isTargetEditable,
 	uploadImage,
 } from "@/utils/helpers";
-import {
-	UseRefHistoryReturn,
-	clamp,
-	useDebouncedRefHistory,
-	useDropZone,
-	useElementBounding,
-	useEventListener,
-} from "@vueuse/core";
+import { useCanvasHistory } from "@/utils/useCanvasHistory";
+import { clamp, useDropZone, useElementBounding, useEventListener } from "@vueuse/core";
 import { FeatherIcon } from "frappe-ui";
 import { Ref, computed, nextTick, onMounted, provide, reactive, ref, watch } from "vue";
 import { toast } from "vue-sonner";
@@ -161,7 +154,7 @@ const canvasProps = reactive({
 	],
 });
 
-const canvasHistory = ref(null) as Ref<UseRefHistoryReturn<{}, {}>> | Ref<null>;
+const canvasHistory = ref(null) as Ref<ReturnType<typeof useCanvasHistory>> | Ref<null>;
 
 provide("canvasProps", canvasProps);
 
@@ -172,17 +165,7 @@ onMounted(() => {
 });
 
 function setupHistory() {
-	canvasHistory.value = useDebouncedRefHistory(block, {
-		capacity: 50,
-		deep: true,
-		debounce: 200,
-		dump: (obj) => {
-			return getBlockObject(obj);
-		},
-		parse: (obj) => {
-			return getBlockInstance(obj);
-		},
-	});
+	canvasHistory.value = useCanvasHistory(block, selectedBlockIds) as ReturnType<typeof useCanvasHistory>;
 }
 
 const { isOverDropZone } = useDropZone(canvasContainer, {
@@ -823,7 +806,7 @@ defineExpose({
 	moveCanvas,
 	zoomIn,
 	zoomOut,
-	history: canvasHistory as Ref<UseRefHistoryReturn<{}, {}>>,
+	history: canvasHistory,
 	clearCanvas,
 	getFirstBlock,
 	block,

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -290,7 +290,7 @@ function setEvents() {
 		if (store.mode === "select") {
 			return;
 		} else {
-			canvasHistory.value?.pause();
+			const pauseId = canvasHistory.value?.pause();
 			ev.stopPropagation();
 			let element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
 			let block = getFirstBlock();
@@ -358,7 +358,7 @@ function setEvents() {
 						store.mode = "select";
 					}, 50);
 					if (store.mode === "text") {
-						canvasHistory.value?.resume(true);
+						pauseId && canvasHistory.value?.resume(pauseId, true);
 						store.editableBlock = childBlock;
 						return;
 					}
@@ -373,7 +373,7 @@ function setEvents() {
 							childBlock.setBaseStyle("height", "200px");
 						}
 					}
-					canvasHistory.value?.resume(true);
+					pauseId && canvasHistory.value?.resume(pauseId, true);
 				},
 				{ once: true },
 			);

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -155,6 +155,7 @@ const setHueSelectorPosition = (color: HashString) => {
 
 const handleSelectorMove = (ev: MouseEvent) => {
 	setColor(ev);
+	const pauseId = store.activeCanvas?.history?.pause();
 	const mouseMove = (mouseMoveEvent: MouseEvent) => {
 		mouseMoveEvent.preventDefault();
 		setColor(mouseMoveEvent);
@@ -165,6 +166,7 @@ const handleSelectorMove = (ev: MouseEvent) => {
 		(mouseUpEvent) => {
 			document.removeEventListener("mousemove", mouseMove);
 			mouseUpEvent.preventDefault();
+			pauseId && store.activeCanvas?.history?.resume(pauseId, true);
 		},
 		{ once: true },
 	);
@@ -172,7 +174,7 @@ const handleSelectorMove = (ev: MouseEvent) => {
 
 const handleHueSelectorMove = (ev: MouseEvent) => {
 	setHue(ev);
-	store.activeCanvas?.history.pause();
+	const pauseId = store.activeCanvas?.history?.pause();
 	const mouseMove = (mouseMoveEvent: MouseEvent) => {
 		mouseMoveEvent.preventDefault();
 		setHue(mouseMoveEvent);
@@ -183,7 +185,7 @@ const handleHueSelectorMove = (ev: MouseEvent) => {
 		(mouseUpEvent) => {
 			document.removeEventListener("mousemove", mouseMove);
 			mouseUpEvent.preventDefault();
-			store.activeCanvas?.history.resume(true);
+			pauseId && store.activeCanvas?.history?.resume(pauseId, true);
 		},
 		{ once: true },
 	);

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -32,7 +32,7 @@
 				<TextInput
 					v-model="textLink"
 					placeholder="https://example.com"
-					class="link-input focus:[&>input]:ring-outline-gray-3 w-56 text-sm [&>input]:border-outline-gray-1 [&>input]:bg-surface-gray-2 [&>input]:text-ink-gray-8 [&>input]:hover:!border-outline-gray-2 [&>input]:hover:!bg-surface-gray-1 focus:[&>input]:border-outline-gray-3 focus:[&>input]:bg-surface-gray-1 [&>input]:focus-visible:bg-surface-gray-1"
+					class="link-input w-56 text-sm [&>input]:border-outline-gray-1 [&>input]:bg-surface-gray-2 [&>input]:text-ink-gray-8 [&>input]:hover:!border-outline-gray-2 [&>input]:hover:!bg-surface-gray-1 focus:[&>input]:border-outline-gray-3 focus:[&>input]:bg-surface-gray-1 focus:[&>input]:ring-outline-gray-3 [&>input]:focus-visible:bg-surface-gray-1"
 					@keydown.enter="
 						() => {
 							if (!linkInput) return;
@@ -227,10 +227,10 @@ watch(
 	(editable) => {
 		editor.value?.setEditable(editable);
 		if (editable) {
-			store.activeCanvas?.history.pause();
+			store.activeCanvas?.history?.pause();
 			editor.value?.commands.focus("all");
 		} else {
-			store.activeCanvas?.history.resume(dataChanged.value);
+			store.activeCanvas?.history?.resume(undefined, dataChanged.value, true);
 			dataChanged.value = false;
 		}
 	},

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -343,12 +343,12 @@ useEventListener(document, "paste", async (e) => {
 // TODO: Refactor with useMagicKeys
 useEventListener(document, "keydown", (e) => {
 	if (isTargetEditable(e)) return;
-	if (e.key === "z" && isCtrlOrCmd(e) && !e.shiftKey && store.activeCanvas?.history.canUndo) {
+	if (e.key === "z" && isCtrlOrCmd(e) && !e.shiftKey && store.activeCanvas?.history?.canUndo) {
 		store.activeCanvas?.history.undo();
 		e.preventDefault();
 		return;
 	}
-	if (e.key === "z" && e.shiftKey && isCtrlOrCmd(e) && store.activeCanvas?.history.canRedo) {
+	if (e.key === "z" && e.shiftKey && isCtrlOrCmd(e) && store.activeCanvas?.history?.canRedo) {
 		store.activeCanvas?.history.redo();
 		e.preventDefault();
 		return;

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -214,7 +214,6 @@ const useStore = defineStore("store", {
 			scrollLayerIntoView: boolean | ScrollLogicalPosition = true,
 			scrollBlockIntoView = false,
 		) {
-			this.activeCanvas?.history?.pause();
 			if (this.settingPage) {
 				return;
 			}
@@ -234,8 +233,6 @@ const useStore = defineStore("store", {
 						?.scrollIntoView({ behavior: "instant", block: align, inline: "center" });
 				});
 			}
-
-			this.activeCanvas?.history?.resume();
 			this.editableBlock = null;
 			if (scrollBlockIntoView) {
 				this.activeCanvas?.scrollBlockIntoView(block);

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -734,7 +734,7 @@ class Block implements BlockOptions {
 			return;
 		}
 		const store = useStore();
-		store.activeCanvas?.history.pause();
+		const pauseId = store.activeCanvas?.history?.pause();
 		const blockCopy = getBlockCopy(this);
 		const parentBlock = this.getParentBlock();
 
@@ -756,8 +756,8 @@ class Block implements BlockOptions {
 			if (child) {
 				child.selectBlock();
 			}
-			store.activeCanvas?.history.resume(true);
 		});
+		pauseId && store.activeCanvas?.history?.resume(pauseId, true);
 	}
 	getPadding() {
 		const padding = this.getStyle("padding") || "0px";

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -423,6 +423,10 @@ async function getFontName(file_url: string) {
 	return opentype.parse(await getFontArrayBuffer(file_url)).names.fullName.en;
 }
 
+function generateId() {
+	return Math.random().toString(36).substr(2, 9);
+}
+
 export {
 	addPxToNumber,
 	alert,
@@ -431,6 +435,7 @@ export {
 	dataURLtoFile,
 	detachBlockFromComponent,
 	findNearestSiblingIndex,
+	generateId,
 	getBlockCopy,
 	getBlockInstance,
 	getBlockObjectCopy as getBlockObject,

--- a/frontend/src/utils/useCanvasHistory.ts
+++ b/frontend/src/utils/useCanvasHistory.ts
@@ -1,0 +1,109 @@
+import Block from "@/utils/block";
+import { getBlockInstance, getBlockObject } from "@/utils/helpers";
+import { debounceFilter, pausableFilter, watchIgnorable } from "@vueuse/core";
+import { nextTick, ref, Ref } from "vue";
+
+type CanvasState = {
+	block: Block;
+	selectedBlockIds: string[];
+};
+const CAPACITY = 50;
+const DEBOUNCE_DELAY = 200;
+
+export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<string[]>) {
+	const {
+		eventFilter: composedFilter,
+		pause,
+		resume: resumeTracking,
+		isActive: isTracking,
+	} = pausableFilter(debounceFilter(DEBOUNCE_DELAY));
+
+	const { ignoreUpdates, ignorePrevAsyncUpdates, stop } = watchIgnorable(source, commit, {
+		deep: true,
+		flush: "post",
+		eventFilter: composedFilter,
+	});
+
+	function setSource(value: string) {
+		const obj = JSON.parse(value) as CanvasState;
+		ignorePrevAsyncUpdates();
+		ignoreUpdates(() => {
+			source.value = getBlockInstance(obj.block);
+			selectedBlockIds.value = obj.selectedBlockIds;
+		});
+	}
+	const last = ref(createHistoryRecord(source, selectedBlockIds));
+	function commit() {
+		nextTick(() => {
+			undoStack.value.unshift(last.value);
+			last.value = createHistoryRecord(source, selectedBlockIds);
+			if (undoStack.value.length > CAPACITY) {
+				undoStack.value.splice(CAPACITY, Number.POSITIVE_INFINITY);
+			}
+			if (redoStack.value.length) {
+				redoStack.value.splice(0, redoStack.value.length);
+			}
+		});
+	}
+	const undoStack = ref([]) as Ref<string[]>;
+	const redoStack = ref([]) as Ref<string[]>;
+
+	function undo() {
+		const state = undoStack.value.shift();
+		if (state) {
+			redoStack.value.unshift(last.value);
+			setSource(state);
+		}
+	}
+
+	function redo() {
+		const state = redoStack.value.shift();
+		if (state) {
+			undoStack.value.unshift(last.value);
+			setSource(state);
+		}
+	}
+
+	const clear = () => {
+		undoStack.value.splice(0, undoStack.value.length);
+		redoStack.value.splice(0, redoStack.value.length);
+	};
+
+	function dispose() {
+		stop();
+		clear();
+	}
+
+	function resume(commitNow?: boolean) {
+		resumeTracking();
+		if (commitNow) commit();
+	}
+
+	function canUndo() {
+		return undoStack.value.length > 0;
+	}
+
+	function canRedo() {
+		return redoStack.value.length > 0;
+	}
+
+	return {
+		undo,
+		redo,
+		dispose,
+		pause,
+		resumeTracking,
+		resume,
+		isTracking,
+		canUndo,
+		canRedo,
+		batch: () => {},
+	};
+}
+
+function createHistoryRecord(source: Ref<Block>, selectedBlockIds: Ref<string[]>) {
+	return JSON.stringify({
+		block: getBlockObject(source.value),
+		selectedBlockIds: selectedBlockIds.value,
+	});
+}

--- a/frontend/src/utils/useDraggableBlock.ts
+++ b/frontend/src/utils/useDraggableBlock.ts
@@ -34,7 +34,7 @@ export function useDraggableBlock(block: Block, target: HTMLElement, options: { 
 	};
 
 	const handleDrop = (e: DragEvent) => {
-		store.activeCanvas?.history.pause();
+		const pauseId = store.activeCanvas?.history?.pause();
 		// move block to new container
 		if (e.dataTransfer) {
 			const draggingBlockId = e.dataTransfer.getData("draggingBlockId");
@@ -55,7 +55,7 @@ export function useDraggableBlock(block: Block, target: HTMLElement, options: { 
 				e.stopPropagation();
 			}
 		}
-		store.activeCanvas?.history.resume(true);
+		pauseId && store.activeCanvas?.history?.resume(pauseId, true);
 	};
 
 	const handleDragEnd = (e: DragEvent) => {


### PR DESCRIPTION
This was done mainly to maintain the selected block states with canvasBlock snapshot so that affected block gets highlighted during undo and redo

- Fixed a case where duplicate snapshots was getting created while creating a new block
- This should also minimize storage required to store history snapshot by eliminating unnecessary data 