### PR TITLE
fix: auto-add # for valid hex color input

### DIFF
--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -141,8 +141,8 @@ const normalizeColorInput = (val: string) => {
 	if (/^#+/.test(val)) {
 		return "#" + val.replace(/^#+/, "");
 	}
-	if(isValidHexChar(val)) {
-		return "#" + val
+	if (isValidHexChar(val)) {
+		return "#" + val;
 	}
 	return val;
 };


### PR DESCRIPTION
It automatically adds # when user enters a valid hex color without the # symbol (e.g. fff -> #fff , ffffff -> #ffffff)

Before:
When correct hex code was entered without # symbol, nothing happened on pressing Enter.

https://github.com/user-attachments/assets/5530e32b-5fa0-4841-b172-39ed2b47b19f


After:

https://github.com/user-attachments/assets/52f39987-cfd8-43c4-9a76-4e9fd8c5e7ec

