### PR TITLE
perf: Use duckdb for faster analytics

### DIFF
--- a/builder/api.py
+++ b/builder/api.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import os
 from io import BytesIO
@@ -15,6 +14,7 @@ from frappe.utils.caching import redis_cache
 from frappe.utils.telemetry import POSTHOG_HOST_FIELD, POSTHOG_PROJECT_FIELD
 from PIL import Image
 
+from builder import builder_analytics
 from builder.builder.doctype.builder_page.builder_page import BuilderPageRenderer
 
 
@@ -272,170 +272,11 @@ def sync_component(component_id: str):
 
 @frappe.whitelist()
 def get_page_analytics(route=None, date_range: str = "last_30_days", interval=None):
-	"""Get analytics data for a specific page route or all pages."""
-	try:
-		if not route and not frappe.has_permission("Web Page View", "read"):
-			return _get_empty_analytics()
-
-		date_config = _get_date_config(date_range)
-		if not date_config:
-			return _get_empty_analytics()
-
-		to_date = frappe.utils.now_datetime()
-		from_date = _calculate_from_date(to_date, date_config)
-		interval = interval or date_config["default_interval"]
-
-		views_data = _get_page_views(route, from_date)
-		grouped_data = _group_analytics_data(views_data, from_date, to_date, interval)
-
-		return {
-			"total_unique_views": sum(frappe.utils.cint(d.get("is_unique", 0)) for d in views_data),
-			"total_views": len(views_data),
-			"data": grouped_data,
-		}
-	except Exception as e:
-		frappe.log_error("Analytics Error", str(e))
-		return _get_empty_analytics()
-
-
-def _get_empty_analytics():
-	return {"total_unique_views": 0, "total_views": 0, "data": []}
-
-
-def _get_date_config(date_range):
-	return {
-		"today": {"delta": -24, "unit": "hours", "default_interval": "hourly"},
-		"this_week": {"delta": -7, "unit": "days", "default_interval": "daily"},
-		"last_7_days": {"delta": -7, "unit": "days", "default_interval": "daily"},
-		"last_30_days": {"delta": -30, "unit": "days", "default_interval": "daily"},
-		"last_90_days": {"delta": -90, "unit": "days", "default_interval": "weekly"},
-		"last_180_days": {"delta": -180, "unit": "days", "default_interval": "weekly"},
-		"this_year": {"delta": None, "unit": None, "default_interval": "monthly"},
-	}.get(date_range)
-
-
-def _calculate_from_date(to_date, config):
-	if config["delta"] is None:  # Handle "this_year" case
-		return frappe.utils.get_datetime(f"{to_date.year}-01-01")
-	return frappe.utils.add_to_date(to_date, **{config["unit"]: config["delta"]})
-
-
-def _get_page_views(route, from_date):
-	filters = {
-		"creation": [">=", from_date],
-	}
-	if route:
-		filters["path"] = route
-
-	return frappe.get_all(
-		"Web Page View",
-		filters=filters,
-		fields=["creation", "is_unique", "path"],
-	)
-
-
-def _group_analytics_data(views_data, from_date, to_date, interval):
-	formats = {
-		"hourly": "%I %p",  # 01 PM
-		"daily": "%d %b",  # 25 Jan
-		"weekly": "%d %b, Week %W",  # Week of Jan
-		"monthly": "%b %Y",  # Jan 2024
-	}
-
-	interval_deltas = {
-		"hourly": {"hours": 1},
-		"daily": {"days": 1},
-		"weekly": {"days": 7},
-		"monthly": {"months": 1},
-	}
-
-	fmt = formats[interval]
-	delta = interval_deltas[interval]
-
-	# Initialize all dates in range with zero counts
-	grouped_data = {}
-	current_date = from_date
-	while current_date <= to_date:
-		key = current_date.strftime(fmt)
-		grouped_data[key] = {"total_page_views": 0, "unique_page_views": 0, "timestamp": current_date}
-		current_date = frappe.utils.add_to_date(current_date, **delta)
-
-	# Fill in actual data where it exists
-	for view in views_data:
-		key = view.creation.strftime(fmt)
-		if key in grouped_data:
-			grouped_data[key]["total_page_views"] += 1
-			grouped_data[key]["unique_page_views"] += frappe.utils.cint(view.is_unique)
-
-	sorted_data = sorted(grouped_data.items(), key=lambda x: x[1]["timestamp"])
-	return [
-		{
-			"interval": k,
-			"total_page_views": v["total_page_views"],
-			"unique_page_views": v["unique_page_views"],
-		}
-		for k, v in sorted_data
-	]
-
-
-def _get_top_referrers(date_range: str = "last_30_days"):
-	from urllib.parse import urlparse
-
-	date_config = _get_date_config(date_range)
-	from_date = _calculate_from_date(frappe.utils.now_datetime(), date_config)
-	WebPageView = frappe.qb.DocType("Web Page View")
-	# Get all referrers in the date range
-	referrers = (
-		frappe.qb.from_(WebPageView)
-		.select(WebPageView.referrer)
-		.where(WebPageView.creation >= from_date)
-		.run(as_dict=True)
-	)
-	# Count by domain
-	domain_counts = {}
-	for row in referrers:
-		ref = row.get("referrer")
-		if not ref:
-			continue
-		try:
-			domain = urlparse(ref).netloc.lower()
-			if domain:
-				domain_counts[domain] = domain_counts.get(domain, 0) + 1
-		except Exception:
-			continue
-	# Sort and return top 20
-	top_domains = sorted(domain_counts.items(), key=lambda x: x[1], reverse=True)[:20]
-	return [{"domain": d, "count": c} for d, c in top_domains]
+	"""Get analytics data for a specific page route or all pages using DuckDB."""
+	return builder_analytics.get_page_analytics(route, date_range, interval)
 
 
 @frappe.whitelist()
 def get_overall_analytics(date_range: str = "last_30_days", interval=None):
-	"""Get overall site analytics with top pages and top referrers."""
-	analytics = get_page_analytics(None, date_range, interval)
-	analytics["top_pages"] = _get_top_pages(date_range=date_range)
-	analytics["top_referrers"] = _get_top_referrers(date_range=date_range)
-	return analytics
-
-
-def _get_top_pages(date_range: str = "last_30_days"):
-	from frappe.query_builder.functions import Count, Sum
-
-	date_config = _get_date_config(date_range)
-	from_date = _calculate_from_date(frappe.utils.now_datetime(), date_config)
-	WebPageView = frappe.qb.DocType("Web Page View")
-	pages = (
-		frappe.qb.from_(WebPageView)
-		.select(
-			WebPageView.path.as_("route"),
-			Count(WebPageView.path).as_("view_count"),
-			Sum(frappe.qb.terms.Case().when(WebPageView.is_unique == "1", 1).else_(0)).as_(
-				"unique_view_count"
-			),
-		)
-		.where(WebPageView.creation >= from_date)
-		.groupby(WebPageView.path)
-		.orderby("view_count", order=frappe.qb.desc)
-		.limit(20)
-		.run(as_dict=True)
-	)
-	return pages
+	"""Get overall site analytics with top pages"""
+	return builder_analytics.get_overall_analytics(date_range, interval)

--- a/builder/api.py
+++ b/builder/api.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from urllib.parse import unquote
 
 import frappe
+import frappe.utils
 import requests
 from frappe.apps import get_apps as get_permitted_apps
 from frappe.core.doctype.file.file import get_local_image
@@ -258,7 +259,7 @@ def delete_folder(folder_name: str) -> None:
 	for page in pages:
 		frappe.db.set_value("Builder Page", page.name, "project_folder", "", update_modified=False)
 
-	frappe.db.delete("Builder Project Folder", folder_name)
+	frappe.db.delete("Builder Project Folder", {"folder_name": folder_name})
 
 
 @frappe.whitelist()
@@ -272,11 +273,9 @@ def sync_component(component_id: str):
 
 @frappe.whitelist()
 def get_page_analytics(route=None, date_range: str = "last_30_days", interval=None):
-	"""Get analytics data for a specific page route or all pages using DuckDB."""
 	return builder_analytics.get_page_analytics(route, date_range, interval)
 
 
 @frappe.whitelist()
 def get_overall_analytics(date_range: str = "last_30_days", interval=None):
-	"""Get overall site analytics with top pages"""
 	return builder_analytics.get_overall_analytics(date_range, interval)

--- a/builder/builder_analytics.py
+++ b/builder/builder_analytics.py
@@ -202,3 +202,10 @@ def get_overall_analytics(date_range: str = "last_30_days", interval=None, table
 	analytics["top_pages"] = get_top_pages(date_range=date_range, table_name=table_name)
 	analytics["top_referrers"] = get_top_referrers(date_range=date_range, table_name=table_name)
 	return analytics
+
+
+def enqueue_web_page_view_ingesion():
+	frappe.enqueue(
+		"builder.builder_analytics.ingest_web_page_views_to_duckdb",
+		queue="long",
+	)

--- a/builder/builder_analytics.py
+++ b/builder/builder_analytics.py
@@ -1,0 +1,204 @@
+import os
+
+import duckdb
+import frappe
+
+DUCKDB_PATH = os.path.join(frappe.get_site_path(), "builder_analytics.duckdb")
+DUCKDB_TABLE = "web_page_views"
+
+
+class DuckDBConnection:
+	"""Context manager for DuckDB connections"""
+
+	def __init__(self):
+		self.db = None
+
+	def __enter__(self):
+		self.db = duckdb.connect(DUCKDB_PATH)
+		return self.db
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		if self.db:
+			self.db.close()
+
+
+def _create_duckdb_table(db):
+	"""Create DuckDB table with the standard schema"""
+	db.execute(f"""
+		CREATE TABLE IF NOT EXISTS {DUCKDB_TABLE} (
+			creation TIMESTAMP,
+			is_unique INTEGER,
+			path TEXT,
+			referrer TEXT
+		)
+	""")
+
+
+def _get_date_range_filter(date_range: str = "last_30_days"):
+	"""Get date range filter for queries"""
+	date_config = _get_date_config(date_range)
+	if not date_config:
+		return "", None, None
+	to_date = frappe.utils.now_datetime()
+	from_date = _calculate_from_date(to_date, date_config)
+	where = f"creation >= '{from_date}' AND creation <= '{to_date}'"
+	return where, from_date, to_date
+
+
+def _get_empty_analytics():
+	return {"total_unique_views": 0, "total_views": 0, "data": []}
+
+
+def _get_date_config(date_range):
+	return {
+		"today": {"delta": -24, "unit": "hours", "default_interval": "hourly"},
+		"this_week": {"delta": -7, "unit": "days", "default_interval": "daily"},
+		"last_7_days": {"delta": -7, "unit": "days", "default_interval": "daily"},
+		"last_30_days": {"delta": -30, "unit": "days", "default_interval": "daily"},
+		"last_90_days": {"delta": -90, "unit": "days", "default_interval": "weekly"},
+		"last_180_days": {"delta": -180, "unit": "days", "default_interval": "weekly"},
+		"this_year": {"delta": None, "unit": None, "default_interval": "monthly"},
+	}.get(date_range)
+
+
+def _calculate_from_date(to_date, config):
+	if config["delta"] is None:  # Handle "this_year" case
+		return frappe.utils.get_datetime(f"{to_date.year}-01-01")
+	return frappe.utils.add_to_date(to_date, **{config["unit"]: config["delta"]})
+
+
+def reset_duckdb_table():
+	"""Reset DuckDB table by dropping and recreating it"""
+	if not frappe.has_permission("Builder Page", ptype="write"):
+		frappe.throw("You do not have permission to reset analytics data.")
+
+	with DuckDBConnection() as db:
+		db.execute(f"DROP TABLE IF EXISTS {DUCKDB_TABLE}")
+		_create_duckdb_table(db)
+
+	# Re-ingest all data
+	ingest_web_page_views_to_duckdb()
+
+
+def ingest_web_page_views_to_duckdb():
+	with DuckDBConnection() as db:
+		_create_duckdb_table(db)
+		last_record = db.execute(f"SELECT MAX(creation) FROM {DUCKDB_TABLE}").fetchone()[0]
+
+		filters = {"creation": [">", last_record]} if last_record else {}
+		records = frappe.get_all(
+			"Web Page View",
+			filters=filters,
+			fields=["creation", "is_unique", "path", "referrer"],
+			as_list=True,
+		)
+
+		if records:
+			db.executemany(
+				f"INSERT INTO {DUCKDB_TABLE} (creation, is_unique, path, referrer) VALUES (?, ?, ?, ?)",
+				records,
+			)
+
+
+def get_page_analytics(route=None, date_range: str = "last_30_days", interval=None):
+	"""Get analytics data for a specific page route or all pages"""
+	try:
+		date_config = _get_date_config(date_range)
+		if not date_config:
+			return _get_empty_analytics()
+
+		where, from_date, to_date = _get_date_range_filter(date_range)
+		if route:
+			where += f" AND path = '{route}'"
+
+		interval = interval or date_config["default_interval"]
+		fmt = {
+			"hourly": "%Y-%m-%d %H:00:00",
+			"daily": "%Y-%m-%d",
+			"weekly": "%Y-%W",
+			"monthly": "%Y-%m",
+		}[interval]
+
+		with DuckDBConnection() as db:
+			# Group by interval
+			q = f"""
+			SELECT
+				strftime('{fmt}', creation) as interval,
+				COUNT(*) as total_page_views,
+				SUM(is_unique) as unique_page_views
+			FROM {DUCKDB_TABLE}
+			WHERE {where}
+			GROUP BY interval
+			ORDER BY interval
+			"""
+			rows = db.execute(q).fetchall()
+
+			# Total views
+			q2 = f"SELECT COUNT(*), SUM(is_unique) FROM {DUCKDB_TABLE} WHERE {where}"
+			total_views, total_unique_views = db.execute(q2).fetchone()
+
+		return {
+			"total_unique_views": total_unique_views or 0,
+			"total_views": total_views or 0,
+			"data": [{"interval": r[0], "total_page_views": r[1], "unique_page_views": r[2]} for r in rows],
+		}
+	except Exception as e:
+		frappe.log_error("DuckDB Analytics Error", str(e))
+		return _get_empty_analytics()
+
+
+def get_top_pages(date_range: str = "last_30_days"):
+	where, _, _ = _get_date_range_filter(date_range)
+	with DuckDBConnection() as db:
+		q = f"""
+			SELECT path as route, COUNT(*) as view_count, SUM(is_unique) as unique_view_count
+			FROM {DUCKDB_TABLE}
+			WHERE {where}
+			GROUP BY path
+			ORDER BY view_count DESC
+			LIMIT 20
+		"""
+		rows = db.execute(q).fetchall()
+		return [{"route": r[0], "view_count": r[1], "unique_view_count": r[2]} for r in rows]
+
+
+def get_top_referrers(date_range: str = "last_30_days"):
+	"""Get top referrers from analytics data using SQL for domain extraction"""
+	try:
+		where, _, _ = _get_date_range_filter(date_range)
+		with DuckDBConnection() as db:
+			q = f"""
+				WITH parsed_referrers AS (
+					SELECT
+						CASE
+							WHEN referrer IS NULL OR referrer = '' THEN 'direct'
+							WHEN REGEXP_MATCHES(referrer, '^https?://([^/]+)') THEN
+								REGEXP_EXTRACT(referrer, '^https?://([^/]+)', 1)
+							ELSE 'direct'
+						END as domain,
+						is_unique
+					FROM {DUCKDB_TABLE}
+					WHERE {where}
+				)
+				SELECT
+					domain,
+					COUNT(*) as total_count,
+					SUM(is_unique) as unique_count
+				FROM parsed_referrers
+				GROUP BY domain
+				ORDER BY total_count DESC
+				LIMIT 20
+			"""
+			rows = db.execute(q).fetchall()
+			return [{"domain": r[0], "count": r[1], "unique_count": r[2]} for r in rows]
+	except Exception as e:
+		frappe.log_error("DuckDB Analytics Error in top referrers", str(e))
+		return []
+
+
+def get_overall_analytics(date_range: str = "last_30_days", interval=None):
+	"""Get overall site analytics with top pages and referrers"""
+	analytics = get_page_analytics(None, date_range, interval)
+	analytics["top_pages"] = get_top_pages(date_range=date_range)
+	analytics["top_referrers"] = get_top_referrers(date_range=date_range)
+	return analytics

--- a/builder/hooks.py
+++ b/builder/hooks.py
@@ -113,9 +113,11 @@ after_migrate = "builder.install.after_migrate"
 # ---------------
 
 scheduler_events = {
-	"hourly": [
-		"builder.builder_analytics.ingest_web_page_views_to_duckdb",
-	],
+	"cron": {
+		"*/10 * * * *": [
+			"builder.builder_analytics.ingest_web_page_views_to_duckdb",
+		],
+	}
 }
 
 # Testing

--- a/builder/hooks.py
+++ b/builder/hooks.py
@@ -112,23 +112,11 @@ after_migrate = "builder.install.after_migrate"
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
-# "all": [
-# "builder.tasks.all"
-# ],
-# "daily": [
-# "builder.tasks.daily"
-# ],
-# "hourly": [
-# "builder.tasks.hourly"
-# ],
-# "weekly": [
-# "builder.tasks.weekly"
-# ],
-# "monthly": [
-# "builder.tasks.monthly"
-# ],
-# }
+scheduler_events = {
+	"hourly": [
+		"builder.builder_analytics.ingest_web_page_views_to_duckdb",
+	],
+}
 
 # Testing
 # -------

--- a/builder/patches.txt
+++ b/builder/patches.txt
@@ -10,3 +10,4 @@ builder.builder.doctype.builder_page.patches.attach_client_script_to_builder_pag
 builder.builder.doctype.builder_page.patches.enable_auto_convert_to_webp_by_default
 builder.builder.doctype.builder_client_script.patches.trigger_asset_compression
 builder.builder.patches.add_composite_index_to_web_page_view
+execute:frappe.call("builder.builder_analytics.enqueue_web_page_view_ingesion")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dynamic = ["version"]
 dependencies = [
     "jsmin>=3.0.1",
     "csscompressor>=0.9.5",
+    "duckdb>=0.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
**Process:**
- All the records gets ingested to duckDB on migration and every 10 mins new records gets ingested
- Query directly on duckDB to get that performance: https://duckdb.org/why_duckdb#fast