### PR TITLE
fix: Left panel default width

### DIFF
--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -3,7 +3,7 @@
 		<PanelResizer
 			:dimension="builderStore.builderLayout.leftPanelWidth"
 			side="right"
-			:minDimension="200	"
+			:minDimension="200"
 			:maxDimension="500"
 			@resize="(width) => (builderStore.builderLayout.leftPanelWidth = width)" />
 		<div


### PR DESCRIPTION
Fix #453

## Problem
The left panel had a default `minDimension` of 280px in the `PanelResizer` component, but the initial width in the store was 250px. This caused the panel to jump to 280px when trying to resize left, making it appear to increase instead of decrease.

## Solution
Added explicit `minDimension="200"` prop to the `PanelResizer` component in `BuilderLeftPanel.vue` to allow the panel to shrink below its initial width.


## Testing
- [x] Dragging left panel to the left decreases width correctly
- [x] Dragging left panel to the right increases width correctly
- [x] No jumping or stuck behavior
- [x] Panel respects minimum (200px) and maximum (500px) dimensions


 cc @surajshetty3416 

## Video

https://github.com/user-attachments/assets/4b19647c-aec5-4142-bc27-e25cf38dd255


