### PR TITLE
fix(dashboard): save filter in local storage

### DIFF
--- a/frontend/src/pages/PageBuilderDashboard.vue
+++ b/frontend/src/pages/PageBuilderDashboard.vue
@@ -180,7 +180,7 @@ const displayType = useStorage("displayType", "grid") as Ref<"grid" | "list">;
 const showFolderSelectorDialog = ref(false);
 
 const searchFilter = ref("");
-const typeFilter = ref("");
+const typeFilter = useStorage("typeFilter", "") as Ref<"" | "draft" | "published" | "unpublished">;
 const orderBy = useStorage("orderBy", "creation") as Ref<
 	"creation" | "modified" | "alphabetically_a_z" | "alphabetically_z_a"
 >;


### PR DESCRIPTION
Minor fix to save the applied filter. As a user, i happen to edit published pages (if previews are similar) because the filter applied on dashboard does not persist during back and forth navigation.

Note: I've left the search filter as is.