### PR TITLE
fix(code-editor): prevent key propagation from codemirror

### DIFF
--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -80,6 +80,7 @@ const resetEditor = async (params: { content: string; resetHistory: boolean; aut
 };
 
 const handleKeyDown = (e: KeyboardEvent) => {
+	e.stopImmediatePropagation();
 	if ((e.ctrlKey || e.metaKey) && e.key === "f") {
 		e.stopImmediatePropagation();
 		e.preventDefault();


### PR DESCRIPTION
pressing escape used to close the editor and the dialog