### PR TITLE
fix(builder_page): use originalElement for body scripts check in build_tag()

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -576,7 +576,8 @@ def build_tag(block: dict, state: dict, data_key: dict | None = None) -> bs.Tag:
 	attach_client_script(tag, block, state)
 
 	# Add body scripts for body element
-	if block.get("element") == "body":
+	effective_element = block.get("originalElement") or block.get("element")
+	if effective_element == "body":
 		tag.append("{% include 'templates/generators/webpage_scripts.html' %}")
 
 	cleanup_props_stack(props, state["standard_props_stack"])


### PR DESCRIPTION

## Problem

Client scripts (JS) attached to Builder pages stopped loading after the refactor
in eb9776cb. The root block of every page is stored as:

```json
{ "element": "div", "originalElement": "body" }
```

`element` is `"div"` because `<body>` cannot be nested inside the Jinja wrapper
template. The semantic identity is preserved in `originalElement`.

`build_tag()` checked `block.get("element") == "body"`, which is never `True`,
so `set_style_and_script()` was never called and no `<script>` tags were injected.

## Solution

Use the same `originalElement or element` pattern already present in
`create_html_tag()` and `build_tag_classes()`:

```python
effective_element = block.get("originalElement") or block.get("element")
if effective_element == "body":
```

Regression introduced by eb9776cb.
