### PR TITLE
fix: Arrow navigation in component editor view

### DIFF
--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -219,7 +219,7 @@ onMounted(() => {
 		findBlock,
 	);
 	setPanAndZoom(canvasEl, canvasContainerEl, canvasProps);
-	useBlockEventHandlers();
+	useBlockEventHandlers(canvasContainerEl);
 });
 
 const handleClick = (ev: MouseEvent) => {

--- a/frontend/src/utils/useBlockEventHandlers.ts
+++ b/frontend/src/utils/useBlockEventHandlers.ts
@@ -8,10 +8,10 @@ import { nextTick } from "vue";
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 
-export function useBlockEventHandlers() {
-	useEventListener(document, "click", handleClick);
-	useEventListener(document, "dblclick", handleDoubleClick);
-	useEventListener(document, "contextmenu", triggerContextMenu);
+export function useBlockEventHandlers(target: HTMLElement) {
+	useEventListener(target, "click", handleClick);
+	useEventListener(target, "dblclick", handleDoubleClick);
+	useEventListener(target, "contextmenu", triggerContextMenu);
 
 	function handleClick(e: MouseEvent) {
 		if (!isBlock(e) || isEditable(e)) return;

--- a/frontend/src/utils/useCanvasEvents.ts
+++ b/frontend/src/utils/useCanvasEvents.ts
@@ -155,7 +155,10 @@ export function useCanvasEvents(
 	});
 
 	useEventListener(document, "keydown", (ev: KeyboardEvent) => {
-		if (isTargetEditable(ev) || selectedBlocks.value.length !== 1) return;
+		// make sure reference container is not hidden or not editable
+		if (!container.value.offsetParent || isTargetEditable(ev) || selectedBlocks.value.length !== 1) {
+			return;
+		}
 
 		const selectedBlock = selectedBlocks.value[0];
 

--- a/frontend/src/utils/useCanvasEvents.ts
+++ b/frontend/src/utils/useCanvasEvents.ts
@@ -163,6 +163,7 @@ export function useCanvasEvents(
 		const selectedBlock = selectedBlocks.value[0];
 
 		const selectBlock = (block: Block | null) => {
+			// TODO: Use canvas's selectBlock instead of canvasStore's to avoid mixup with other canvas
 			if (block) canvasStore.selectBlock(block, null, true, true);
 			return !!block;
 		};

--- a/frontend/src/utils/useCanvasUtils.ts
+++ b/frontend/src/utils/useCanvasUtils.ts
@@ -44,7 +44,7 @@ export function useCanvasUtils(
 		const container = canvasContainer.value as HTMLElement;
 		const containerRect = container.getBoundingClientRect();
 		await nextTick();
-		const selectedBlock = document.body.querySelector(
+		const selectedBlock = canvasContainer.value.querySelector(
 			`.editor[data-block-id="${blockToFocus.blockId}"][selected=true]`,
 		) as HTMLElement;
 		if (!selectedBlock) {


### PR DESCRIPTION
The event listeners for the page canvas and the component editor canvas were both attached to the document, which caused unintended behavior. Even when the page canvas was hidden, its event listeners were still active and responding to events. As a result, interactions intended only for the active component editor canvas were also triggering the page canvas listeners. This led to issues like the `selectedBlockIds` list in the component editor canvas being incorrectly updated with block IDs from the page canvas 🤦‍♂️