### PR TITLE
fix(BlockLayers): Better drag-n-drop UX with target indicators

### DIFF
--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -9,7 +9,7 @@ const useCanvasStore = defineStore("canvasStore", {
 		activeCanvas: <InstanceType<typeof BuilderCanvas> | null>null,
 		requiresConfirmationForCopyingEntirePage: <boolean>true,
 		copyEntirePage: <boolean>false,
-		layerDraggingOverBlockId: <string | null>null,
+		layerDraggingOverBlock: <string | null>null,
 		preventClick: false,
 		guides: {
 			showX: false,


### PR DESCRIPTION
Previously, it was hard for users to know where the block would drop while dragging from the Layers panel, and even harder to confidently drop a block inside a parent block. Also, the ghost element obstructed the layers where users wanted to drop a dragged layer.

**Before:**

https://github.com/user-attachments/assets/d53cd5a6-9621-4005-af61-36f036062d57


Now we have drop target indicators and I've removed the ghost layer to resolve above issues.

**Now:**

https://github.com/user-attachments/assets/d52ef8f7-f5d7-45c8-a13f-03b6a38bc787


