### PR TITLE
build: Update DuckDB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     "jsmin>=3.0.1",
     "csscompressor>=0.9.5",
-    "duckdb>=0.9.0",
+    "duckdb~=1.3.0",
     "pandas (>=2.3.2,<3.0.0)",
 ]
 


### PR DESCRIPTION
Temporary solution to match DuckDB version with Frappe Insights to avoid conflicts while installing both apps in Frappe Cloud