### PR TITLE
fix: Add hyphenated search support for z-index property

### DIFF
--- a/frontend/src/components/BlockPropertySections/StyleSection.ts
+++ b/frontend/src/components/BlockPropertySections/StyleSection.ts
@@ -183,7 +183,7 @@ const styleSectionProperties = [
 				styleProperty: "zIndex",
 			};
 		},
-		searchKeyWords: "Z, Index, ZIndex, Z Index",
+		searchKeyWords: "Z, Index, ZIndex, Z Index, Z-index, Z-Index",
 		condition: () =>
 			!blockController.multipleBlocksSelected() &&
 			!blockController.isRoot() &&


### PR DESCRIPTION
Issue:
The z-index property could only be found by searching 'zi' but not 'z-' which matches the actual CSS property name 'z-index'.

Solution:
Added 'z-index' and 'Z-Index' to the searchKeyWords array to support hyphenated search patterns while keeping camelCase support.

Now both search patterns work:
- Searching 'zi' matches 'ZIndex'
- Searching 'z-' matches 'z-index'

Fixes #451

cc @surajshetty3416