### PR TITLE
fix(GlobalAnalytics): text color to section headers

### DIFF
--- a/frontend/src/components/Settings/GlobalAnalytics.vue
+++ b/frontend/src/components/Settings/GlobalAnalytics.vue
@@ -16,7 +16,7 @@
 		</AnalyticsOverview>
 		<div class="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2">
 			<div>
-				<h3 class="mb-4 text-lg font-medium">Top Pages</h3>
+				<h3 class="mb-4 text-lg font-medium text-ink-gray-7">Top Pages</h3>
 				<div
 					v-if="analytics.loading"
 					class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
@@ -39,7 +39,7 @@
 					row-key="route" />
 			</div>
 			<div>
-				<h3 class="mb-4 text-lg font-medium">Top Referrers</h3>
+				<h3 class="mb-4 text-lg font-medium text-ink-gray-7">Top Referrers</h3>
 				<div
 					v-if="analytics.loading"
 					class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">


### PR DESCRIPTION
Before:
<img width="1440" height="845" alt="Screenshot 2025-12-28 at 10 39 29 PM" src="https://github.com/user-attachments/assets/b26438d7-0c28-4c11-8958-dabb92c716a6" />

Fix:
<img width="1440" height="845" alt="Screenshot 2025-12-28 at 10 39 36 PM" src="https://github.com/user-attachments/assets/6f1ff44f-fce6-4cb8-8eec-a5fa0d4aa30c" />
