### PR TITLE
fix: Layer panel visibility for deeply nested layers

### DIFF
--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -11,7 +11,7 @@
 				<div
 					:data-block-layer-id="element.blockId"
 					:title="element.blockId"
-					class="min-w-24 cursor-pointer select-none overflow-hidden rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7"
+					class="min-w-24 cursor-pointer select-none rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7"
 					@click.stop="selectBlock(element, $event)"
 					@mouseover.stop="canvasStore.activeCanvas?.setHoveredBlock(element.blockId)"
 					@mouseleave.stop="canvasStore.activeCanvas?.setHoveredBlock(null)">
@@ -45,7 +45,7 @@
 							}"
 							v-if="Boolean(element.extendedFromComponent)" />
 						<span
-							class="layer-label min-h-[1em] min-w-[2em] truncate"
+							class="layer-label min-h-[1em] min-w-[2em] max-w-64 truncate"
 							:contenteditable="element.editable"
 							:title="element.blockId"
 							:class="{
@@ -68,7 +68,7 @@
 						<FeatherIcon
 							v-if="!element.isRoot()"
 							:name="element.isVisible() ? 'eye' : 'eye-off'"
-							class="ml-auto mr-2 hidden h-3 w-3 group-hover:block"
+							class="invisible ml-auto mr-2 h-3 w-3 group-hover:visible"
 							@click.stop="element.toggleVisibility()" />
 						<span v-if="element.isRoot()" class="ml-auto mr-2 text-sm capitalize text-ink-gray-5">
 							{{ canvasStore.activeCanvas?.activeBreakpoint }}

--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -33,16 +33,16 @@
 			<div v-show="builderStore.leftPanelActiveTab === 'Assets'">
 				<BuilderAssets class="mt-1 p-4 pt-3" />
 			</div>
-			<div v-show="builderStore.leftPanelActiveTab === 'Layers'" class="p-3">
+			<div v-show="builderStore.leftPanelActiveTab === 'Layers'" class="p-3 pr-0">
 				<BlockLayers
-					class="no-scrollbar block-layers overflow-auto"
+					class="no-scrollbar block-layers w-fit min-w-full pr-3"
 					v-if="pageCanvas"
 					:disable-draggable="true"
 					ref="pageLayers"
 					:blocks="[pageCanvas?.getRootBlock() as Block]"
 					v-show="canvasStore.editingMode == 'page'" />
 				<BlockLayers
-					class="no-scrollbar block-layers overflow-auto"
+					class="no-scrollbar block-layers w-fit min-w-full pr-3"
 					ref="componentLayers"
 					:disable-draggable="true"
 					:blocks="[fragmentCanvas?.getRootBlock()]"

--- a/frontend/src/components/Controls/CodeEditor.vue
+++ b/frontend/src/components/Controls/CodeEditor.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="editor flex flex-col gap-1">
+	<div class="code-editor flex flex-col gap-1">
 		<span class="text-p-sm font-medium text-ink-gray-8" v-show="label">
 			{{ label }}
 			<span v-if="isDirty" class="text-[10px] text-gray-600">●</span>


### PR DESCRIPTION
**Before**

https://github.com/user-attachments/assets/f2916f07-758b-4345-b43a-fb2acdb1eca3



**After:**

https://github.com/user-attachments/assets/18939189-9eac-47c1-8b92-44e43a10dec1

> unrelated: Panel resize handle cursor does not show up for some reason while screen recording :/

