### PR TITLE
feat: Show drop target placeholder during drag & drop

### DIFF
--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -52,6 +52,7 @@ const showResizer = computed(() => {
 	return (
 		!props.block.isRoot() &&
 		!props.editable &&
+		!store.isDragging &&
 		isBlockSelected.value &&
 		!blockController.multipleBlocksSelected() &&
 		!props.block.getParentBlock()?.isGrid() &&
@@ -93,6 +94,7 @@ const showPaddingHandler = computed(() => {
 	return (
 		isBlockSelected.value &&
 		!resizing.value &&
+		!store.isDragging &&
 		!props.editable &&
 		!blockController.multipleBlocksSelected() &&
 		!props.block.isSVG() &&
@@ -104,6 +106,7 @@ const showMarginHandler = computed(() => {
 	return (
 		isBlockSelected.value &&
 		!props.block.isRoot() &&
+		!store.isDragging &&
 		!resizing.value &&
 		!props.editable &&
 		!blockController.multipleBlocksSelected() &&
@@ -120,6 +123,7 @@ const showBorderRadiusHandler = computed(() => {
 		!props.block.isSVG() &&
 		!props.editable &&
 		!resizing.value &&
+		!store.isDragging &&
 		!blockController.multipleBlocksSelected()
 	);
 });
@@ -167,7 +171,13 @@ const getStyleClasses = computed(() => {
 	} else {
 		classes.push("ring-blue-400");
 	}
-	if (isBlockSelected.value && !props.editable && !props.block.isRoot() && !props.block.isRepeater()) {
+	if (
+		isBlockSelected.value &&
+		!props.editable &&
+		!props.block.isRoot() &&
+		!props.block.isRepeater() &&
+		!store.isDragging
+	) {
 		// make editor interactive
 		classes.push("pointer-events-auto");
 		// Place the block on the top of the stack

--- a/frontend/src/components/BuilderAssets.vue
+++ b/frontend/src/components/BuilderAssets.vue
@@ -89,7 +89,12 @@ useEventListener(componentContainer, "dragstart", (e) => {
 	const component = (e.target as HTMLElement)?.closest(".user-component") as HTMLElement;
 	if (component) {
 		setComponentData(e, component.dataset.componentName as string);
+		store.handleDragStart(e);
 	}
+});
+
+useEventListener(componentContainer, "dragend", () => {
+	store.handleDragEnd();
 });
 
 useEventListener(componentContainer, "dblclick", (e) => {

--- a/frontend/src/components/BuilderBlockTemplates.vue
+++ b/frontend/src/components/BuilderBlockTemplates.vue
@@ -26,7 +26,8 @@
 						draggable="true"
 						@click="selectBlockTemplate(blockTemplate)"
 						@dblclick="is_developer_mode && store.editBlockTemplate(blockTemplate.name)"
-						@dragstart="(ev) => setBlockTemplateData(ev, blockTemplate)">
+						@dragstart="(ev) => setBlockTemplateData(ev, blockTemplate)"
+						@dragend="() => store.handleDragEnd()">
 						<div
 							class="flex h-4/5 items-center justify-center"
 							:class="{
@@ -70,6 +71,7 @@ const blockTemplates = computed(() => {
 
 const setBlockTemplateData = (ev: DragEvent, component: BlockTemplate) => {
 	ev?.dataTransfer?.setData("blockTemplate", component.name);
+	store.handleDragStart(ev);
 };
 
 const selectedBlockTemplate = ref<string | null>(null);

--- a/frontend/src/components/BuilderBlockTemplates.vue
+++ b/frontend/src/components/BuilderBlockTemplates.vue
@@ -70,7 +70,7 @@ const blockTemplates = computed(() => {
 });
 
 const setBlockTemplateData = (ev: DragEvent, component: BlockTemplate) => {
-	ev?.dataTransfer?.setData("blockTemplate", component.name);
+	ev.dataTransfer?.setData("blockTemplate", component.name);
 	store.handleDragStart(ev);
 };
 

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -11,9 +11,6 @@
 		</Transition>
 		<BlockSnapGuides></BlockSnapGuides>
 		<div
-			v-if="isOverDropZone"
-			class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 z-30 bg-cyan-300 opacity-20"></div>
-		<div
 			class="fixed flex gap-40"
 			ref="canvas"
 			:style="{

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -1,7 +1,11 @@
 <template>
 	<div ref="canvasContainer" @click="handleClick">
 		<slot name="header"></slot>
-		<div class="overlay absolute" id="overlay" ref="overlay" />
+		<div
+			class="overlay absolute"
+			:class="{ 'pointer-events-none': isOverDropZone }"
+			id="overlay"
+			ref="overlay" />
 		<Transition name="fade">
 			<div
 				class="absolute bottom-0 left-0 right-0 top-0 z-[19] grid w-full place-items-center bg-surface-gray-1 p-10 text-ink-gray-5"

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -296,4 +296,8 @@ const renderedBreakpoints = computed(() => canvasProps.breakpoints.filter((bp) =
 .fade-leave-to {
 	opacity: 0;
 }
+
+#placeholder {
+	@apply h-auto w-full border-t-2 border-blue-500 transition-all;
+}
 </style>

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -298,6 +298,12 @@ const renderedBreakpoints = computed(() => canvasProps.breakpoints.filter((bp) =
 }
 
 #placeholder {
-	@apply h-auto w-full border-t-2 border-blue-500 transition-all;
+	@apply transition-all;
+}
+.vertical-placeholder {
+	@apply w-auto border-l-2 border-blue-500;
+}
+.horizontal-placeholder {
+	@apply h-auto w-full border-t-2 border-blue-500;
 }
 </style>

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -305,9 +305,9 @@ const renderedBreakpoints = computed(() => canvasProps.breakpoints.filter((bp) =
 	@apply transition-all;
 }
 .vertical-placeholder {
-	@apply w-auto border-l-2 border-blue-500;
+	@apply mx-4 w-auto border-l-2 border-dashed border-blue-500;
 }
 .horizontal-placeholder {
-	@apply h-auto w-full border-t-2 border-blue-500;
+	@apply my-4 h-auto w-full border-t-2 border-dashed border-blue-500;
 }
 </style>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -94,6 +94,7 @@ const useStore = defineStore("store", {
 			"Media",
 			"Advanced",
 		] as BlockTemplate["category"][],
+		isDragging: false,
 		dragTarget: {
 			placeholder: <HTMLElement | null>null,
 			parentBlock: <Block | null>null,
@@ -539,6 +540,7 @@ const useStore = defineStore("store", {
 		// drag and drop
 		handleDragStart(ev: DragEvent) {
 			if (ev.target && ev.dataTransfer) {
+				this.isDragging = true
 				const ghostScale = this.activeCanvas?.canvasProps.scale
 				const ghostElement = (ev.target as HTMLElement).cloneNode(true) as HTMLElement
 
@@ -576,6 +578,7 @@ const useStore = defineStore("store", {
 				parentBlock: null,
 				index: null,
 			}
+			this.isDragging = false
 		}
 	},
 });

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -94,6 +94,11 @@ const useStore = defineStore("store", {
 			"Media",
 			"Advanced",
 		] as BlockTemplate["category"][],
+		dragTarget: {
+			placeholder: <HTMLElement | null>null,
+			parentBlock: <Block | null>null,
+			index: <number | null>null,
+		}
 	}),
 	actions: {
 		clearBlocks() {
@@ -531,6 +536,47 @@ const useStore = defineStore("store", {
 				fragmentId: null,
 			};
 		},
+		// drag and drop
+		handleDragStart(ev: DragEvent) {
+			if (ev.target && ev.dataTransfer) {
+				const ghostScale = this.activeCanvas?.canvasProps.scale
+				const ghostElement = (ev.target as HTMLElement).cloneNode(true) as HTMLElement
+
+				ghostElement.id = "ghost"
+				ghostElement.style.position = "fixed"
+				ghostElement.style.transform = `scale(${ghostScale || 1})`
+				ghostElement.style.pointerEvents = "none"
+				ghostElement.style.zIndex = "999999"
+				document.body.appendChild(ghostElement)
+
+				// Set the scaled drag image
+				ev.dataTransfer.setDragImage(ghostElement, 0, 0)
+				// Clean up the ghost element
+				setTimeout(() => {
+					document.body.removeChild(ghostElement)
+				}, 0)
+
+				let element = document.createElement("div")
+				element.id = "placeholder"
+
+				const root = document.querySelector(".__builder_component__[data-block-id='root']")
+				if (root) {
+					this.dragTarget.placeholder = root.appendChild(element)
+				}
+			}
+		},
+		handleDragEnd() {
+			const placeholder = document.getElementById("placeholder")
+			if (placeholder) {
+				placeholder.remove()
+			}
+
+			this.dragTarget = {
+				placeholder: null,
+				parentBlock: null,
+				index: null,
+			}
+		}
 	},
 });
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -441,6 +441,31 @@ function generateId() {
 	return Math.random().toString(36).substr(2, 9);
 }
 
+function throttle<T extends (...args: any[]) => void>(func: T, wait: number = 1000) {
+	let timeout: ReturnType<typeof setTimeout> | null = null
+	let lastArgs: Parameters<T> | null = null
+	let pending = false
+
+	const invoke = (...args: Parameters<T>) => {
+		lastArgs = args
+		if (timeout) {
+			pending = true
+			return
+		}
+
+		func(...lastArgs);
+		timeout = setTimeout(() => {
+			timeout = null
+			if (pending && lastArgs) {
+				pending = false
+				invoke(...lastArgs)
+			}
+		}, wait)
+	};
+
+	return invoke
+}
+
 export {
 	addPxToNumber,
 	alert,
@@ -475,4 +500,5 @@ export {
 	RGBToHex,
 	stripExtension,
 	uploadImage,
+	throttle,
 };

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -153,7 +153,7 @@ export function useCanvasDropZone(
 		const newParent = document.querySelector(`.__builder_component__[data-block-id="${parentBlock.blockId}"]`)
 		if (!newParent) return
 
-		if (store.dragTarget.parentBlock === parentBlock && store.dragTarget.index === index) return
+		if (store.dragTarget.parentBlock?.blockId === parentBlock.blockId && store.dragTarget.index === index) return
 
 		// flip placeholder border as per layout direction to avoid shifting elements too much
 		if (layoutDirection === "row") {

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -1,7 +1,7 @@
 import useStore from "@/store";
 import { posthog } from "@/telemetry";
 import Block from "@/utils/block";
-import { getBlockCopy, getBlockInstance, uploadImage } from "@/utils/helpers";
+import { getBlockCopy, getBlockInstance, throttle, uploadImage } from "@/utils/helpers";
 import useComponentStore from "@/utils/useComponentStore";
 import { useDropZone } from "@vueuse/core";
 import { Ref } from "vue";
@@ -197,7 +197,7 @@ export function useCanvasDropZone(
 		return "column"
 	}
 
-	const updateDropTarget = (parentBlock: Block | null, index: number, layoutDirection: LayoutDirection) => {
+	const updateDropTarget = throttle((parentBlock: Block | null, index: number, layoutDirection: LayoutDirection) => {
 		// append placeholder component to the dom directly
 		// to avoid re-rendering the whole canvas
 		const { placeholder } = store.dragTarget
@@ -220,7 +220,7 @@ export function useCanvasDropZone(
 		newParent.insertBefore(placeholder, newParent.children[index])
 		store.dragTarget.parentBlock = parentBlock
 		store.dragTarget.index = index
-	}
+	}, 130)
 
 	return { isOverDropZone };
 }

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -18,103 +18,51 @@ export function useCanvasDropZone(
 ) {
 	const { isOverDropZone } = useDropZone(canvasContainer, {
 		onDrop: async (files, ev) => {
-			let element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
-			let parentBlock = block.value as Block | null;
-			if (element) {
-				if (element.dataset.blockId) {
-					parentBlock = findBlock(element.dataset.blockId) || parentBlock;
-				}
-			}
-			const componentName = ev.dataTransfer?.getData("componentName");
-			const blockTemplate = ev.dataTransfer?.getData("blockTemplate");
-			if (componentName) {
-				await componentStore.loadComponent(componentName);
-				const component = componentStore.componentMap.get(componentName) as Block;
-				const newBlock = getBlockCopy(component);
-				newBlock.extendFromComponent(componentName);
-				// if shift key is pressed, replace parent block with new block
-				if (ev.shiftKey) {
-					while (parentBlock && parentBlock.isChildOfComponent) {
-						parentBlock = parentBlock.getParentBlock();
-					}
-					if (!parentBlock) return;
-					const parentParentBlock = parentBlock.getParentBlock();
-					if (!parentParentBlock) return;
-					parentParentBlock.replaceChild(parentBlock, newBlock);
-				} else {
-					while (parentBlock && !parentBlock.canHaveChildren()) {
-						parentBlock = parentBlock.getParentBlock();
-					}
-					if (!parentBlock) return;
-					parentBlock.addChild(newBlock);
-				}
-				ev.stopPropagation();
-				posthog.capture("builder_component_used");
-			} else if (blockTemplate) {
-				await store.fetchBlockTemplate(blockTemplate);
-				const newBlock = getBlockInstance(store.getBlockTemplate(blockTemplate).block, false);
-				// if shift key is pressed, replace parent block with new block
-				if (ev.shiftKey) {
-					while (parentBlock && parentBlock.isChildOfComponent) {
-						parentBlock = parentBlock.getParentBlock();
-					}
-					if (!parentBlock) return;
-					const parentParentBlock = parentBlock.getParentBlock();
-					if (!parentParentBlock) return;
-					const index = parentParentBlock.children.indexOf(parentBlock);
-					parentParentBlock.children.splice(index, 1, newBlock);
-				} else {
-					while (parentBlock && !parentBlock.canHaveChildren()) {
-						parentBlock = parentBlock.getParentBlock();
-					}
-					if (!parentBlock) return;
-					parentBlock.addChild(newBlock);
-				}
-				posthog.capture("builder_block_template_used", { template: blockTemplate });
-			} else if (files && files.length) {
-				uploadImage(files[0]).then((fileDoc: { fileURL: string; fileName: string }) => {
-					if (!parentBlock) return;
+			if (files && files.length) {
+				handleFileDrop(files, ev);
+			} else {
+				const componentName = ev.dataTransfer?.getData("componentName");
+				const blockTemplate = ev.dataTransfer?.getData("blockTemplate");
+				const { parentBlock, index } = store.dragTarget;
+				if (!parentBlock) return;
 
-					if (fileDoc.fileName.match(/\.(mp4|webm|ogg|mov)$/)) {
-						if (parentBlock.isVideo()) {
-							parentBlock.setAttribute("src", fileDoc.fileURL);
-						} else {
-							while (parentBlock && !parentBlock.canHaveChildren()) {
-								parentBlock = parentBlock.getParentBlock() as Block;
-							}
-							parentBlock.addChild(store.getVideoBlock(fileDoc.fileURL));
+				if (componentName) {
+					await componentStore.loadComponent(componentName);
+					const component = componentStore.componentMap.get(componentName) as Block;
+					const newBlock = getBlockCopy(component);
+					newBlock.extendFromComponent(componentName);
+					// if shift key is pressed, replace parent block with new block
+					if (ev.shiftKey) {
+						while (parentBlock && parentBlock.isChildOfComponent) {
+							parentBlock = parentBlock.getParentBlock();
 						}
-						posthog.capture("builder_video_uploaded");
-						return;
-					}
-
-					if (parentBlock.isImage()) {
-						parentBlock.setAttribute("src", fileDoc.fileURL);
-						posthog.capture("builder_image_uploaded", {
-							type: "image-replace",
-						});
-					} else if (parentBlock.isSVG()) {
-						const imageBlock = store.getImageBlock(fileDoc.fileURL, fileDoc.fileName);
+						if (!parentBlock) return;
 						const parentParentBlock = parentBlock.getParentBlock();
-						parentParentBlock?.replaceChild(parentBlock, getBlockInstance(imageBlock));
-						posthog.capture("builder_image_uploaded", {
-							type: "svg-replace",
-						});
-					} else if (parentBlock.isContainer() && ev.shiftKey) {
-						parentBlock.setStyle("background", `url(${fileDoc.fileURL})`);
-						posthog.capture("builder_image_uploaded", {
-							type: "background",
-						});
+						if (!parentParentBlock) return;
+						parentParentBlock.replaceChild(parentBlock, newBlock);
 					} else {
-						while (parentBlock && !parentBlock.canHaveChildren()) {
-							parentBlock = parentBlock.getParentBlock() as Block;
-						}
-						parentBlock.addChild(store.getImageBlock(fileDoc.fileURL, fileDoc.fileName));
-						posthog.capture("builder_image_uploaded", {
-							type: "new-image",
-						});
+						parentBlock.addChild(newBlock, index);
 					}
-				});
+					ev.stopPropagation();
+					posthog.capture("builder_component_used");
+				} else if (blockTemplate) {
+					await store.fetchBlockTemplate(blockTemplate);
+					const newBlock = getBlockInstance(store.getBlockTemplate(blockTemplate).block, false);
+					// if shift key is pressed, replace parent block with new block
+					if (ev.shiftKey) {
+						while (parentBlock && parentBlock.isChildOfComponent) {
+							parentBlock = parentBlock.getParentBlock();
+						}
+						if (!parentBlock) return;
+						const parentParentBlock = parentBlock.getParentBlock();
+						if (!parentParentBlock) return;
+						const index = parentParentBlock.children.indexOf(parentBlock);
+						parentParentBlock.children.splice(index, 1, newBlock);
+					} else {
+						parentBlock.addChild(newBlock, index);
+					}
+					posthog.capture("builder_block_template_used", { template: blockTemplate });
+				}
 			}
 		},
 
@@ -221,6 +169,59 @@ export function useCanvasDropZone(
 		store.dragTarget.parentBlock = parentBlock
 		store.dragTarget.index = index
 	}, 130)
+
+	const handleFileDrop = (files: File[], ev: DragEvent) => {
+		let element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
+		let parentBlock = block.value as Block | null;
+		if (element) {
+			if (element.dataset.blockId) {
+				parentBlock = findBlock(element.dataset.blockId) || parentBlock;
+			}
+		}
+		uploadImage(files[0]).then((fileDoc: { fileURL: string; fileName: string }) => {
+			if (!parentBlock) return;
+
+			if (fileDoc.fileName.match(/\.(mp4|webm|ogg|mov)$/)) {
+				if (parentBlock.isVideo()) {
+					parentBlock.setAttribute("src", fileDoc.fileURL);
+				} else {
+					while (parentBlock && !parentBlock.canHaveChildren()) {
+						parentBlock = parentBlock.getParentBlock() as Block;
+					}
+					parentBlock.addChild(store.getVideoBlock(fileDoc.fileURL));
+				}
+				posthog.capture("builder_video_uploaded");
+				return;
+			}
+
+			if (parentBlock.isImage()) {
+				parentBlock.setAttribute("src", fileDoc.fileURL);
+				posthog.capture("builder_image_uploaded", {
+					type: "image-replace",
+				});
+			} else if (parentBlock.isSVG()) {
+				const imageBlock = store.getImageBlock(fileDoc.fileURL, fileDoc.fileName);
+				const parentParentBlock = parentBlock.getParentBlock();
+				parentParentBlock?.replaceChild(parentBlock, getBlockInstance(imageBlock));
+				posthog.capture("builder_image_uploaded", {
+					type: "svg-replace",
+				});
+			} else if (parentBlock.isContainer() && ev.shiftKey) {
+				parentBlock.setStyle("background", `url(${fileDoc.fileURL})`);
+				posthog.capture("builder_image_uploaded", {
+					type: "background",
+				});
+			} else {
+				while (parentBlock && !parentBlock.canHaveChildren()) {
+					parentBlock = parentBlock.getParentBlock() as Block;
+				}
+				parentBlock.addChild(store.getImageBlock(fileDoc.fileURL, fileDoc.fileName));
+				posthog.capture("builder_image_uploaded", {
+					type: "new-image",
+				});
+			}
+		});
+	}
 
 	return { isOverDropZone };
 }

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -115,6 +115,31 @@ export function useCanvasDropZone(
 				});
 			}
 		},
+
+		onOver: (files, ev) => {
+			if (files && files.length) return;
+
+			const parentBlock = findDropTarget(ev);
+			if (parentBlock) {
+				store.hoveredBlock = parentBlock.blockId;
+			}
+		}
 	});
+
+	const findDropTarget = (ev: DragEvent) => {
+		const element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
+		const targetElement = element.closest(".__builder_component__") as HTMLElement;
+
+		let parentBlock = block.value as Block | null;
+		if (targetElement && targetElement.dataset.blockId) {
+			parentBlock = findBlock(targetElement.dataset.blockId) || parentBlock;
+			while (parentBlock && !parentBlock.canHaveChildren()) {
+				parentBlock = parentBlock.getParentBlock();
+			}
+		}
+
+		return parentBlock;
+	}
+
 	return { isOverDropZone };
 }

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -13,7 +13,7 @@ type LayoutDirection = "row" | "column"
 
 export function useCanvasDropZone(
 	canvasContainer: Ref<HTMLElement>,
-	block: Ref<Block>,
+	block: Ref<Block | null>,
 	findBlock: (id: string) => Block | null,
 ) {
 	const { isOverDropZone } = useDropZone(canvasContainer, {
@@ -23,7 +23,7 @@ export function useCanvasDropZone(
 			} else {
 				const componentName = ev.dataTransfer?.getData("componentName");
 				const blockTemplate = ev.dataTransfer?.getData("blockTemplate");
-				const { parentBlock, index } = store.dragTarget;
+				let { parentBlock, index } = store.dragTarget;
 				if (!parentBlock) return;
 
 				if (componentName) {
@@ -83,7 +83,7 @@ export function useCanvasDropZone(
 
 		let parentBlock = block.value;
 		let layoutDirection = "column" as LayoutDirection;
-		let index = parentBlock.children.length;
+		let index = parentBlock?.children.length || 0;
 
 		if (targetElement && targetElement.dataset.blockId) {
 			parentBlock = findBlock(targetElement.dataset.blockId) || parentBlock;

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -144,11 +144,12 @@ export function useCanvasDropZone(
 			}
 
 			if (parentBlock) {
-				const parentElement = document.querySelector(`[data-block-id="${parentBlock.blockId}"]:not(.editor)`) as HTMLElement;
+				const parentElement = document.querySelector(`.__builder_component__[data-block-id="${parentBlock.blockId}"]`) as HTMLElement;
 				layoutDirection = getLayoutDirection(parentElement);
 				index = findDropIndex(ev, parentElement, layoutDirection);
 			}
 		}
+
 
 		return { parentBlock, index, layoutDirection };
 	}

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -206,6 +206,15 @@ export function useCanvasDropZone(
 
 		if (store.dragTarget.parentBlock === parentBlock && store.dragTarget.index === index) return
 
+		// flip placeholder border as per layout direction to avoid shifting elements too much
+		if (layoutDirection === "row") {
+			placeholder.classList.remove("horizontal-placeholder")
+			placeholder.classList.add("vertical-placeholder")
+		} else {
+			placeholder.classList.remove("vertical-placeholder")
+			placeholder.classList.add("horizontal-placeholder")
+		}
+
 		// Append the placeholder to the new parent
 		newParent.insertBefore(placeholder, newParent.children[index])
 		store.dragTarget.parentBlock = parentBlock


### PR DESCRIPTION
### Before:

Hard to figure out where my component/block will drop

https://github.com/user-attachments/assets/a6491ec2-220f-4d44-830a-86377288a3d8

### After:

Porting from studio: https://github.com/frappe/studio/pull/14 & https://github.com/frappe/studio/pull/15

Shows a placeholder for drag target

https://github.com/user-attachments/assets/209b16a4-0ff3-4bf8-b4db-ea47fee22b23

Flips placeholder orientation as per layout direction — column/row to avoid too much layout shifting and follow general flow of elements in the container. Eg: This is a Quick Stack with flex direction = row, so elements will be added vertically, so placeholder flips accordingly

https://github.com/user-attachments/assets/9822e2c7-b27a-465c-9efc-05292fbf8967

### How

**dragstart**

- Inserts a placeholder div in DOM on dragstart (dashed border with some margin to differentiate it from the selected block borders)

**dragover**
- Finds the parent block (that can have children) based on mouse position
- Finds the exact index at which to drop the component/block
	- Finds midpoints of all child elements as per layout direction
	- Finds the closest child to the mouse position
	- If the mouse is to the left/top of the midpoint, inserts placeholder before that child
	- If the mouse is to the right/below the midpoint, inserts placeholder after that child
	- Index defaults to end of the parent container if no children are found
- updates drag state in store

**drop**
- fetches state from store, inserts the element at that position

**dragend**
- resets drag state
- removes placeholder from DOM

<hr>

- [ ] Handle/refactor replace block case
- [ ] Handle sensitivity while dropping on shared edges between 2 blocks 
- [ ] Test grid layouts

