### PR TITLE
fix(code-editor): prevent "save" propagation

### DIFF
--- a/frontend/src/utils/createCodeMirrorState.ts
+++ b/frontend/src/utils/createCodeMirrorState.ts
@@ -169,6 +169,7 @@ export const createStartingState = async ({
 						onSaveCallback();
 						return true;
 					},
+					stopPropagation: true,
 				},
 			]),
 		);


### PR DESCRIPTION
in fragment mode - editing inline HTML (or block script) and saving it would bubble up and trigger the save action for the component