### PR TITLE
fix: added frappe dependency version in pyproject.toml for FC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ Repository = "https://github.com/frappe/builder.git"
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.black]
 line-length = 99
 


### PR DESCRIPTION
<img width="578" height="516" alt="Screenshot 2026-02-11 at 12 10 56 AM" src="https://github.com/user-attachments/assets/86677979-839b-4dad-9367-0883a7bcbc2a" />
