### PR TITLE
feat: Option to copy entire page with configuration and scripts

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,7 @@
 		<UseDark attribute="data-theme"></UseDark>
 		<Toaster :theme="isDark ? 'dark' : 'light'" richColors />
 		<Dialogs></Dialogs>
+		<component v-for="dialog in builderStore.appDialogs" :is="dialog"></component>
 	</div>
 </template>
 <script setup lang="ts">

--- a/frontend/src/components/BlockContextMenu.vue
+++ b/frontend/src/components/BlockContextMenu.vue
@@ -21,7 +21,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
 import blockController from "@/utils/blockController";
 import getBlockTemplate from "@/utils/blockTemplate";
-import { confirm, detachBlockFromComponent, getBlockCopy } from "@/utils/helpers";
+import { confirm, detachBlockFromComponent, getBlockCopy, triggerCopyEvent } from "@/utils/helpers";
 import { vOnClickOutside } from "@vueuse/components";
 import { useStorage } from "@vueuse/core";
 import { Ref, nextTick, ref } from "vue";
@@ -87,7 +87,7 @@ const contextMenuOptions: ContextMenuOption[] = [
 		},
 		condition: () => block.value.isHTML(),
 	},
-	{ label: "Copy", action: () => document.execCommand("copy") },
+	{ label: "Copy", action: () => triggerCopyEvent() },
 	{ label: "Copy Style", action: copyStyle },
 	{
 		label: "Paste Style",

--- a/frontend/src/components/MainMenu.vue
+++ b/frontend/src/components/MainMenu.vue
@@ -18,6 +18,12 @@
 						icon: 'plus',
 					},
 					{
+						label: 'Copy To Clipboard',
+						onClick: handleCopyPage,
+						icon: 'clipboard',
+						condition: () => Boolean(pageStore.activePage),
+					},
+					{
 						label: 'Duplicate Page',
 						onClick: () => pageStore.duplicatePage(pageStore.activePage as BuilderPage),
 						icon: 'copy',
@@ -70,8 +76,11 @@
 	</Dropdown>
 </template>
 <script setup lang="ts">
+import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
+import { triggerCopyEvent } from "@/utils/helpers";
+
 import { useDark, useToggle } from "@vueuse/core";
 import { Dropdown } from "frappe-ui";
 
@@ -80,4 +89,12 @@ const isDark = useDark({
 	attribute: "data-theme",
 });
 const toggleDark = useToggle(isDark);
+const canvasStore = useCanvasStore();
+
+const handleCopyPage = () => {
+	if (!pageStore.activePage) return;
+	canvasStore.copyEntirePage = true;
+	canvasStore.requiresConfirmationForCopyingEntirePage = false;
+	triggerCopyEvent();
+};
 </script>

--- a/frontend/src/components/MainMenu.vue
+++ b/frontend/src/components/MainMenu.vue
@@ -18,7 +18,7 @@
 						icon: 'plus',
 					},
 					{
-						label: 'Copy To Clipboard',
+						label: 'Copy Page',
 						onClick: handleCopyPage,
 						icon: 'clipboard',
 						condition: () => Boolean(pageStore.activePage),

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex gap-5">
-		<div class="flex flex-col gap-3">
+		<div class="flex flex-col gap-3 pt-6">
 			<div class="flex h-full w-48 flex-col justify-between gap-1">
 				<div class="flex flex-col gap-1">
 					<a
@@ -111,7 +111,9 @@
 
 <script setup lang="ts">
 import EditableSpan from "@/components/EditableSpan.vue";
+import usePageStore from "@/stores/pageStore";
 import { posthog } from "@/telemetry";
+import { BuilderClientScript } from "@/types/Builder/BuilderClientScript";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
 import { Autocomplete, createListResource, createResource, Dropdown } from "frappe-ui";
 import { computed, nextTick, ref, watch } from "vue";
@@ -121,6 +123,7 @@ import CSSIcon from "./Icons/CSS.vue";
 import JavaScriptIcon from "./Icons/JavaScript.vue";
 
 const scriptEditor = ref<InstanceType<typeof CodeEditor> | null>(null);
+const pageStore = usePageStore();
 
 type attachedScript = {
 	script: string;
@@ -153,7 +156,7 @@ const attachedScriptResource = createListResource({
 		"builder_script.name as script_name",
 		"name",
 	],
-	orderBy: "`tabBuilder Page Client Script`.creation asc",
+	orderBy: "`tabBuilder Page Client Script`.idx asc",
 	auto: true,
 	onSuccess: (data: attachedScript[]) => {
 		if (data && data.length > 0 && !activeScript.value) {
@@ -178,6 +181,14 @@ const selectScript = (script: attachedScript) => {
 
 const updateScript = (value: string) => {
 	if (!activeScript.value) return;
+
+	pageStore.activePageScripts = pageStore.activePageScripts.map((script: BuilderClientScript) => {
+		if (script.name === activeScript.value?.script_name) {
+			script.script = value;
+		}
+		return script;
+	});
+
 	clientScriptResource.setValue
 		.submit({
 			name: activeScript.value.script_name,
@@ -206,7 +217,7 @@ const addScript = (scriptType: "JavaScript" | "CSS") => {
 			script_type: scriptType,
 			script: scriptType === "JavaScript" ? "// Write your script here\n" : "/* Write your CSS here */\n",
 		})
-		.then((res: { name: string; script_type: string; script: string }) => {
+		.then((res: BuilderClientScript) => {
 			attachedScriptResource.insert
 				.submit({
 					parent: props.page.name,
@@ -224,6 +235,7 @@ const addScript = (scriptType: "JavaScript" | "CSS") => {
 							selectScript(script);
 						}
 					});
+					pageStore.activePageScripts.push(res);
 				});
 		});
 };
@@ -252,11 +264,20 @@ const deleteScript = (scriptName: string) => {
 	attachedScriptResource.delete.submit(scriptName).then(() => {
 		attachedScriptResource.reload();
 	});
+	pageStore.activePageScripts = pageStore.activePageScripts.filter(
+		(script: BuilderClientScript) => script.name !== scriptName,
+	);
 };
 
 const updateScriptName = async (newName: string, script: attachedScript) => {
 	if (!newName) return;
 	script.editable = false;
+	pageStore.activePageScripts = pageStore.activePageScripts.map((_script: BuilderClientScript) => {
+		if (_script.name === script.name) {
+			script.name = newName;
+		}
+		return script;
+	});
 	return createResource({
 		url: "frappe.client.rename_doc",
 	})

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -5,6 +5,7 @@ import RealTimeHandler from "@/utils/realtimeHandler";
 import { useStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
 import { toast } from "vue-sonner";
+import type Dialog from "../components/Controls/Dialog.vue";
 import BlockLayers from "./components/BlockLayers.vue";
 
 declare global {
@@ -16,6 +17,7 @@ declare global {
 const useBuilderStore = defineStore("builderStore", {
 	state: () => ({
 		activeLayers: <InstanceType<typeof BlockLayers> | null>null,
+		appDialogs: <(typeof Dialog)[]>[],
 		blockContextMenu: <InstanceType<typeof BlockContextMenu> | null>null,
 		propertyFilter: <string | null>null,
 		mode: <BuilderMode>"select", // check setEvents in BuilderCanvas for usage

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -7,6 +7,8 @@ import { nextTick } from "vue";
 const useCanvasStore = defineStore("canvasStore", {
 	state: () => ({
 		activeCanvas: <InstanceType<typeof BuilderCanvas> | null>null,
+		requiresConfirmationForCopyingEntirePage: <boolean>true,
+		copyEntirePage: <boolean>false,
 		preventClick: false,
 		guides: {
 			showX: false,

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -154,7 +154,7 @@ const useComponentStore = defineStore("componentStore", {
 						block: obj.block,
 					});
 				} else {
-					console.log("Skipping component update", obj.name, existingComponent, newComponent);
+					console.log("Skipping component update", obj.name);
 					return;
 				}
 			}

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -163,8 +163,15 @@ const useComponentStore = defineStore("componentStore", {
 				.then(() => {
 					this.setComponentMap(obj);
 				})
-				.catch(() => {
-					console.log(`There was an error while creating ${obj.component_name}`);
+				.catch((e: { response: { status: number } }) => {
+					if (e?.response?.status === 409) {
+						if (updateExisting) {
+							return webComponent.setValue.submit({
+								name: obj.name,
+								block: obj.block,
+							});
+						}
+					}
 				});
 		},
 		getComponentName(componentId: string) {

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -14,10 +14,11 @@ import {
 	getCopyWithoutParent,
 	getRouteVariables,
 } from "@/utils/helpers";
-import { createDocumentResource, createResource } from "frappe-ui";
+import { createDocumentResource, createListResource, createResource } from "frappe-ui";
 import { defineStore } from "pinia";
 import { nextTick } from "vue";
 import { toast } from "vue-sonner";
+import { BuilderClientScript } from "../types/Builder/BuilderClientScript";
 
 const usePageStore = defineStore("pageStore", {
 	state: () => ({
@@ -29,6 +30,7 @@ const usePageStore = defineStore("pageStore", {
 		pageBlocks: <Block[]>[],
 		saveId: null as string | null,
 		activePage: <BuilderPage | null>null,
+		activePageScripts: <BuilderClientScript[]>[],
 		savingPage: false,
 		settingPage: false,
 	}),
@@ -67,6 +69,21 @@ const usePageStore = defineStore("pageStore", {
 
 			const canvasStore = useCanvasStore();
 			canvasStore.activeCanvas?.setRootBlock(this.pageBlocks[0], resetCanvas);
+
+			if (page.client_scripts?.length) {
+				// Fetch full script documents for each script
+				const scriptsResource = createListResource({
+					doctype: "Builder Client Script",
+					fields: ["script_type", "name", "script"],
+					filters: [["name", "in", page.client_scripts.map((script) => script.builder_script)]],
+					auto: true,
+				});
+
+				await scriptsResource.list.promise;
+				this.activePageScripts = scriptsResource.data as BuilderClientScript[];
+			} else {
+				this.activePageScripts = [];
+			}
 
 			nextTick(() => {
 				const componentStore = useComponentStore();

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -1,0 +1,329 @@
+import type Block from "@/block";
+import useCanvasStore from "@/stores/canvasStore";
+import useComponentStore from "@/stores/componentStore";
+import usePageStore from "@/stores/pageStore";
+import { BuilderComponent } from "@/types/Builder/BuilderComponent";
+import { BuilderPage } from "@/types/Builder/BuilderPage";
+import blockController from "@/utils/blockController";
+
+import {
+	copyToClipboard,
+	detachBlockFromComponent,
+	getBlockCopy,
+	getBlockInstance,
+	getCopyWithoutParent,
+	isJSONString,
+	showDialog,
+} from "@/utils/helpers";
+import { nextTick } from "vue";
+import { webPages } from "../data/webPage";
+import { BuilderClientScript } from "../types/Builder/BuilderClientScript";
+
+type BuilderPageClientScriptRef = { builder_script: string; idx?: number };
+
+type BuilderPageSettings = Pick<
+	BuilderPage,
+	| "page_name"
+	| "route"
+	| "dynamic_route"
+	| "is_template"
+	| "template_name"
+	| "page_data_script"
+	| "head_html"
+	| "body_html"
+	| "page_title"
+	| "meta_description"
+	| "meta_image"
+	| "canonical_url"
+	| "authenticated_access"
+	| "disable_indexing"
+	| "favicon"
+	| "blocks"
+> & {
+	client_scripts?: BuilderPageClientScriptRef[];
+};
+
+interface BuilderClipboardData {
+	blocks: (Block | BlockOptions)[];
+	components: BuilderComponent[];
+	sourceURL?: string;
+	pageDoc?: BuilderPageSettings;
+	pageScripts?: BuilderClientScript[];
+}
+
+type BuilderClientScriptDocument = Partial<BuilderClientScript>;
+
+function generateHash(componentId: string, siteURL: string): string {
+	// Generate a deterministic hash with the same length as componentId, using siteURL for uniqueness
+	const str = `${componentId}_${siteURL}`;
+	let hash = 5381;
+	for (let i = 0; i < str.length; i++) {
+		hash = (hash << 5) + hash + str.charCodeAt(i); // djb2 hash
+	}
+	const hashStr = Math.abs(hash).toString(36);
+	// Pad or trim the hash to match the original componentId length
+	const targetLength = componentId.length;
+	const padded = hashStr.repeat(Math.ceil(targetLength / hashStr.length)).slice(0, targetLength);
+	return padded;
+}
+
+function updateURLsInBlock(block: Block, currentSiteURL: string): void {
+	// Update image and video sources to absolute URLs
+	if (block.isImage() || block.isVideo()) {
+		const src = block.getAttribute("src");
+		if (src && typeof src === "string" && !src.startsWith("http")) {
+			block.setAttribute("src", `${currentSiteURL}${src}`);
+		}
+	}
+
+	// Update background image URLs
+	if (block) {
+		const bgSrc = block.getStyle("backgroundImage");
+		if (bgSrc && typeof bgSrc === "string" && bgSrc.startsWith("url(")) {
+			const urlMatch = bgSrc.match(/url\(["']?([^"']+)["']?\)/);
+			if (urlMatch && urlMatch[1] && !urlMatch[1].startsWith("http")) {
+				block.setStyle("backgroundImage", `url(${currentSiteURL}${urlMatch[1]})`);
+			}
+		}
+	}
+
+	// Update href attributes for links
+	// if (block.isLink()) {
+	// 	const href = block.getAttribute("href");
+	// 	if (href && typeof href === "string" && !href.startsWith("http") && !href.startsWith("#")) {
+	// 		block.setAttribute("href", `${currentSiteURL}${href}`);
+	// 	}
+	// }
+
+	// Recursively process children
+	block.children.forEach((child) => updateURLsInBlock(child, currentSiteURL));
+}
+
+export function copyBuilderBlocks(
+	e: ClipboardEvent,
+	currentSiteURL: string,
+	copyEntirePage: boolean = false,
+) {
+	const canvasStore = useCanvasStore();
+	const componentStore = useComponentStore();
+	const pageStore = usePageStore();
+	if (!canvasStore.activeCanvas?.selectedBlocks.length && !copyEntirePage) return;
+	e.preventDefault();
+
+	const componentDocuments: BuilderComponent[] = [];
+	const blocksToCopy =
+		canvasStore.activeCanvas?.selectedBlocks.map((block) => {
+			// Collect all used components
+			const components = block.getUsedComponentNames();
+			for (const componentName of components) {
+				const component = componentStore.getComponent(componentName);
+				if (component) {
+					componentDocuments.push(component);
+				}
+			}
+
+			// Handle component children and create copy
+			let blockCopy = null;
+			if (!Boolean(block.extendedFromComponent) && block.isChildOfComponent) {
+				blockCopy = detachBlockFromComponent(block, null);
+			} else {
+				blockCopy = getCopyWithoutParent(block);
+			}
+
+			return blockCopy;
+		}) || [];
+
+	const dataToCopy: BuilderClipboardData = {
+		blocks: blocksToCopy,
+		components: componentDocuments,
+		sourceURL: currentSiteURL,
+	};
+
+	if (copyEntirePage) {
+		const currentPage = pageStore.activePage as BuilderPage;
+		dataToCopy.pageDoc = {
+			page_name: currentPage.page_name,
+			route: currentPage.route,
+			dynamic_route: currentPage.dynamic_route,
+			page_data_script: currentPage.page_data_script,
+			head_html: currentPage.head_html,
+			body_html: currentPage.body_html,
+			page_title: currentPage.page_title,
+			meta_description: currentPage.meta_description,
+			meta_image: currentPage.meta_image,
+			authenticated_access: currentPage.authenticated_access,
+			disable_indexing: currentPage.disable_indexing,
+			favicon: currentPage.favicon,
+			client_scripts:
+				currentPage.client_scripts?.map((script) => {
+					return {
+						builder_script: script.builder_script,
+						idx: script.idx,
+					};
+				}) || [],
+		};
+		dataToCopy.pageScripts = pageStore.activePageScripts;
+	}
+	copyToClipboard(dataToCopy, e, "builder-copied-blocks");
+}
+
+export async function pasteBuilderBlocks(e: ClipboardEvent, currentSiteURL: string): Promise<void> {
+	const componentStore = useComponentStore();
+	const canvasStore = useCanvasStore();
+	const pageStore = usePageStore();
+
+	const data = e.clipboardData?.getData("builder-copied-blocks") as string;
+	if (!data || !isJSONString(data)) return;
+
+	const clipboardData = JSON.parse(data) as BuilderClipboardData;
+	const componentIdMap = new Map<string, string>();
+	const isPagePaste = Boolean(clipboardData.pageDoc);
+	let blocks = clipboardData.blocks;
+	const crossSitePaste = clipboardData.sourceURL && clipboardData.sourceURL !== currentSiteURL;
+	const isCanvasEmpty = !canvasStore.activeCanvas?.getRootBlock().children.length;
+
+	if (isPagePaste && crossSitePaste) {
+		// update pageScript name
+		const pageScriptIdMap = new Map<string, string>();
+		for (const script of clipboardData.pageScripts || []) {
+			const newScriptId = generateHash(script.name, clipboardData.sourceURL || "");
+			// maintain map
+			pageScriptIdMap.set(script.name, newScriptId);
+			const scriptDoc: BuilderClientScriptDocument = {
+				...script,
+				name: newScriptId,
+			};
+
+			const clientScript =
+				clipboardData.pageDoc && clipboardData.pageDoc.client_scripts
+					? clipboardData.pageDoc.client_scripts.find((s) => s.builder_script === script.name)
+					: undefined;
+			if (clientScript) {
+				console.log("Updating client script reference:", clientScript.builder_script, "to", newScriptId);
+				clientScript.builder_script = newScriptId;
+			}
+		}
+	}
+
+	if (crossSitePaste) {
+		// Update component IDs and references (to avoid conflicts & overwrites in the current site)
+		for (const component of clipboardData.components) {
+			const originalId = component.name;
+			const newId = generateHash(originalId, clipboardData.sourceURL || "");
+			componentIdMap.set(originalId, newId);
+
+			component.name = newId;
+			component.component_id = newId;
+			delete component.for_web_page;
+
+			// Create new component with updated ID
+			await componentStore.createComponent(component, true);
+		}
+
+		// Update block references to components
+		for (const block of blocks) {
+			if (block.extendedFromComponent && componentIdMap.has(block.extendedFromComponent)) {
+				block.extendedFromComponent = componentIdMap.get(block.extendedFromComponent);
+			}
+			if (block.isChildOfComponent && componentIdMap.has(block.isChildOfComponent)) {
+				block.isChildOfComponent = componentIdMap.get(block.isChildOfComponent);
+			}
+			// Handle nested blocks recursively
+			updateBlockComponentReferences(block, componentIdMap);
+		}
+
+		blocks = blocks.map((block) => {
+			const blockCopy = getBlockInstance(block);
+			updateURLsInBlock(blockCopy, clipboardData.sourceURL as string);
+			return blockCopy;
+		});
+	} else if (!clipboardData.sourceURL) {
+		// Same site paste - just create components
+		for (const component of clipboardData.components) {
+			delete component.for_web_page;
+			await componentStore.createComponent(component, false);
+		}
+	}
+
+	if (blockController.isBlockSelected() && !blockController.multipleBlocksSelected() && blocks.length === 1) {
+		// handle SVG paste case
+		const selectedBlock = blockController.getSelectedBlocks()[0];
+		const copiedBlock = getBlockCopy(blocks[0]);
+		if (selectedBlock.isSVG() && copiedBlock.isSVG()) {
+			const svgBlock = copiedBlock;
+			if (!svgBlock.innerHTML) return;
+			const svgContent = new DOMParser()
+				.parseFromString(svgBlock.innerHTML, "text/html")
+				.body.querySelector("svg");
+			if (svgContent) {
+				svgContent.removeAttribute("width");
+				svgContent.removeAttribute("height");
+				selectedBlock.setInnerHTML(svgContent.outerHTML);
+				return;
+			}
+		}
+	}
+
+	if (isPagePaste) {
+		await showDialog({
+			title: "Pasting a page!",
+			message:
+				"You are about to paste a page with settings and scripts. Do you want to update the current page or create a new one?",
+			actions: [
+				{
+					label: "Create New Page",
+					variant: "solid",
+					async onClick() {
+						if (clipboardData.pageDoc) {
+							clipboardData.pageDoc.blocks = clipboardData.blocks.map((block) => {
+								return getCopyWithoutParent(block);
+							});
+						}
+						const newPage = await webPages.insert.submit(clipboardData.pageDoc);
+						window.location.href = `/builder/page/${encodeURIComponent(newPage.name)}`;
+					},
+				},
+				{
+					label: "Update Current Page",
+					variant: "subtle",
+					async onClick() {
+						const currentPage = pageStore.activePage as BuilderPage;
+						await webPages.setValue.submit({
+							...clipboardData.pageDoc,
+							name: currentPage.name,
+						});
+						await pageStore.setPage(currentPage.name);
+						nextTick(() => {
+							canvasStore.pushBlocks(blocks);
+							pageStore.savePage();
+						});
+					},
+				},
+			],
+			size: "md",
+		});
+	} else {
+		if (canvasStore.activeCanvas?.selectedBlocks.length && blocks[0].blockId !== "root") {
+			let parentBlock = canvasStore.activeCanvas.selectedBlocks[0];
+			while (parentBlock && !parentBlock.canHaveChildren()) {
+				parentBlock = parentBlock.getParentBlock() as Block;
+			}
+			blocks.forEach((block: BlockOptions) => {
+				parentBlock.addChild(getBlockCopy(block), null, true);
+			});
+		} else {
+			canvasStore.pushBlocks(blocks);
+		}
+	}
+}
+
+function updateBlockComponentReferences(block: BlockOptions, componentIdMap: Map<string, string>): void {
+	if (block.extendedFromComponent && componentIdMap.has(block.extendedFromComponent)) {
+		block.extendedFromComponent = componentIdMap.get(block.extendedFromComponent);
+	}
+	if (block.isChildOfComponent && componentIdMap.has(block.isChildOfComponent)) {
+		block.isChildOfComponent = componentIdMap.get(block.isChildOfComponent);
+	}
+
+	block.children?.forEach((child) => updateBlockComponentReferences(child, componentIdMap));
+}

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -4,7 +4,6 @@ import useComponentStore from "@/stores/componentStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderComponent } from "@/types/Builder/BuilderComponent";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
-import blockController from "@/utils/blockController";
 
 import {
 	copyToClipboard,
@@ -15,7 +14,9 @@ import {
 	isJSONString,
 	showDialog,
 } from "@/utils/helpers";
+import { createListResource } from "frappe-ui";
 import { nextTick } from "vue";
+import { toast } from "vue-sonner";
 import { webPages } from "../data/webPage";
 import { BuilderClientScript } from "../types/Builder/BuilderClientScript";
 
@@ -53,18 +54,249 @@ interface BuilderClipboardData {
 
 type BuilderClientScriptDocument = Partial<BuilderClientScript>;
 
-function generateHash(componentId: string, siteURL: string): string {
-	// Generate a deterministic hash with the same length as componentId, using siteURL for uniqueness
-	const str = `${componentId}_${siteURL}`;
-	let hash = 5381;
-	for (let i = 0; i < str.length; i++) {
-		hash = (hash << 5) + hash + str.charCodeAt(i); // djb2 hash
+export function copyBuilderBlocks(
+	e: ClipboardEvent,
+	currentSiteURL: string,
+	copyEntirePage: boolean = false,
+) {
+	const canvasStore = useCanvasStore();
+	const componentStore = useComponentStore();
+	const pageStore = usePageStore();
+	if (!canvasStore.activeCanvas?.selectedBlocks.length && !copyEntirePage) return;
+	e.preventDefault();
+
+	const blocks = (
+		copyEntirePage
+			? [canvasStore.activeCanvas?.getRootBlock()]
+			: canvasStore.activeCanvas?.selectedBlocks ?? []
+	) as Block[];
+
+	const componentDocuments: BuilderComponent[] = [];
+	const blocksToCopy = blocks.map((block) => {
+		// Collect all used components
+		const components = block.getUsedComponentNames();
+		for (const componentName of components) {
+			const component = componentStore.getComponent(componentName);
+			if (component) {
+				componentDocuments.push(component);
+			}
+		}
+
+		// Handle component children and create copy
+		let blockCopy = null;
+		if (!Boolean(block.extendedFromComponent) && block.isChildOfComponent) {
+			blockCopy = detachBlockFromComponent(block, null);
+		} else {
+			blockCopy = getCopyWithoutParent(block);
+		}
+
+		return blockCopy;
+	});
+
+	const dataToCopy: BuilderClipboardData = {
+		blocks: blocksToCopy,
+		components: componentDocuments,
+		sourceURL: currentSiteURL,
+	};
+
+	if (copyEntirePage) {
+		const currentPage = pageStore.activePage as BuilderPage;
+		dataToCopy.pageDoc = {
+			page_name: currentPage.page_name,
+			route: currentPage.route,
+			dynamic_route: currentPage.dynamic_route,
+			page_data_script: currentPage.page_data_script,
+			head_html: currentPage.head_html,
+			body_html: currentPage.body_html,
+			page_title: currentPage.page_title,
+			meta_description: currentPage.meta_description,
+			meta_image: currentPage.meta_image,
+			authenticated_access: currentPage.authenticated_access,
+			disable_indexing: currentPage.disable_indexing,
+			favicon: currentPage.favicon,
+			client_scripts:
+				currentPage.client_scripts?.map((script) => {
+					return {
+						builder_script: script.builder_script,
+						idx: script.idx,
+					};
+				}) || [],
+		};
+		dataToCopy.pageScripts = pageStore.activePageScripts;
 	}
-	const hashStr = Math.abs(hash).toString(36);
-	// Pad or trim the hash to match the original componentId length
-	const targetLength = componentId.length;
-	const padded = hashStr.repeat(Math.ceil(targetLength / hashStr.length)).slice(0, targetLength);
-	return padded;
+	copyToClipboard(dataToCopy, e, "builder-copied-blocks");
+	copyEntirePage && toast.success("Page Copied");
+}
+
+export async function pasteBuilderBlocks(e: ClipboardEvent, currentSiteURL: string): Promise<void> {
+	const data = e.clipboardData?.getData("builder-copied-blocks") as string;
+	if (!data || !isJSONString(data)) return;
+
+	const clipboardData = JSON.parse(data) as BuilderClipboardData;
+	const crossSitePaste = Boolean(clipboardData.sourceURL && clipboardData.sourceURL !== currentSiteURL);
+
+	if (clipboardData.pageDoc) {
+		await handlePagePaste(clipboardData, crossSitePaste, currentSiteURL);
+	} else {
+		if (clipboardData.components.length) {
+			toast.loading("Pasting...", {
+				id: "paste-blocks",
+			});
+			await handleComponents(clipboardData, crossSitePaste);
+		}
+		await insertBlocks(clipboardData.blocks);
+		clipboardData.components.length &&
+			toast.success("Done", {
+				id: "paste-blocks",
+			});
+	}
+}
+
+async function handlePagePaste(
+	clipboardData: BuilderClipboardData,
+	crossSitePaste: boolean,
+	currentURL: string | undefined = undefined,
+): Promise<void> {
+	const canvasStore = useCanvasStore();
+	const pageStore = usePageStore();
+
+	await showDialog({
+		title: "Pasting a page!",
+		message:
+			"You are about to paste a page with settings and scripts. Do you want to update the current page or create a new one?",
+		actions: [
+			{
+				label: "Create New Page",
+				variant: "solid",
+				async onClick() {
+					toast.loading("Pasting...", { id: "paste-page" });
+					await handleComponents(clipboardData, crossSitePaste);
+					await handlePageScripts(clipboardData, currentURL || "");
+					if (clipboardData.pageDoc) {
+						clipboardData.pageDoc.blocks = clipboardData.blocks.map((block) => getCopyWithoutParent(block));
+					}
+					const newPage = await webPages.insert.submit(clipboardData.pageDoc);
+					window.location.href = `/builder/page/${encodeURIComponent(newPage.name)}`;
+					await pageStore.setPage(newPage.name);
+					toast.success("Done", { id: "paste-page" });
+				},
+			},
+			{
+				label: "Update Current Page",
+				variant: "subtle",
+				async onClick() {
+					toast.loading("Pasting...", { id: "paste-page" });
+					await handleComponents(clipboardData, crossSitePaste);
+					await handlePageScripts(clipboardData, currentURL || "");
+					const currentPage = pageStore.activePage as BuilderPage;
+					await webPages.setValue.submit({
+						...clipboardData.pageDoc,
+						name: currentPage.name,
+					});
+					await pageStore.setPage(currentPage.name);
+					nextTick(() => {
+						canvasStore.pushBlocks(clipboardData.blocks);
+						pageStore.savePage();
+					});
+					toast.success("Done", { id: "paste-page" });
+				},
+			},
+		],
+		size: "md",
+	});
+}
+
+async function handleComponents(clipboardData: BuilderClipboardData, crossSitePaste: boolean) {
+	const componentStore = useComponentStore();
+	const componentIdMap = new Map<string, string>();
+	let { blocks } = clipboardData;
+
+	for (const component of clipboardData.components) {
+		delete component.for_web_page;
+
+		if (crossSitePaste) {
+			const originalId = component.name;
+			const newId = generateHash(originalId, clipboardData.sourceURL || "");
+			componentIdMap.set(originalId, newId);
+			component.name = newId;
+			component.component_id = newId;
+			await componentStore.createComponent(component, true);
+		} else {
+			await componentStore.createComponent(component, false);
+		}
+	}
+
+	if (crossSitePaste) {
+		blocks.map((block) => {
+			updateBlockComponentReferences(block, componentIdMap);
+			const blockCopy = getBlockInstance(block);
+			updateURLsInBlock(blockCopy, clipboardData.sourceURL as string);
+			return blockCopy;
+		});
+	}
+}
+
+async function insertBlocks(blocks: (Block | BlockOptions)[]) {
+	const canvasStore = useCanvasStore();
+	if (canvasStore.activeCanvas?.selectedBlocks.length && blocks[0].blockId !== "root") {
+		let parentBlock = canvasStore.activeCanvas.selectedBlocks[0];
+		while (parentBlock && !parentBlock.canHaveChildren()) {
+			parentBlock = parentBlock.getParentBlock() as Block;
+		}
+		blocks.forEach((block) => parentBlock.addChild(getBlockCopy(block), null, true));
+	} else {
+		canvasStore.pushBlocks(blocks);
+	}
+}
+
+async function handlePageScripts(clipboardData: BuilderClipboardData, currentSiteURL: string): Promise<void> {
+	console.log(
+		"Handling page scripts",
+		clipboardData.pageScripts,
+		clipboardData.sourceURL,
+		currentSiteURL,
+		clipboardData.pageDoc,
+	);
+	if (!clipboardData.pageDoc || !clipboardData.sourceURL || clipboardData.sourceURL === currentSiteURL) {
+		return;
+	}
+
+	const pageScriptIdMap = new Map<string, string>();
+	for (const script of clipboardData.pageScripts || []) {
+		const newScriptId = generateHash(script.name, clipboardData.sourceURL);
+		pageScriptIdMap.set(script.name, newScriptId);
+
+		const scriptDoc: BuilderClientScriptDocument = {
+			...script,
+			name: newScriptId,
+		};
+
+		const clientScriptResource = createListResource({
+			doctype: "Builder Client Script",
+		});
+		try {
+			console.log("Inserting script", scriptDoc);
+			await clientScriptResource.insert.submit(scriptDoc);
+		} catch (error) {
+			// pass
+		}
+
+		const clientScript = clipboardData.pageDoc.client_scripts?.find((s) => s.builder_script === script.name);
+		if (clientScript) {
+			clientScript.builder_script = newScriptId;
+		}
+	}
+}
+
+function updateBlockComponentReferences(block: BlockOptions, componentIdMap: Map<string, string>): void {
+	if (block.extendedFromComponent && componentIdMap.has(block.extendedFromComponent)) {
+		block.extendedFromComponent = componentIdMap.get(block.extendedFromComponent);
+	}
+	if (block.isChildOfComponent && componentIdMap.has(block.isChildOfComponent)) {
+		block.isChildOfComponent = componentIdMap.get(block.isChildOfComponent);
+	}
+
+	block.children?.forEach((child) => updateBlockComponentReferences(child, componentIdMap));
 }
 
 function updateURLsInBlock(block: Block, currentSiteURL: string): void {
@@ -99,231 +331,16 @@ function updateURLsInBlock(block: Block, currentSiteURL: string): void {
 	block.children.forEach((child) => updateURLsInBlock(child, currentSiteURL));
 }
 
-export function copyBuilderBlocks(
-	e: ClipboardEvent,
-	currentSiteURL: string,
-	copyEntirePage: boolean = false,
-) {
-	const canvasStore = useCanvasStore();
-	const componentStore = useComponentStore();
-	const pageStore = usePageStore();
-	if (!canvasStore.activeCanvas?.selectedBlocks.length && !copyEntirePage) return;
-	e.preventDefault();
-
-	const componentDocuments: BuilderComponent[] = [];
-	const blocksToCopy =
-		canvasStore.activeCanvas?.selectedBlocks.map((block) => {
-			// Collect all used components
-			const components = block.getUsedComponentNames();
-			for (const componentName of components) {
-				const component = componentStore.getComponent(componentName);
-				if (component) {
-					componentDocuments.push(component);
-				}
-			}
-
-			// Handle component children and create copy
-			let blockCopy = null;
-			if (!Boolean(block.extendedFromComponent) && block.isChildOfComponent) {
-				blockCopy = detachBlockFromComponent(block, null);
-			} else {
-				blockCopy = getCopyWithoutParent(block);
-			}
-
-			return blockCopy;
-		}) || [];
-
-	const dataToCopy: BuilderClipboardData = {
-		blocks: blocksToCopy,
-		components: componentDocuments,
-		sourceURL: currentSiteURL,
-	};
-
-	if (copyEntirePage) {
-		const currentPage = pageStore.activePage as BuilderPage;
-		dataToCopy.pageDoc = {
-			page_name: currentPage.page_name,
-			route: currentPage.route,
-			dynamic_route: currentPage.dynamic_route,
-			page_data_script: currentPage.page_data_script,
-			head_html: currentPage.head_html,
-			body_html: currentPage.body_html,
-			page_title: currentPage.page_title,
-			meta_description: currentPage.meta_description,
-			meta_image: currentPage.meta_image,
-			authenticated_access: currentPage.authenticated_access,
-			disable_indexing: currentPage.disable_indexing,
-			favicon: currentPage.favicon,
-			client_scripts:
-				currentPage.client_scripts?.map((script) => {
-					return {
-						builder_script: script.builder_script,
-						idx: script.idx,
-					};
-				}) || [],
-		};
-		dataToCopy.pageScripts = pageStore.activePageScripts;
+function generateHash(componentId: string, siteURL: string): string {
+	// Generate a deterministic hash with the same length as componentId, using siteURL for uniqueness
+	const str = `${componentId}_${siteURL}`;
+	let hash = 5381;
+	for (let i = 0; i < str.length; i++) {
+		hash = (hash << 5) + hash + str.charCodeAt(i); // djb2 hash
 	}
-	copyToClipboard(dataToCopy, e, "builder-copied-blocks");
-}
-
-export async function pasteBuilderBlocks(e: ClipboardEvent, currentSiteURL: string): Promise<void> {
-	const componentStore = useComponentStore();
-	const canvasStore = useCanvasStore();
-	const pageStore = usePageStore();
-
-	const data = e.clipboardData?.getData("builder-copied-blocks") as string;
-	if (!data || !isJSONString(data)) return;
-
-	const clipboardData = JSON.parse(data) as BuilderClipboardData;
-	const componentIdMap = new Map<string, string>();
-	const isPagePaste = Boolean(clipboardData.pageDoc);
-	let blocks = clipboardData.blocks;
-	const crossSitePaste = clipboardData.sourceURL && clipboardData.sourceURL !== currentSiteURL;
-	const isCanvasEmpty = !canvasStore.activeCanvas?.getRootBlock().children.length;
-
-	if (isPagePaste && crossSitePaste) {
-		// update pageScript name
-		const pageScriptIdMap = new Map<string, string>();
-		for (const script of clipboardData.pageScripts || []) {
-			const newScriptId = generateHash(script.name, clipboardData.sourceURL || "");
-			// maintain map
-			pageScriptIdMap.set(script.name, newScriptId);
-			const scriptDoc: BuilderClientScriptDocument = {
-				...script,
-				name: newScriptId,
-			};
-
-			const clientScript =
-				clipboardData.pageDoc && clipboardData.pageDoc.client_scripts
-					? clipboardData.pageDoc.client_scripts.find((s) => s.builder_script === script.name)
-					: undefined;
-			if (clientScript) {
-				console.log("Updating client script reference:", clientScript.builder_script, "to", newScriptId);
-				clientScript.builder_script = newScriptId;
-			}
-		}
-	}
-
-	if (crossSitePaste) {
-		// Update component IDs and references (to avoid conflicts & overwrites in the current site)
-		for (const component of clipboardData.components) {
-			const originalId = component.name;
-			const newId = generateHash(originalId, clipboardData.sourceURL || "");
-			componentIdMap.set(originalId, newId);
-
-			component.name = newId;
-			component.component_id = newId;
-			delete component.for_web_page;
-
-			// Create new component with updated ID
-			await componentStore.createComponent(component, true);
-		}
-
-		// Update block references to components
-		for (const block of blocks) {
-			if (block.extendedFromComponent && componentIdMap.has(block.extendedFromComponent)) {
-				block.extendedFromComponent = componentIdMap.get(block.extendedFromComponent);
-			}
-			if (block.isChildOfComponent && componentIdMap.has(block.isChildOfComponent)) {
-				block.isChildOfComponent = componentIdMap.get(block.isChildOfComponent);
-			}
-			// Handle nested blocks recursively
-			updateBlockComponentReferences(block, componentIdMap);
-		}
-
-		blocks = blocks.map((block) => {
-			const blockCopy = getBlockInstance(block);
-			updateURLsInBlock(blockCopy, clipboardData.sourceURL as string);
-			return blockCopy;
-		});
-	} else if (!clipboardData.sourceURL) {
-		// Same site paste - just create components
-		for (const component of clipboardData.components) {
-			delete component.for_web_page;
-			await componentStore.createComponent(component, false);
-		}
-	}
-
-	if (blockController.isBlockSelected() && !blockController.multipleBlocksSelected() && blocks.length === 1) {
-		// handle SVG paste case
-		const selectedBlock = blockController.getSelectedBlocks()[0];
-		const copiedBlock = getBlockCopy(blocks[0]);
-		if (selectedBlock.isSVG() && copiedBlock.isSVG()) {
-			const svgBlock = copiedBlock;
-			if (!svgBlock.innerHTML) return;
-			const svgContent = new DOMParser()
-				.parseFromString(svgBlock.innerHTML, "text/html")
-				.body.querySelector("svg");
-			if (svgContent) {
-				svgContent.removeAttribute("width");
-				svgContent.removeAttribute("height");
-				selectedBlock.setInnerHTML(svgContent.outerHTML);
-				return;
-			}
-		}
-	}
-
-	if (isPagePaste) {
-		await showDialog({
-			title: "Pasting a page!",
-			message:
-				"You are about to paste a page with settings and scripts. Do you want to update the current page or create a new one?",
-			actions: [
-				{
-					label: "Create New Page",
-					variant: "solid",
-					async onClick() {
-						if (clipboardData.pageDoc) {
-							clipboardData.pageDoc.blocks = clipboardData.blocks.map((block) => {
-								return getCopyWithoutParent(block);
-							});
-						}
-						const newPage = await webPages.insert.submit(clipboardData.pageDoc);
-						window.location.href = `/builder/page/${encodeURIComponent(newPage.name)}`;
-					},
-				},
-				{
-					label: "Update Current Page",
-					variant: "subtle",
-					async onClick() {
-						const currentPage = pageStore.activePage as BuilderPage;
-						await webPages.setValue.submit({
-							...clipboardData.pageDoc,
-							name: currentPage.name,
-						});
-						await pageStore.setPage(currentPage.name);
-						nextTick(() => {
-							canvasStore.pushBlocks(blocks);
-							pageStore.savePage();
-						});
-					},
-				},
-			],
-			size: "md",
-		});
-	} else {
-		if (canvasStore.activeCanvas?.selectedBlocks.length && blocks[0].blockId !== "root") {
-			let parentBlock = canvasStore.activeCanvas.selectedBlocks[0];
-			while (parentBlock && !parentBlock.canHaveChildren()) {
-				parentBlock = parentBlock.getParentBlock() as Block;
-			}
-			blocks.forEach((block: BlockOptions) => {
-				parentBlock.addChild(getBlockCopy(block), null, true);
-			});
-		} else {
-			canvasStore.pushBlocks(blocks);
-		}
-	}
-}
-
-function updateBlockComponentReferences(block: BlockOptions, componentIdMap: Map<string, string>): void {
-	if (block.extendedFromComponent && componentIdMap.has(block.extendedFromComponent)) {
-		block.extendedFromComponent = componentIdMap.get(block.extendedFromComponent);
-	}
-	if (block.isChildOfComponent && componentIdMap.has(block.isChildOfComponent)) {
-		block.isChildOfComponent = componentIdMap.get(block.isChildOfComponent);
-	}
-
-	block.children?.forEach((child) => updateBlockComponentReferences(child, componentIdMap));
+	const hashStr = Math.abs(hash).toString(36);
+	// Pad or trim the hash to match the original componentId length
+	const targetLength = componentId.length;
+	const padded = hashStr.repeat(Math.ceil(targetLength / hashStr.length)).slice(0, targetLength);
+	return padded;
 }

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -309,7 +309,7 @@ function updateURLsInBlock(block: Block, currentSiteURL: string): void {
 	// Update image and video sources to absolute URLs
 	if (block.isImage() || block.isVideo()) {
 		const src = block.getAttribute("src");
-		if (src && typeof src === "string" && !src.startsWith("http")) {
+		if (src && typeof src === "string" && src.startsWith("/")) {
 			block.setAttribute("src", `${currentSiteURL}${src}`);
 		}
 	}
@@ -319,7 +319,7 @@ function updateURLsInBlock(block: Block, currentSiteURL: string): void {
 		const bgSrc = block.getStyle("backgroundImage");
 		if (bgSrc && typeof bgSrc === "string" && bgSrc.startsWith("url(")) {
 			const urlMatch = bgSrc.match(/url\(["']?([^"']+)["']?\)/);
-			if (urlMatch && urlMatch[1] && !urlMatch[1].startsWith("http")) {
+			if (urlMatch && urlMatch[1] && urlMatch[1].startsWith("/")) {
 				block.setStyle("backgroundImage", `url(${currentSiteURL}${urlMatch[1]})`);
 			}
 		}

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -250,13 +250,6 @@ async function insertBlocks(blocks: (Block | BlockOptions)[]) {
 }
 
 async function handlePageScripts(clipboardData: BuilderClipboardData, currentSiteURL: string): Promise<void> {
-	console.log(
-		"Handling page scripts",
-		clipboardData.pageScripts,
-		clipboardData.sourceURL,
-		currentSiteURL,
-		clipboardData.pageDoc,
-	);
 	if (!clipboardData.pageDoc || !clipboardData.sourceURL || clipboardData.sourceURL === currentSiteURL) {
 		return;
 	}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,11 +1,13 @@
 import Block from "@/block";
 import AlertDialog from "@/components/AlertDialog.vue";
+import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { confirmDialog, FileUploadHandler } from "frappe-ui";
-import { h, reactive, toRaw } from "vue";
+import { defineComponent, h, markRaw, reactive, ref, toRaw } from "vue";
 import { toast } from "vue-sonner";
+import Dialog from "../components/Controls/Dialog.vue";
 
 function getNumberFromPx(px: string | number | null | undefined): number {
 	if (!px) {
@@ -716,6 +718,84 @@ function shortenNumber(num: number): string {
 	return shortNum % 1 === 0 ? shortNum.toFixed(0) + unitname : shortNum.toFixed(1) + unitname;
 }
 
+interface DialogAction {
+	label: string;
+	variant?: "solid" | "subtle" | "outline" | "ghost";
+	theme?: "gray" | "blue" | "green" | "red";
+	onClick?: () => void | Promise<void>;
+}
+
+interface DialogOptions {
+	title?: string;
+	message: string;
+	icon?: {
+		name: string;
+		appearance?: "warning" | "info" | "danger" | "success";
+	};
+	actions?: DialogAction[];
+	size?: "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl" | "6xl" | "7xl";
+}
+
+function showDialog(options: DialogOptions): Promise<void> {
+	return new Promise((resolve) => {
+		const isOpen = ref(true);
+		const dialogOptions = {
+			title: options.title || "",
+			message: options.message,
+			icon: options.icon,
+			size: options.size || "md",
+			actions: (options.actions || []).map((action) => ({
+				label: action.label,
+				variant: action.variant || "subtle",
+				theme: action.theme || "gray",
+				onClick: async ({ close }: { close: () => void }) => {
+					if (action.onClick) {
+						await action.onClick();
+					}
+					close();
+				},
+			})),
+		};
+
+		const DialogComponent = markRaw(
+			defineComponent({
+				name: "DynamicDialog",
+				setup() {
+					const handleClose = () => {
+						isOpen.value = false;
+						// Remove dialog from appDialogs after animation
+						setTimeout(() => {
+							const builderStore = useBuilderStore();
+							const index = builderStore.appDialogs.indexOf(DialogComponent);
+							if (index > -1) {
+								builderStore.appDialogs.splice(index, 1);
+							}
+							resolve();
+						}, 200);
+					};
+
+					return () =>
+						h(Dialog, {
+							modelValue: isOpen.value,
+							"onUpdate:modelValue": (val: boolean) => {
+								isOpen.value = val;
+								if (!val) handleClose();
+							},
+							options: dialogOptions,
+						});
+				},
+			}),
+		) as typeof Dialog;
+
+		const builderStore = useBuilderStore();
+		builderStore.appDialogs.push(DialogComponent);
+	});
+}
+
+function triggerCopyEvent() {
+	document.execCommand("copy");
+}
+
 export {
 	addPxToNumber,
 	alert,
@@ -758,7 +838,9 @@ export {
 	replaceMapKey,
 	RGBToHex,
 	shortenNumber,
+	showDialog,
 	stripExtension,
 	throttle,
+	triggerCopyEvent,
 	uploadImage,
 };


### PR DESCRIPTION
https://github.com/user-attachments/assets/3faded42-fe5b-4a5e-8903-89b68d13aacd

### Option to copy entire page with configuration and scripts

#### Other:
- Handled cases where copying back-n-forth between sites used to override components
- While copying blocks cross-site, all image or video sources will be updated to absolute URL to avoid broken image or video
- Introduced `showDialog` function to conveniently trigger custom dialogs via script

#### Cases tested:

Copy from site to site
- normal w/o component ✅
- with component ✅
	- no need to update or create ✅
- body copy
	- page copy ✅
		- with scripts ✅
	- just block ✅

Copy from site to other site
- normal w/o component ✅
- normal with images (update URL) ✅
- with component (with deterministic new IDs) ✅
	- update if exists ✅
- with nested components ⚠️ [not implemented]
- body copy
	- page copy 
		- with existing scripts (update existing) ✅
		- with new scripts ✅
	- just block ✅

Copy plugin to site ✅