### PR TITLE
feat: Show revert change and unpublish button

### DIFF
--- a/frontend/src/components/BuilderBlockTemplates.vue
+++ b/frontend/src/components/BuilderBlockTemplates.vue
@@ -32,7 +32,7 @@
 							:class="{
 								'w-14': !blockTemplate?.preview_width || blockTemplate?.preview_width == 1,
 							}">
-							<img :src="blockTemplate.preview" />
+							<img :src="blockTemplate.preview" class="pointer-events-none" />
 						</div>
 						<p class="text-sm text-ink-gray-6">
 							{{ blockTemplate.template_name }}

--- a/frontend/src/components/BuilderToolbar.vue
+++ b/frontend/src/components/BuilderToolbar.vue
@@ -133,36 +133,20 @@
 					<PlayIcon class="h-[18px] w-[18px] cursor-pointer text-ink-gray-8"></PlayIcon>
 				</Tooltip>
 			</router-link>
-			<BuilderButton
-				variant="solid"
-				iconLeft="globe"
-				@click="
-					() => {
-						publishing = true;
-						store.publishPage().finally(() => (publishing = false));
-					}
-				"
-				class="border-0"
-				:class="{
-					'bg-surface-gray-7 !text-ink-white hover:bg-surface-gray-6':
-						!publishing && store.activePage?.draft_blocks,
-					'dark:bg-surface-gray-2 dark:text-ink-gray-4': !store.activePage?.draft_blocks,
-				}"
-				:loading="publishing">
-				{{ publishing ? "Publishing" : "Publish" }}
-			</BuilderButton>
+			<PublishButton></PublishButton>
 		</div>
 	</div>
 </template>
 <script setup lang="ts">
+import Dialog from "@/components/Controls/Dialog.vue";
 import AuthenticatedUserIcon from "@/components/Icons/AuthenticatedUser.vue";
 import PlayIcon from "@/components/Icons/Play.vue";
 import SettingsGearIcon from "@/components/Icons/SettingsGear.vue";
+import PublishButton from "@/components/PublishButton.vue";
 import { webPages } from "@/data/webPage";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
 import { getTextContent } from "@/utils/helpers";
 import { Tooltip } from "frappe-ui";
-import Dialog from "@/components/Controls/Dialog.vue";
 import Popover from "frappe-ui/src/components/Popover.vue";
 import { computed, ref } from "vue";
 import { toast } from "vue-sonner";
@@ -176,6 +160,14 @@ const publishing = ref(false);
 const showInfoDialog = ref(false);
 const showSettingsDialog = ref(false);
 const toolbar = ref(null);
+
+const publishButtonLabel = computed(() => {
+	if ((store.activePage?.draft_blocks && !store.activePage?.published) || !store.activePage?.draft_blocks) {
+		return "Publish";
+	} else {
+		return "Publish Changes";
+	}
+});
 
 const currentlyViewedByText = computed(() => {
 	const names = store.viewers.map((viewer) => viewer.fullname).map((name) => name.split(" ")[0]);

--- a/frontend/src/components/PublishButton.vue
+++ b/frontend/src/components/PublishButton.vue
@@ -1,0 +1,63 @@
+<template>
+	<div class="flex items-center">
+		<BuilderButton
+			variant="solid"
+			@click="
+				() => {
+					publishing = true;
+					store.publishPage().finally(() => (publishing = false));
+				}
+			"
+			class="border-0"
+			:class="{
+				'rounded-br-none rounded-tr-none': store.activePage?.published,
+			}"
+			:loading="publishing">
+			{{ publishButtonLabel }}
+		</BuilderButton>
+		<Dropdown
+			v-if="store.activePage?.published"
+			:options="[
+				{
+					label: 'Revert Changes',
+					onClick: () => store.revertChanges(),
+					condition: () => store.activePage?.draft_blocks,
+					icon: 'refresh-cw',
+				},
+				{
+					label: 'Unpublish',
+					onClick: () => store.unpublishPage(),
+					condition: () => store.activePage?.published,
+					icon: 'cloud-off',
+				},
+			]"
+			size="sm"
+			class="flex-1 [&>div>div>div]:w-full"
+			placement="right">
+			<template v-slot="{ open }">
+				<BuilderButton
+					variant="solid"
+					@click="open"
+					:disabled="Boolean(store.activePage?.is_template)"
+					icon="chevron-down"
+					class="!w-6 justify-start rounded-bl-none rounded-tl-none border-0 pr-0 text-xs"></BuilderButton>
+			</template>
+		</Dropdown>
+	</div>
+</template>
+<script lang="ts" setup>
+import useStore from "@/store";
+import { Dropdown } from "frappe-ui";
+import { computed, ref } from "vue";
+
+const store = useStore();
+const publishing = ref(false);
+
+const publishButtonLabel = computed(() => {
+	if ((store.activePage?.draft_blocks && !store.activePage?.published) || !store.activePage?.draft_blocks) {
+		return "Publish";
+	} else {
+		return "Publish Changes";
+	}
+});
+</script>

--- a/frontend/src/pages/PagePreview.vue
+++ b/frontend/src/pages/PagePreview.vue
@@ -24,24 +24,7 @@
 						}" />
 				</div>
 			</div>
-			<BuilderButton
-				variant="solid"
-				iconLeft="globe"
-				@click="
-					() => {
-						publishing = true;
-						store.publishPage().finally(() => (publishing = false));
-					}
-				"
-				class="absolute right-3 border-0"
-				:class="{
-					'bg-surface-gray-7 !text-ink-white hover:bg-surface-gray-6':
-						!publishing && store.activePage?.draft_blocks,
-					'dark:bg-surface-gray-2 dark:text-ink-gray-4': !store.activePage?.draft_blocks,
-				}"
-				:loading="publishing">
-				{{ publishing ? "Publishing" : "Publish" }}
-			</BuilderButton>
+			<PublishButton class="absolute right-3 border-0"></PublishButton>
 		</div>
 		<div
 			class="relative mt-5 flex h-[85vh] bg-white"
@@ -82,6 +65,7 @@
 </template>
 <script lang="ts" setup>
 import PanelResizer from "@/components/PanelResizer.vue";
+import PublishButton from "@/components/PublishButton.vue";
 import router from "@/router";
 import useStore from "@/store";
 import { posthog } from "@/telemetry";

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -323,7 +323,22 @@ const useStore = defineStore("store", {
 					}
 				});
 		},
-		unpublishPage() {
+		async revertChanges() {
+			const confirmed = await confirm(
+				"This will revert all changes made to the page since the last publish. Are you sure you want to continue?",
+			);
+			if (confirmed) {
+				await this.updateActivePage("draft_blocks", null);
+				this.setPage(this.activePage?.name as string);
+			}
+		},
+		async unpublishPage() {
+			const confirmed = await confirm(
+				"Are you sure you want to unpublish this page? It will no longer be accessible on the website.",
+			);
+			if (!confirmed) {
+				return;
+			}
 			return webPages.setValue
 				.submit({
 					name: this.selectedPage,


### PR DESCRIPTION
- If a page is not published
	<img width="163" alt="Screenshot 2025-01-29 at 8 55 18 AM" src="https://github.com/user-attachments/assets/6635e07a-3958-4b86-bd52-e99416855313" />

- If a page is published
	<img width="199" alt="Screenshot 2025-01-29 at 8 55 43 AM" src="https://github.com/user-attachments/assets/c83e6061-89cc-4754-b686-fa7c87e4f901" />

- If a page is published and has some unpublished changes
	<img width="291" alt="Screenshot 2025-01-29 at 8 53 04 AM" src="https://github.com/user-attachments/assets/847a74ed-67a2-4fcc-b256-b61cd5e7cea8" />

**Note:** "Revert Changes" will discard all the changes done over the last published page and will give a warning before doing that. 
