### PR TITLE
fix(Code Editor): tab behaviour on multiline selection

### DIFF
--- a/frontend/src/utils/createCodeMirrorState.ts
+++ b/frontend/src/utils/createCodeMirrorState.ts
@@ -8,6 +8,8 @@ import {
 	defaultKeymap,
 	history,
 	historyKeymap,
+	indentMore,
+	indentLess,
 } from "@codemirror/commands";
 import {
 	bracketMatching,
@@ -112,20 +114,8 @@ export const createStartingState = async ({
 		keymap.of([
 			{
 				key: "Tab",
-				run: (view) => {
-					const spaces = "	";
-					view.dispatch({
-						changes: {
-							from: view.state.selection.main.from,
-							to: view.state.selection.main.to,
-							insert: spaces,
-						},
-						selection: {
-							anchor: view.state.selection.main.from + spaces.length,
-						},
-					});
-					return true;
-				},
+				run: indentMore,
+				shift: indentLess,
 			},
 		]),
 		EditorView.domEventHandlers({


### PR DESCRIPTION
**Before**:

Selecting multiple lines and pressing tab deletes the block

https://github.com/user-attachments/assets/452997fa-f1e9-435b-a064-e9e383ad35a9

**After**:

Use codemirror's `indentMore`, `indentLess` commands to indent on tab, and deindent on shift + tab

https://github.com/user-attachments/assets/639814d1-ce25-4c3b-be6d-3d26de1b3235
