### PR TITLE
fix: Component System

### DIFF
--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -162,7 +162,7 @@ const getStyleClasses = computed(() => {
 	if (movable.value && !props.block.isRoot()) {
 		classes.push("cursor-grab");
 	}
-	if (Boolean(props.block.extendedFromComponent)) {
+	if (props.block.isExtendedFromComponent()) {
 		classes.push("ring-purple-400");
 	} else {
 		classes.push("ring-blue-400");

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -2,7 +2,10 @@
 	<div
 		ref="handler"
 		class="border-radius-resize pointer-events-auto absolute h-[10px] w-[10px] cursor-pointer rounded-full border-2 border-blue-400 bg-white"
-		:class="{ hidden: !isHandlerVisible }"
+		:class="{
+			hidden: !isHandlerVisible,
+			'border-purple-400': targetBlock.isExtendedFromComponent(),
+		}"
 		:style="handlerPosition"
 		@mousedown.stop="handleRounded">
 		<div

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -25,6 +25,9 @@
 		@mousedown.stop="handleBottomResize" />
 	<div
 		class="pointer-events-auto absolute bottom-[-5px] right-[-5px] h-[12px] w-[12px] cursor-nwse-resize rounded-full border-[2.5px] border-blue-400 bg-white"
+		:class="{
+			'border-purple-400': targetBlock.isExtendedFromComponent(),
+		}"
 		v-show="!resizing"
 		@mousedown.stop.prevent="handleBottomCornerResize" />
 </template>

--- a/frontend/src/components/BuilderAssets.vue
+++ b/frontend/src/components/BuilderAssets.vue
@@ -25,7 +25,7 @@
 								store.fragmentData.fragmentId === component.name ||
 								componentStore.selectedComponent === component.component_id,
 						}">
-						<div class="flex items-center gap-2 text-ink-gray-5">
+						<div class="flex items-center gap-2 text-ink-gray-7">
 							<FeatherIcon :name="'box'" class="h-4 w-4"></FeatherIcon>
 							<p class="text-base">
 								{{ component.component_name }}

--- a/frontend/src/components/Modals/NewComponent.vue
+++ b/frontend/src/components/Modals/NewComponent.vue
@@ -62,6 +62,8 @@ const createComponentHandler = async (context: { close: () => void }) => {
 	const block = store.activeCanvas?.findBlock(props.block.blockId);
 	if (!block) return;
 	block.extendFromComponent(componentData.name);
+	componentProperties.value.componentName = "";
+	componentProperties.value.isGlobalComponent = 0;
 	context.close();
 };
 </script>

--- a/frontend/src/components/Modals/NewComponent.vue
+++ b/frontend/src/components/Modals/NewComponent.vue
@@ -47,24 +47,21 @@ const componentProperties = ref({
 	isGlobalComponent: 0,
 });
 
-const createComponentHandler = (close: () => void) => {
+const createComponentHandler = async (context: { close: () => void }) => {
 	const blockCopy = getBlockCopy(props.block, true);
 	blockCopy.removeStyle("left");
 	blockCopy.removeStyle("top");
 	blockCopy.removeStyle("position");
-	webComponent.insert
-		.submit({
-			block: getBlockString(blockCopy),
-			component_name: componentProperties.value.componentName,
-			for_web_page: componentProperties.value.isGlobalComponent ? null : store.selectedPage,
-		})
-		.then(async (data: BuilderComponent) => {
-			posthog.capture("builder_component_created", { component_name: data.name });
-			componentStore.setComponentMap(data);
-			const block = store.activeCanvas?.findBlock(props.block.blockId);
-			if (!block) return;
-			block.extendFromComponent(data.name);
-		});
-	close();
+	const componentData = (await webComponent.insert.submit({
+		block: getBlockString(blockCopy),
+		component_name: componentProperties.value.componentName,
+		for_web_page: componentProperties.value.isGlobalComponent ? null : store.selectedPage,
+	})) as BuilderComponent;
+	posthog.capture("builder_component_created", { component_name: componentData.name });
+	componentStore.setComponentMap(componentData);
+	const block = store.activeCanvas?.findBlock(props.block.blockId);
+	if (!block) return;
+	block.extendFromComponent(componentData.name);
+	context.close();
 };
 </script>

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -47,6 +47,7 @@ class Block implements BlockOptions {
 	visibilityCondition?: string;
 	elementBeforeConversion?: string;
 	parentBlock: Block | null;
+	// @ts-expect-error
 	referenceComponent: Block | null;
 	customAttributes: BlockAttributeMap;
 	constructor(options: BlockOptions) {
@@ -62,16 +63,24 @@ class Block implements BlockOptions {
 		if (this.extendedFromComponent) {
 			componentStore.loadComponent(this.extendedFromComponent);
 		}
-		this.referenceComponent = computed(() => {
-			if (this.extendedFromComponent) {
-				return markRaw(componentStore.getComponentBlock(this.extendedFromComponent as string)) || null;
-			} else if (this.isChildOfComponent) {
-				const componentBlock = componentStore.getComponentBlock(this.isChildOfComponent as string);
-				const componentBlockInstance = findBlock(this.referenceBlockId as string, [componentBlock]);
-				return componentBlockInstance ? markRaw(componentBlockInstance) : null;
-			}
-			return null;
-		}) as unknown as Block | null;
+		// ToDo: Investigate this
+		// This fixes a weird case where referenceComponent used to return null even if the extendedFromComponent was set mostyl because of the reactive transformation of block during block instance creation.
+		// still not entirely clear about this weird behavior
+		Object.defineProperty(this, "referenceComponent", {
+			value: computed(() => {
+				if (this.extendedFromComponent) {
+					return markRaw(componentStore.getComponentBlock(this.extendedFromComponent as string)) || null;
+				} else if (this.isChildOfComponent) {
+					const componentBlock = componentStore.getComponentBlock(this.isChildOfComponent as string);
+					const componentBlockInstance = findBlock(this.referenceBlockId as string, [componentBlock]);
+					return componentBlockInstance ? markRaw(componentBlockInstance) : null;
+				}
+				return null;
+			}),
+			writable: false,
+			enumerable: false,
+			configurable: true,
+		});
 
 		this.dataKey = options.dataKey || null;
 
@@ -657,6 +666,8 @@ class Block implements BlockOptions {
 	}
 	extendFromComponent(componentName: string) {
 		this.extendedFromComponent = componentName;
+		// @ts-expect-error
+		this.referenceComponent?.effect?.run();
 		const component = this.referenceComponent as Block;
 		if (component) {
 			extendWithComponent(this, componentName, component.children);
@@ -895,7 +906,7 @@ function extendWithComponent(
 	componentChildren: Block[],
 	resetOverrides: boolean = true,
 ) {
-	resetBlock(block, true, resetOverrides);
+	resetBlock(block, false, resetOverrides);
 	block.children?.forEach((child, index) => {
 		child.isChildOfComponent = extendedFromComponent;
 		let componentChild = componentChildren[index];

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -63,9 +63,8 @@ class Block implements BlockOptions {
 		if (this.extendedFromComponent) {
 			componentStore.loadComponent(this.extendedFromComponent);
 		}
-		// ToDo: Investigate this
-		// This fixes a weird case where referenceComponent used to return null even if the extendedFromComponent was set mostyl because of the reactive transformation of block during block instance creation.
-		// still not entirely clear about this weird behavior
+		// TODO: Investigate this
+		// This fixes a weird case where referenceComponent used to return null even if the extendedFromComponent was set mostyl because of the reactive transformation of block during block instance creation. Still not entirely clear about this weird behavior
 		Object.defineProperty(this, "referenceComponent", {
 			value: computed(() => {
 				if (this.extendedFromComponent) {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -282,8 +282,16 @@ function isCtrlOrCmd(e: KeyboardEvent | MouseEvent) {
 	return e.ctrlKey || e.metaKey;
 }
 
-const detachBlockFromComponent = (block: Block) => {
+const detachBlockFromComponent = (block: Block, componentId: null | string) => {
+	if (!componentId) {
+		componentId = block.extendedFromComponent as string;
+	}
 	const blockCopy = getBlockCopy(block, true);
+
+	if (block.extendedFromComponent && block.extendedFromComponent != componentId) {
+		return blockCopy;
+	}
+
 	const component = block.referenceComponent;
 	blockCopy.element = block?.getElement();
 	blockCopy.attributes = block.getAttributes();
@@ -309,7 +317,7 @@ const detachBlockFromComponent = (block: Block) => {
 	delete blockCopy.extendedFromComponent;
 	delete blockCopy.isChildOfComponent;
 	delete blockCopy.referenceBlockId;
-	blockCopy.children = blockCopy.children.map(detachBlockFromComponent);
+	blockCopy.children = blockCopy.children.map((block) => detachBlockFromComponent(block, componentId));
 	return getBlockInstance(blockCopy);
 };
 

--- a/frontend/src/utils/useComponentStore.ts
+++ b/frontend/src/utils/useComponentStore.ts
@@ -138,7 +138,7 @@ const useComponentStore = defineStore("componentStore", {
 				});
 		},
 		getComponentName(componentId: string) {
-			let componentObj = webComponent.getRow(componentId);
+			let componentObj = this.componentDocMap.get(componentId);
 			if (!componentObj) {
 				return componentId;
 			}


### PR DESCRIPTION
- Fixed a case where overrides in nested component were not getting reflected during the usage
- Detach component option will only detach parent component instead of detaching all the nested component.
- Fixed a case where after creating a component and using it, changes to the component were not getting synced to the instance of the component.
- https://github.com/frappe/builder/pull/300/files#diff-e054a38b9c2a84b68fa62328ad66517a2cb01ff6054912208f3019dde5fbaabeR68 this change also improved the performance of the block loading since it is skips the reactive conversion overhead for referenceComponent for each block.
