### PR TITLE
fix: paste and cut events not updating input values

### DIFF
--- a/frontend/src/components/Controls/Input.vue
+++ b/frontend/src/components/Controls/Input.vue
@@ -72,12 +72,12 @@ const triggerUpdate = useDebounceFn(($event: Event) => {
 	}
 }, 100);
 
-const handleFocus = ($event: Event) =>{
-	if(props.selectOnFocus && !props.disabled && props.type !== "checkbox"){
+const handleFocus = ($event: Event) => {
+	if (props.selectOnFocus && !props.disabled && props.type !== "checkbox") {
 		const target = $event.target as HTMLInputElement;
-		setTimeout(()=>{
+		setTimeout(() => {
 			target.select();
 		}, 0);
 	}
-}
+};
 </script>


### PR DESCRIPTION
### Issue:
Pasting or cutting text into input fields didn't trigger updates. The preview would only update after typing additional characters or using arrow keys.

### Solution:
- Added `@paste` and `@cut` event handlers to trigger immediate updates when values are pasted or cut
- Added auto-select on focus feature for better UX
- Now input updates immediately when pasting or cutting values

## Before

- Pasting or cutting text did not update the preview immediately
- Users had to type extra characters or use arrow keys to force an update

## After

- Input values update instantly on paste or cut actions
- Preview remains consistent with user input


https://github.com/user-attachments/assets/5e1ac321-b272-49be-b0f0-1d6e0455309f


Fixes #449

cc @surajshetty3416