### PR TITLE
fix(pre-commit): Use different prettier pre-commit fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.11.13
     hooks:
       - id: ruff
         name: "Run ruff import sorter"
@@ -17,8 +17,8 @@ repos:
       - id: ruff-format
         name: "Run ruff formatter"
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/JoC0de/pre-commit-prettier
+    rev: v3.5.3
     hooks:
       - id: prettier
         types_or:
@@ -27,6 +27,8 @@ repos:
         additional_dependencies:
           - prettier
           - prettier-plugin-tailwindcss
+        args:
+          - --plugin=prettier-plugin-tailwindcss
         exclude: |
             (?x)^(
                 frappe/public/dist/.*|


### PR DESCRIPTION
Prettier pre commit suddenly started having an issue. It was adding unnecessary extra lines to vue file. 

This started happening after recent update I think. 
I tried updating and pinning the versions of prettier and prettier-plugin-tailwindcss but it did fix the issue. 

I randomly tried commenting out few lines from config file and running the pre-commit. Here I kindof narrowed down the issue a bit. Turns out that the issue was related to `prettier-plugin-tailwindcss`. Am guessing it has something to do with the compatibility between prettier and this plugin.

Finally, while searching for solution, I tried [this forked version](https://github.com/JoC0de/pre-commit-prettier) were author [claimed](https://github.com/prettier/prettier/discussions/16227#discussioncomment-10443876) to have fixed the issue with pre-commit for latest prettier version and turned out to be the solution. This one works as expected for now.