### PR TITLE
fix: Allow Enter key to save Component

### DIFF
--- a/frontend/src/components/Modals/NewComponent.vue
+++ b/frontend/src/components/Modals/NewComponent.vue
@@ -17,7 +17,7 @@
 				type="text"
 				:modelValue="componentName"
 				@input="(value: string) => (componentName = value)"
-				@keyup.enter.prevent="handleEnterKey"
+				@keydown.enter.prevent="handleEnterKey"
 				label="Component Name"
 				required />
 			<div class="mt-3">


### PR DESCRIPTION
**Fixes: #465**

**Issue:**
Saving a component required clicking the Save button with a mouse. Pressing Enter in the component name field had no effect

**Solution:**
- Added @keydown.enter.prevent event handler to the component name input field
- Created handleEnterKey() function to validate input and trigger save action
- Added [v-model="showDialog"] to properly control dialog visibility

https://github.com/user-attachments/assets/c97b1c33-7598-47e0-b3f9-ca19d68b7dad

@surajshetty3416 



