### PR TITLE
feat: Option to set lang attribute to the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ python3 ./easy-install.py deploy \
     --version=stable \
     --app=builder \
     --sitename subdomain.domain.tld
-	```
 
 Replace the following parameters with your values:
 - `email@example.com`: Your email address

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ wget https://frappe.io/easy-install.py
 ```bash
 python3 ./easy-install.py deploy \
     --project=builder_prod_setup \
-    --email=email@example.com  \
+    --email=email@example.com \
     --image=ghcr.io/frappe/builder \
     --version=stable \
     --app=builder \

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ python3 ./easy-install.py deploy \
     --version=stable \
     --app=builder \
     --sitename subdomain.domain.tld
-
+```
 Replace the following parameters with your values:
 - `email@example.com`: Your email address
 - `subdomain.domain.tld`: Your domain name where Builder will be hosted

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ wget https://frappe.io/easy-install.py
 ```bash
 python3 ./easy-install.py deploy \
     --project=builder_prod_setup \
-    --email=email@example.com \
+    --email=email@example.com  \
     --image=ghcr.io/frappe/builder \
     --version=stable \
     --app=builder \
     --sitename subdomain.domain.tld
-```
+	```
 
 Replace the following parameters with your values:
 - `email@example.com`: Your email address

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ python3 ./easy-install.py deploy \
     --app=builder \
     --sitename subdomain.domain.tld
 ```
+
 Replace the following parameters with your values:
 - `email@example.com`: Your email address
 - `subdomain.domain.tld`: Your domain name where Builder will be hosted

--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -152,7 +152,7 @@
    "options": "URL"
   },
   {
-   "description": "Language code for HTML lang attribute (e.g., en, es, fr, de). If not set, the default language from Builder Settings will be used.",
+   "description": "Language code for HTML (e.g., en, es, fr, de). Uses default if unset.",
    "fieldname": "language",
    "fieldtype": "Data",
    "label": "Language"

--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -35,6 +35,7 @@
   "meta_description",
   "meta_image",
   "canonical_url",
+  "language",
   "set_meta_tags",
   "options_tab",
   "authenticated_access",
@@ -149,6 +150,12 @@
    "fieldtype": "Data",
    "label": "Canonical URL",
    "options": "URL"
+  },
+  {
+   "description": "Language code for HTML lang attribute (e.g., en, es, fr, de). If not set, the default language from Builder Settings will be used.",
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "label": "Language"
   },
   {
    "fieldname": "client_scripts",

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -282,6 +282,7 @@ class BuilderPage(WebsiteGenerator):
 		self.set_style_and_script(context)
 		self.set_meta_tags(context=context, page_data=page_data)
 		self.set_favicon(context)
+		self.set_language(context)
 		context.page_data = clean_data(context.page_data)
 		try:
 			context["__content"] = render_template(context.__content, context)
@@ -305,6 +306,14 @@ class BuilderPage(WebsiteGenerator):
 			context.favicon = self.favicon
 		if not context.get("favicon"):
 			context.favicon = frappe.get_cached_value("Builder Settings", None, "favicon")
+
+	def set_language(self, context):
+		# Set page-specific language or fall back to default language from Builder Settings
+		context.language = self.language
+		if not context.language:
+			context.default_language = frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
+		else:
+			context.default_language = frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
 
 	def is_component_used(self, component_id):
 		if self.blocks and is_component_used(self.blocks, component_id):

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -312,8 +312,6 @@ class BuilderPage(WebsiteGenerator):
 		context.language = self.language
 		if not context.language:
 			context.default_language = frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
-		else:
-			context.default_language = frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
 
 	def is_component_used(self, component_id):
 		if self.blocks and is_component_used(self.blocks, component_id):

--- a/builder/builder/doctype/builder_settings/builder_settings.json
+++ b/builder/builder/doctype/builder_settings/builder_settings.json
@@ -67,7 +67,7 @@
   },
   {
    "default": "en",
-   "description": "Default language code for HTML lang attribute (e.g., en, es, fr, de)",
+   "description": "Default HTML lang code (e.g., en, es, fr)",
    "fieldname": "default_language",
    "fieldtype": "Data",
    "label": "Default Language"

--- a/builder/builder/doctype/builder_settings/builder_settings.json
+++ b/builder/builder/doctype/builder_settings/builder_settings.json
@@ -13,6 +13,7 @@
   "style_public_url",
   "favicon",
   "auto_convert_images_to_webp",
+  "default_language",
   "landing_page_section",
   "home_page"
  ],
@@ -63,6 +64,13 @@
    "fieldname": "auto_convert_images_to_webp",
    "fieldtype": "Check",
    "label": "Auto convert images to WebP"
+  },
+  {
+   "default": "en",
+   "description": "Default language code for HTML lang attribute (e.g., en, es, fr, de)",
+   "fieldname": "default_language",
+   "fieldtype": "Data",
+   "label": "Default Language"
   },
   {
    "description": "This will be appended at the end of the &lt;head&gt;",

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- Made with Frappe Builder -->
-<html lang="en">
+<html lang="{{ language or default_language or 'en' }}">
 <head>
 	{% if base_url %}
 	<base href="{{ base_url }}">

--- a/frontend/src/components/Settings/GlobalGeneral.vue
+++ b/frontend/src/components/Settings/GlobalGeneral.vue
@@ -12,6 +12,18 @@
 				}
 			"
 			:options="routeOptions"></InlineInput>
+		<InlineInput
+			type="text"
+			label="Default Language"
+			description="Default language code for HTML lang attribute (e.g., en, es, fr, de, zh, ja)"
+			class="w-1/2"
+			placeholder="en"
+			:modelValue="builderSettings.doc?.default_language || 'en'"
+			@update:modelValue="
+				(val) => {
+					builderStore.updateBuilderSettings('default_language', val);
+				}
+			"></InlineInput>
 		<hr class="w-full border-outline-gray-2" />
 		<div class="flex flex-col justify-between gap-5">
 			<span class="text-lg font-semibold text-ink-gray-9">Favicon</span>

--- a/frontend/src/components/Settings/GlobalGeneral.vue
+++ b/frontend/src/components/Settings/GlobalGeneral.vue
@@ -15,7 +15,7 @@
 		<InlineInput
 			type="text"
 			label="Default Language"
-			description="Default language code for HTML lang attribute (e.g., en, es, fr, de, zh, ja)"
+			description="Default HTML lang code (e.g., en, es, fr)"
 			class="w-1/2"
 			placeholder="en"
 			:modelValue="builderSettings.doc?.default_language || 'en'"

--- a/frontend/src/components/Settings/PageMeta.vue
+++ b/frontend/src/components/Settings/PageMeta.vue
@@ -59,6 +59,14 @@
 				:modelValue="pageStore.activePage?.canonical_url"
 				:hideClearButton="true"
 				@update:modelValue="(val: string) => pageStore.updateActivePage('canonical_url', val)" />
+			<BuilderInput
+				type="text"
+				label="Language"
+				description="Language code for HTML lang attribute (e.g., en, es, fr, de, zh, ja). If not set, the default language from Builder Settings will be used."
+				placeholder="en"
+				:modelValue="pageStore.activePage?.language"
+				:hideClearButton="true"
+				@update:modelValue="(val: string) => pageStore.updateActivePage('language', val)" />
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/Settings/PageMeta.vue
+++ b/frontend/src/components/Settings/PageMeta.vue
@@ -62,7 +62,7 @@
 			<BuilderInput
 				type="text"
 				label="Language"
-				description="Language code for HTML lang attribute (e.g., en, es, fr, de, zh, ja). If not set, the default language from Builder Settings will be used."
+				description="Language code for HTML (e.g., en, es, fr, de). Uses default if unset."
 				placeholder="en"
 				:modelValue="pageStore.activePage?.language"
 				:hideClearButton="true"

--- a/frontend/src/types/Builder/BuilderPage.ts
+++ b/frontend/src/types/Builder/BuilderPage.ts
@@ -50,6 +50,8 @@ You can generate using favicon-generator.org	*/
 	meta_image?: string
 	/**	Canonical URL : Data - The preferred URL version of this page for search engines. If not set, the current page URL will be used.	*/
 	canonical_url?: string
+	/**	Language : Data - Language code for HTML lang attribute (e.g., en, es, fr, de). If not set, the default language from Builder Settings will be used.	*/
+	language?: string
 	/**	Authenticated Access : Check - Only allow logged-in users to view this page.	*/
 	authenticated_access?: 0 | 1
 	/**	Disable Indexing : Check - Prevent search engines from indexing this page	*/

--- a/frontend/src/types/Builder/BuilderSettings.ts
+++ b/frontend/src/types/Builder/BuilderSettings.ts
@@ -26,6 +26,8 @@ export interface BuilderSettings{
 	favicon?: string
 	/**	Auto convert images to WebP : Check - All the images uploaded to Canvas will be auto converted to WebP for better page performance.	*/
 	auto_convert_images_to_webp?: 0 | 1
+	/**	Default Language : Data - Default language code for HTML lang attribute (e.g., en, es, fr, de)	*/
+	default_language?: string
 	/**	Home Page : Data	*/
 	home_page?: string
 }


### PR DESCRIPTION
This PR adds the ability to configure the HTML lang attribute both globally and on a per-page basis, addressing the need for better internationalization support in Frappe Builder.