### PR TITLE
feat: add option for justify in text alignment

### DIFF
--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -191,6 +191,12 @@ const typographySectionProperties = [
 						icon: "align-right",
 						hideLabel: true,
 					},
+					{
+						label: "Justify",
+						value: "justify",
+						icon: "align-justify",
+						hideLabel: true,
+					},
 				],
 				defaultValue: "left",
 			};

--- a/frontend/src/components/Controls/TabButtons.vue
+++ b/frontend/src/components/Controls/TabButtons.vue
@@ -13,7 +13,7 @@
 							active ? 'ring-outline-gray-2 focus-visible:ring' : '',
 							!modelValue && checked ? 'border border-dashed border-outline-gray-3' : '',
 							modelValue && checked ? 'bg-surface-white text-ink-gray-9 shadow' : 'text-ink-gray-7',
-							'flex flex-1 justify-center gap-2 whitespace-nowrap rounded-[7px] px-3 py-[5px] leading-none transition-colors focus:outline-none',
+							'flex flex-1 justify-center gap-2 whitespace-nowrap rounded-[7px] px-2 py-[5px] leading-none transition-colors focus:outline-none',
 						]">
 						<FeatherIcon
 							class="size-4"


### PR DESCRIPTION
Added `text-align: justify` in the properties panel. Had to reduce the horizontal padding on the tabs to make the four buttons fit though.

<img width="3956" height="2276" alt="CleanShot 2026-02-04 at 23 44 16@2x" src="https://github.com/user-attachments/assets/3a1222cb-c2c0-43c7-966d-0737934d3b2a" />
