### PR TITLE
fix: Move builder logo to sidebar 

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -83,7 +83,7 @@ useTitle(title);
 [id^="headlessui-menu-items"],
 [id^="headlessui-combobox-options"] {
 	@apply bg-surface-white;
-	@apply dark:bg-surface-gray-1;
+	@apply dark:bg-surface-gray-2;
 	@apply text-ink-gray-7;
 
 	@apply overflow-y-auto;

--- a/frontend/src/components/DashboardSidebar.vue
+++ b/frontend/src/components/DashboardSidebar.vue
@@ -1,7 +1,103 @@
 <template>
 	<section
-		class="sticky bottom-0 left-0 top-0 flex w-60 flex-col gap-3 bg-surface-gray-1 p-2 shadow-lg max-lg:hidden">
+		class="sticky bottom-0 left-0 top-0 flex flex-col gap-3 bg-surface-gray-1 p-2 shadow-lg max-lg:hidden"
+		:class="[builderStore.showDashboardSidebar ? 'w-60' : 'w-auto']">
 		<div class="flex flex-col">
+			<div class="mb-2 flex gap-2">
+				<Dialog
+					v-model="showSettingsDialog"
+					style="z-index: 40"
+					class="[&>div>div[id^=headlessui-dialog-panel]]:my-3"
+					:options="{
+						title: 'Settings',
+						size: '5xl',
+					}">
+					<template #body>
+						<BuilderSettings @close="showSettingsDialog = false" :onlyGlobal="true"></BuilderSettings>
+					</template>
+				</Dialog>
+				<div class="flex w-full items-center">
+					<Dropdown
+						:options="[
+							{
+								group: 'Builder',
+								hideLabel: true,
+								items: [
+									{
+										label: 'New Page',
+										onClick: () =>
+											$router.push({
+												name: 'builder',
+												params: { pageId: 'new' },
+											}),
+										icon: 'plus',
+									},
+								],
+							},
+							{
+								group: 'Options',
+								hideLabel: true,
+								items: [
+									{
+										label: 'Apps',
+										component: AppsMenu,
+										icon: 'grid',
+									},
+									{
+										label: 'Toggle Theme',
+										onClick: () => toggleDark(),
+										icon: isDark ? 'sun' : 'moon',
+									},
+									{
+										label: 'Settings',
+										onClick: () => (showSettingsDialog = true),
+										icon: 'settings',
+									},
+								],
+							},
+							{
+								group: 'Help',
+								hideLabel: true,
+								items: [
+									{
+										label: 'Help',
+										onClick: () => {
+											// @ts-ignore
+											window.open('https://t.me/frappebuilder');
+										},
+										icon: 'info',
+									},
+								],
+							},
+						]"
+						size="sm"
+						class="flex-1 [&>div>div>div]:w-full"
+						placement="right">
+						<template v-slot="{ open }">
+							<div
+								class="flex items-center justify-between rounded py-1"
+								:class="{
+									'!bg-surface-white shadow-sm dark:!bg-surface-gray-2':
+										open && builderStore.showDashboardSidebar,
+									'!p-2 hover:bg-surface-gray-2': builderStore.showDashboardSidebar,
+								}">
+								<div class="flex w-full cursor-pointer items-center gap-2">
+									<img src="/builder_logo.png" alt="logo" class="h-7" />
+									<h1
+										class="text-md mt-[2px] font-semibold leading-5 text-gray-800 dark:text-gray-200"
+										v-show="builderStore.showDashboardSidebar">
+										Builder
+									</h1>
+								</div>
+								<FeatherIcon
+									:name="open ? 'chevron-up' : 'chevron-down'"
+									class="h-4 w-4 !text-gray-700 dark:!text-gray-200"
+									v-show="builderStore.showDashboardSidebar"></FeatherIcon>
+							</div>
+						</template>
+					</Dropdown>
+				</div>
+			</div>
 			<span
 				class="flex cursor-pointer gap-2 rounded p-2 text-base text-ink-gray-6"
 				@click="() => setFolderActive('')"
@@ -9,15 +105,19 @@
 					'bg-surface-modal text-ink-gray-8 shadow-sm dark:bg-surface-gray-2': !builderStore.activeFolder,
 				}">
 				<FilesIcon class="size-4"></FilesIcon>
-				All Pages
+				<span v-show="builderStore.showDashboardSidebar">All Pages</span>
 			</span>
-			<span class="flex cursor-pointer gap-2 p-2 text-base text-ink-gray-6" @click="emit('openSettings')">
+			<span
+				class="flex cursor-pointer gap-2 p-2 text-base text-ink-gray-6"
+				@click="showSettingsDialog = true">
 				<SettingsIcon class="size-4"></SettingsIcon>
-				Settings
+				<span v-show="builderStore.showDashboardSidebar">Settings</span>
 			</span>
 		</div>
 		<div class="flex flex-1 flex-col">
-			<div class="flex items-center justify-between p-2 text-base text-ink-gray-6">
+			<div
+				class="flex items-center justify-between p-2 text-base text-ink-gray-6"
+				v-show="builderStore.showDashboardSidebar">
 				<span>Folders</span>
 				<BuilderButton
 					variant="subtle"
@@ -27,6 +127,7 @@
 			</div>
 			<span
 				class="flex h-8 w-full cursor-pointer items-center justify-between gap-2 rounded p-2 py-1 text-base text-ink-gray-6"
+				v-show="builderStore.showDashboardSidebar"
 				v-for="project in builderProjectFolder.data"
 				:class="{
 					'bg-surface-modal text-ink-gray-8 shadow-sm dark:bg-surface-gray-2': isFolderActive(
@@ -72,11 +173,21 @@
 				</Dropdown>
 			</span>
 		</div>
+		<div
+			class="flex cursor-pointer items-center gap-2 rounded p-2 text-base text-ink-gray-6 hover:bg-surface-gray-2"
+			@click="() => (builderStore.showDashboardSidebar = !builderStore.showDashboardSidebar)">
+			<FeatherIcon
+				:name="builderStore.showDashboardSidebar ? 'chevrons-left' : 'chevrons-right'"
+				class="h-4 w-4" />
+			<span v-show="builderStore.showDashboardSidebar">Collapse</span>
+		</div>
 		<NewFolder v-model="showNewFolderDialog"></NewFolder>
 		<TrialBanner v-if="builderStore.isFCSite"></TrialBanner>
 	</section>
 </template>
 <script lang="ts" setup>
+import AppsMenu from "@/components/AppsMenu.vue";
+import BuilderSettings from "@/components/BuilderSettings.vue";
 import BuilderButton from "@/components/Controls/BuilderButton.vue";
 import EditableSpan from "@/components/EditableSpan.vue";
 import FilesIcon from "@/components/Icons/Files.vue";
@@ -87,13 +198,16 @@ import builderProjectFolder from "@/data/builderProjectFolder";
 import useBuilderStore from "@/stores/builderStore";
 import { BuilderProjectFolder } from "@/types/Builder/BuilderProjectFolder";
 import { confirm } from "@/utils/helpers";
-import { createResource, Dropdown } from "frappe-ui";
+import { useDark, useToggle } from "@vueuse/core";
+import { createResource, Dialog, Dropdown } from "frappe-ui";
 import { TrialBanner } from "frappe-ui/frappe";
 import { ref } from "vue";
-
+const isDark = useDark({
+	attribute: "data-theme",
+});
+const toggleDark = useToggle(isDark);
 const builderStore = useBuilderStore();
 const renamingFolder = ref("");
-const emit = defineEmits(["openSettings"]);
 const showNewFolderDialog = ref(false);
 
 const isFolderActive = (folderName: string) => {
@@ -142,4 +256,5 @@ const deleteFolder = async (folderName: string) => {
 	);
 	setFolderActive("");
 };
+const showSettingsDialog = ref(false);
 </script>

--- a/frontend/src/pages/PageBuilderDashboard.vue
+++ b/frontend/src/pages/PageBuilderDashboard.vue
@@ -1,118 +1,27 @@
 <template>
-	<div class="flex h-screen flex-col">
+	<div class="flex h-screen">
 		<!-- toolbar -->
-		<div
-			class="toolbar sticky top-0 z-10 flex h-12 items-center justify-between border-b-[1px] border-outline-gray-1 bg-surface-white p-2 px-3 py-1"
-			ref="toolbar">
-			<div>
-				<Dialog
-					v-model="showSettingsDialog"
-					style="z-index: 40"
-					class="[&>div>div[id^=headlessui-dialog-panel]]:my-3"
-					:options="{
-						title: 'Settings',
-						size: '5xl',
-					}">
-					<template #body>
-						<BuilderSettings @close="showSettingsDialog = false" :onlyGlobal="true"></BuilderSettings>
-					</template>
-				</Dialog>
-				<div class="flex items-center">
-					<Dropdown
-						:options="[
-							{
-								group: 'Builder',
-								hideLabel: true,
-								items: [
-									{
-										label: 'New Page',
-										onClick: () =>
-											$router.push({
-												name: 'builder',
-												params: { pageId: 'new' },
-											}),
-										icon: 'plus',
-									},
-								],
-							},
-							{
-								group: 'Options',
-								hideLabel: true,
-								items: [
-									{
-										label: 'Apps',
-										component: AppsMenu,
-										icon: 'grid',
-									},
-									{
-										label: 'Toggle Theme',
-										onClick: () => toggleDark(),
-										icon: isDark ? 'sun' : 'moon',
-									},
-									{
-										label: 'Toggle Sidebar',
-										onClick: () => (builderStore.showDashboardSidebar = !builderStore.showDashboardSidebar),
-										icon: 'sidebar',
-									},
-									{
-										label: 'Settings',
-										onClick: () => (showSettingsDialog = true),
-										icon: 'settings',
-									},
-								],
-							},
-							{
-								group: 'Help',
-								hideLabel: true,
-								items: [
-									{
-										label: 'Help',
-										onClick: () => {
-											// @ts-ignore
-											window.open('https://t.me/frappebuilder');
-										},
-										icon: 'info',
-									},
-								],
-							},
-						]"
-						size="sm"
-						class="flex-1 [&>div>div>div]:w-full"
-						placement="right">
-						<template v-slot="{ open }">
-							<div class="flex cursor-pointer items-center gap-2">
-								<img src="/builder_logo.png" alt="logo" class="h-7" />
-								<h1 class="text-md mt-[2px] font-semibold leading-5 text-gray-800 dark:text-gray-200">
-									Builder
-								</h1>
-								<FeatherIcon
-									:name="open ? 'chevron-up' : 'chevron-down'"
-									class="h-4 w-4 !text-gray-700 dark:!text-gray-200"></FeatherIcon>
-							</div>
-						</template>
-					</Dropdown>
-				</div>
+		<DashboardSidebar class="z-30"></DashboardSidebar>
+		<div class="flex w-full flex-1 flex-col overflow-hidden">
+			<div
+				class="toolbar sticky top-0 z-10 flex h-12 items-center justify-end border-b-[1px] border-outline-gray-1 bg-surface-white p-2 px-3 py-1"
+				ref="toolbar">
+				<router-link
+					:to="{ name: 'builder', params: { pageId: 'new' } }"
+					@click="
+						() => {
+							posthog.capture('builder_new_page_created');
+						}
+					">
+					<BuilderButton
+						variant="solid"
+						iconLeft="plus"
+						class="bg-surface-gray-7 !text-ink-white hover:bg-surface-gray-6">
+						New
+					</BuilderButton>
+				</router-link>
 			</div>
-			<router-link
-				:to="{ name: 'builder', params: { pageId: 'new' } }"
-				@click="
-					() => {
-						posthog.capture('builder_new_page_created');
-					}
-				">
-				<BuilderButton
-					variant="solid"
-					iconLeft="plus"
-					class="bg-surface-gray-7 !text-ink-white hover:bg-surface-gray-6">
-					New
-				</BuilderButton>
-			</router-link>
-		</div>
-		<div class="flex w-full flex-1 overflow-hidden">
 			<!-- Sidebar -->
-			<DashboardSidebar
-				v-show="builderStore.showDashboardSidebar"
-				@openSettings="showSettingsDialog = true"></DashboardSidebar>
 			<!-- Main Content -->
 			<div class="flex-1 overflow-auto">
 				<section class="m-auto mb-32 flex h-fit w-3/4 max-w-6xl flex-col pt-5">
@@ -248,9 +157,6 @@
 	</div>
 </template>
 <script setup lang="ts">
-import AppsMenu from "@/components/AppsMenu.vue";
-import BuilderSettings from "@/components/BuilderSettings.vue";
-import Dialog from "@/components/Controls/Dialog.vue";
 import OptionToggle from "@/components/Controls/OptionToggle.vue";
 import DashboardSidebar from "@/components/DashboardSidebar.vue";
 import SelectFolder from "@/components/Modals/SelectFolder.vue";
@@ -262,7 +168,7 @@ import useBuilderStore from "@/stores/builderStore";
 import { posthog } from "@/telemetry";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
 import { useDark, useEventListener, useStorage, useToggle, watchDebounced } from "@vueuse/core";
-import { createResource, Dropdown } from "frappe-ui";
+import { createResource } from "frappe-ui";
 import { onActivated, Ref, ref, watch } from "vue";
 
 const isDark = useDark({


### PR DESCRIPTION
Move builder logo to sidebar to make it look consistent with other apps

**Before:**
<img width="1440" alt="Screenshot 2025-06-23 at 5 26 55 PM" src="https://github.com/user-attachments/assets/61bda606-1229-4275-b269-55a591b17adc" />


**After:**
<img width="1440" alt="Screenshot 2025-06-23 at 5 26 41 PM" src="https://github.com/user-attachments/assets/398f352e-7e5b-4416-a0be-5bd3df4b5852" />
