### PR TITLE
fix(code-editor): prevent all clipboard events from bubbling up

### DIFF
--- a/frontend/src/utils/createCodeMirrorState.ts
+++ b/frontend/src/utils/createCodeMirrorState.ts
@@ -129,8 +129,14 @@ export const createStartingState = async ({
 			},
 		]),
 		EditorView.domEventHandlers({
+			// to avoid interfering with builder clipboard events
 			cut: (event, view) => {
-				// this is to prevent the cut event from propagating to document and trigger cutting the block
+				event.stopPropagation();
+			},
+			copy: (event, view) => {
+				event.stopPropagation();
+			},
+			paste: (event, view) => {
 				event.stopPropagation();
 			},
 		}),


### PR DESCRIPTION
Previously only the "cut" event was handled and it's propagation was prevented but in some parts the "paste" event also causes unexpected changes in blocks as the event bubbles up from the code editor to the document.

https://github.com/user-attachments/assets/701b7331-14c6-4810-9a0b-8ad0aabbdcd3

This PR tries to fix these issues by preventing all clipboard (cut, copy, paste) events from bubbling up.