### PR TITLE
fix(PlacementControl): increase button click area to match hovered icon

### DIFF
--- a/frontend/src/components/PlacementControl.vue
+++ b/frontend/src/components/PlacementControl.vue
@@ -19,7 +19,7 @@
 					<div
 						@click="setAlignment(option)"
 						@dblclick="setAlignment(option, true)"
-						class="hidden gap-[2px] hover:opacity-100 group-hover/option:flex"
+						class="hidden w-5 gap-[2px] hover:opacity-100 group-hover/option:flex"
 						:class="{
 							'flex-row': direction === 'row',
 							'flex-col': direction === 'column',


### PR DESCRIPTION
previously the click would register only after putting the pointer on a small vertical click area on the icon, even though the hovered icon would show up much before that.

before:

https://github.com/user-attachments/assets/dc31bc33-43e5-4dd3-a4fd-7a905d70ed62

after:

https://github.com/user-attachments/assets/cad3087d-3e9d-4b64-8ead-3d1d99a19f80

