### PR TITLE
fix: Hide edit icon for Website Users

### DIFF
--- a/builder/templates/generators/webpage_scripts.html
+++ b/builder/templates/generators/webpage_scripts.html
@@ -15,7 +15,7 @@
 {% endif %}
 {% if not preview %}
 <script>
-if(window.matchMedia("(min-width:768px)").matches&&document.cookie.includes("user_id=")&&!document.cookie.includes("user_id=Guest")){const a=Object.assign(document.createElement("a"),{rel:"nofollow",href:"{{editor_link}}",target:"editor-{{page_name}}",style:"position:fixed;bottom:40px;right:50px;height:35px;width:35px;opacity:.1",innerHTML:'<img src="/assets/builder/frontend/builder_logo.png" alt="Edit in Builder" style="box-shadow:#bdbdbd 0 0 5px;border-radius:10px"/>'});document.body.appendChild(a),a.addEventListener("mouseover",()=>a.style.opacity="1"),a.addEventListener("mouseout",()=>a.style.opacity=".1")}
+if(window.matchMedia("(min-width:768px)").matches&&document.cookie.includes("user_id=")&&!document.cookie.includes("user_id=Guest")&&!document.cookie.includes("system_user=no;")){const a=Object.assign(document.createElement("a"),{rel:"nofollow",href:"{{editor_link}}",target:"editor-{{page_name}}",style:"position:fixed;bottom:40px;right:50px;height:35px;width:35px;opacity:.1",innerHTML:'<img src="/assets/builder/frontend/builder_logo.png" alt="Edit in Builder" style="box-shadow:#bdbdbd 0 0 5px;border-radius:10px"/>'});document.body.appendChild(a),a.addEventListener("mouseover",()=>a.style.opacity="1"),a.addEventListener("mouseout",()=>a.style.opacity=".1")}
 </script>
 {% endif %}
 {% if _body_html %}


### PR DESCRIPTION
This PR fixes an issue where the Builder edit icon was visible to users who don't have sufficient permissions to edit pages, such as Website Users. 

## Changes
- Added an additional check in the editor icon condition to hide it for Website Users
- The icon will now only be displayed for System Users who have the necessary privileges

## Why
Previously, the edit icon was being displayed for all logged-in users, including Website Users who don't have permission to use Builder. This was confusing as clicking the icon would lead them to an access denied page.

## Testing
- Login as a Website User and verify that the edit icon doesn't appear
- Login as a System User and verify that the edit icon still appears properly