### PR TITLE
perf: Implement CSS variable caching

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -251,10 +251,6 @@ class BuilderPage(WebsiteGenerator):
 		if context.preview and self.draft_blocks:
 			blocks = self.draft_blocks
 
-		css_variables, dark_mode_css_variables = get_css_variables()
-		context.css_variables = css_variables
-		context.dark_mode_css_variables = dark_mode_css_variables
-
 		content, style, fonts = get_block_html(blocks)
 		self.set_custom_font(context, fonts)
 		context.fonts = fonts
@@ -311,7 +307,9 @@ class BuilderPage(WebsiteGenerator):
 		# Set page-specific language or fall back to default language from Builder Settings
 		context.language = self.language
 		if not context.language:
-			context.default_language = frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
+			context.default_language = (
+				frappe.get_cached_value("Builder Settings", None, "default_language") or "en"
+			)
 
 	def is_component_used(self, component_id):
 		if self.blocks and is_component_used(self.blocks, component_id):
@@ -405,23 +403,7 @@ class BuilderPage(WebsiteGenerator):
 
 	def is_home_page(self):
 		"""Check if this page is set as the home page in Builder Settings."""
-		return frappe.get_cached_value("Builder Settings", None, "home_page") == self.route
-
-
-def get_css_variables():
-	builder_variables = frappe.get_all("Builder Variable", fields=["variable_name", "value", "dark_value"])
-	css_variables = {}
-	dark_mode_css_variables = {}
-
-	for builder_variable in builder_variables:
-		if builder_variable.variable_name and builder_variable.value:
-			variable_name = f"--{camel_case_to_kebab_case(builder_variable.variable_name, True)}"
-			css_variables[variable_name] = builder_variable.value
-
-			if hasattr(builder_variable, "dark_value") and builder_variable.dark_value:
-				dark_mode_css_variables[variable_name] = builder_variable.dark_value
-
-	return css_variables, dark_mode_css_variables
+		return frappe.get_cached_value("Builder Settings", "Builder Settings", "home_page") == self.route
 
 
 def replace_component_in_blocks(blocks, target_component, replace_with):

--- a/builder/builder/doctype/builder_variable/builder_variable.py
+++ b/builder/builder/doctype/builder_variable/builder_variable.py
@@ -5,6 +5,9 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.modules.export_file import delete_folder, export_to_files
+from frappe.utils.caching import redis_cache
+
+from builder.utils import camel_case_to_kebab_case
 
 
 class BuilderVariable(Document):
@@ -26,7 +29,11 @@ class BuilderVariable(Document):
 	def autoname(self):
 		self.name = append_number_if_name_exists("Builder Variable", frappe.scrub(self.variable_name))
 
+	def after_insert(self):
+		get_css_variables.clear_cache()
+
 	def on_update(self):
+		get_css_variables.clear_cache()
 		if self.is_standard:
 			export_to_files(
 				record_list=[["Builder Variable", self.name, "builder_variable"]], record_module="builder"
@@ -36,5 +43,27 @@ class BuilderVariable(Document):
 			delete_folder("builder", "builder_variable", self.name)
 
 	def on_trash(self):
+		get_css_variables.clear_cache()
 		if self.is_standard:
 			delete_folder("builder", "builder_variable", self.name)
+
+
+@redis_cache(ttl=10 * 24 * 3600)
+def get_css_variables():
+	builder_variables = frappe.get_all("Builder Variable", fields=["variable_name", "value", "dark_value"])
+	css_variables = {}
+	dark_mode_css_variables = {}
+
+	for builder_variable in builder_variables:
+		if builder_variable.variable_name and builder_variable.value:
+			variable_name = f"--{camel_case_to_kebab_case(builder_variable.variable_name, True)}"
+			css_variables[variable_name] = builder_variable.value
+
+			if hasattr(builder_variable, "dark_value") and builder_variable.dark_value:
+				dark_mode_css_variables[variable_name] = builder_variable.dark_value
+
+	return css_variables, dark_mode_css_variables
+
+
+def clear_builder_variable_cache(doc, method):
+	get_css_variables.clear_cache()

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -22,38 +22,10 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	{% for (font, options) in fonts.items() %}<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ font }}:wght@{{ ";".join(options.weights) }}&display=swap" media="screen">{% endfor %}
 	{{ style }}
-	{%- if css_variables -%}
-	<style>
-		:root {
-			{% for key, value in css_variables.items() %}
-			{{ key }}: {{ value }};
-			{% endfor %}
-		}
-		{%- if dark_mode_css_variables -%}
-		@media (prefers-color-scheme: dark) {
-			:root {
-				{% for key, value in dark_mode_css_variables.items() %}
-				{{ key }}: {{ value }};
-				{% endfor %}
-			}
-		}
-		{%- endif -%}
-		{%- if preview -%}
-			[data-prefers-color-scheme="dark"] {
-				{% for key, value in dark_mode_css_variables.items() %}
-				{{ key }}: {{ value }};
-				{% endfor %}
-			}
-			{%- if dark_mode_css_variables -%}
-			[data-prefers-color-scheme="light"] {
-				{% for key, value in css_variables.items() %}
-				{{ key }}: {{ value }};
-				{% endfor %}
-			}
-			{%- endif -%}
-		{%- endif -%}
-	</style>
-	{%- endif -%}
+	<link rel="stylesheet" href="/builder_assets/variables.css" media="screen">
+	{% if preview %}
+	<link rel="stylesheet" href="/builder_assets/color_scheme_variables.css" media="screen">
+	{% endif %}
 	{%- if custom_fonts -%}
 	<style>{% for font in custom_fonts %}@font-face {font-family: "{{ font.font_name }}";src: url("{{ font.font_file }}");}{% endfor %}</style>
 	{%- endif -%}

--- a/builder/www/builder_assets/color_scheme_variables.css
+++ b/builder/www/builder_assets/color_scheme_variables.css
@@ -1,0 +1,6 @@
+[data-prefers-color-scheme="dark"] {
+{%- for key, value in dark_mode_css_variables.items() %}{{ key }}: {{ value }};{%- endfor %}}
+
+{%- if dark_mode_css_variables -%}[data-prefers-color-scheme="light"] {
+{%- for key, value in css_variables.items() %}{{ key }}: {{ value }};{%- endfor %}}
+{%- endif -%}

--- a/builder/www/builder_assets/color_scheme_variables.py
+++ b/builder/www/builder_assets/color_scheme_variables.py
@@ -1,0 +1,7 @@
+from builder.builder.doctype.builder_variable.builder_variable import get_css_variables
+
+
+def get_context(context):
+	css_variables, dark_mode_css_variables = get_css_variables()
+	context.css_variables = css_variables
+	context.dark_mode_css_variables = dark_mode_css_variables

--- a/builder/www/builder_assets/variables.css
+++ b/builder/www/builder_assets/variables.css
@@ -1,0 +1,7 @@
+{%- if css_variables -%}:root {
+{%- for key, value in css_variables.items() %}{{ key }}: {{ value }};
+{%- endfor %}}{%- endif -%}
+
+{%- if dark_mode_css_variables -%}@media (prefers-color-scheme: dark) {:root {
+{%- for key, value in dark_mode_css_variables.items() %}{{ key }}: {{ value }};
+{%- endfor %}}}{%- endif -%}

--- a/builder/www/builder_assets/variables.py
+++ b/builder/www/builder_assets/variables.py
@@ -1,0 +1,7 @@
+from builder.builder.doctype.builder_variable.builder_variable import get_css_variables
+
+
+def get_context(context):
+	css_variables, dark_mode_css_variables = get_css_variables()
+	context.css_variables = css_variables
+	context.dark_mode_css_variables = dark_mode_css_variables


### PR DESCRIPTION
The CSS variable logic has been moved out of the Builder Page and placed into a dedicated templated page. This ensures the latest CSS variables are loaded even when the page is cached on the server side. Previously, each Builder Page request triggered a `get_all` call to get variable list. Now, all variable-related logic is decoupled and cached separately... this eliminates redundant requests on page load.