### PR TITLE
fix: Content field styling preserved

### DIFF
--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -205,12 +205,33 @@ watch(
 watch(
 	() => textContent.value,
 	(newValue: string) => {
+		if (!editor.value) return;
+		
 		const innerHTML = getInnerHTML(editor.value);
-		const isSame = newValue === innerHTML;
-		if (isSame) {
+		if (newValue === innerHTML) return;
+		
+		// If plain text is entered but current content has HTML styling, preserve it
+		const isPlainText = !/<[^>]+>/.test(newValue);
+		const hasStyles = /<[^>]+style=/.test(innerHTML) || /<(em|strong|i|b|u)/.test(innerHTML);
+		
+		if (isPlainText && hasStyles && newValue.trim()) {
+			const tempDiv = document.createElement('div');
+			tempDiv.innerHTML = innerHTML;
+			
+			if (tempDiv.textContent !== newValue) {
+				// Update only the text content, preserving all HTML tags
+				const walker = document.createTreeWalker(tempDiv, NodeFilter.SHOW_TEXT);
+				const textNode = walker.nextNode();
+				if (textNode) {
+					textNode.textContent = newValue;
+					editor.value.commands.setContent(tempDiv.innerHTML, false);
+					return;
+				}
+			}
 			return;
 		}
-		editor.value?.commands.setContent(newValue || "", false);
+		
+		editor.value.commands.setContent(newValue || "", false);
 	},
 );
 
@@ -242,8 +263,24 @@ if (!props.preview) {
 					content: textContent.value,
 					extensions: [
 						StarterKit,
-						TextStyle,
-						Color,
+						TextStyle.extend({
+							addGlobalAttributes() {
+								return [
+									{
+										types: ['textStyle'],
+										attributes: {
+											style: {
+												parseHTML: element => element.getAttribute('style'),
+												renderHTML: attributes => attributes.style ? { style: attributes.style } : {},
+											},
+										},
+									},
+								];
+							},
+						}),
+						Color.configure({
+							types: ['textStyle'],
+						}),
 						FontFamily,
 						Link.configure({
 							openOnClick: false,


### PR DESCRIPTION
## Description
Fixes #489 

Text styling (color, italic, bold, underline) is now preserved when editing text through the Content field in the properties panel.

## Problem
Previously, editing text via the Content field would strip all formatting, leaving only plain text.

## Solution
- Modified `TextBlock.vue` to detect plain text input and preserve existing HTML styling
- Extended TipTap's `TextStyle` to handle inline `style` attributes
- When plain text is entered, only the text content is updated while keeping all HTML tags intact

## Testing
1. Add text block
2. Apply styling (color, italic, bold, etc.)
3. Edit text in Content field
4. Styling is preserved

## Before

https://github.com/user-attachments/assets/cf7b754f-c227-46a1-a8d7-0867e5cbee86



## After

https://github.com/user-attachments/assets/8139f9a8-680e-451f-a1cb-887db207f4a5

