### PR TITLE
fix: avoid build from source due to python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jsmin>=3.0.1",
     "csscompressor>=0.9.5",
     "pandas (>=2.3.2,<3.0.0)",
-    "duckdb~=1.3.0",
+    "duckdb==1.4.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes: https://github.com/frappe/builder/issues/474