### PR TITLE
perf(analytics): Directly create DuckDB table from pandas DataFrame

### DIFF
--- a/builder/patches.txt
+++ b/builder/patches.txt
@@ -11,3 +11,4 @@ builder.builder.doctype.builder_page.patches.enable_auto_convert_to_webp_by_defa
 builder.builder.doctype.builder_client_script.patches.trigger_asset_compression
 builder.builder.patches.add_composite_index_to_web_page_view
 execute:frappe.call("builder.builder_analytics.enqueue_web_page_view_ingesion")
+execute:frappe.call("builder.builder_analytics.setup_duckdb_table")


### PR DESCRIPTION
This change optimizes data ingestion by replacing row-by-row MySQL inserts (executemany) with a bulk load approach using Pandas → DuckDB.

- Reads data in bulk using pd.read_sql() for efficient retrieval.
- Creates DuckDB table directly from the DataFrame in a single operation.
- Reduces network round-trips, minimizes insert overhead, and leverages DuckDB’s vectorized execution engine for significantly faster ingestion.

With this change, ingestion time of 3.5M records came down **from ~10min to ~19s** 🚀

Reference: https://duckdb.org/2021/05/14/sql-on-pandas.html