### PR TITLE
fix: text cursor editing across multiple views

### DIFF
--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -243,8 +243,7 @@ if (!props.preview) {
 			if (
 				canvasStore.activeCanvas?.isSelected(props.block) &&
 				canvasStore.activeCanvas?.activeBreakpoint === props.breakpoint &&
-				!blockController.multipleBlocksSelected() &&
-				!editor.value
+				!blockController.multipleBlocksSelected()
 			) {
 				editor.value = new Editor({
 					content: textContent.value,
@@ -309,7 +308,7 @@ const handleEscKey = () => {
 };
 
 const handleClickOutside = (e: MouseEvent) => {
-	if ((e.target as HTMLElement).closest(".__text_block__")) {
+	if ((e.target as HTMLElement).closest(".canvas-container")) {
 		canvasStore.editableBlock = null;
 	}
 };


### PR DESCRIPTION
This fixes the issue where the text cursor disappeared when both desktop and mobile views were open. Editing now works correctly in each view.

Before:

https://github.com/user-attachments/assets/248de74c-b739-477b-bb83-447c6ae18ffd

After:

https://github.com/user-attachments/assets/d4d756b3-8343-4737-bd1d-4aaa0ebf62ee

