### PR TITLE
fix(TypographySection): Add `controlType: "key"` for Content

### DIFF
--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -21,6 +21,7 @@ const typographySectionProperties = [
 			return {
 				label: "Content",
 				propertyKey: "innerHTML",
+				controlType: "key",
 				// @ts-ignore
 				allowDynamicValue: true,
 				getModelValue: () => blockController.getText(),


### PR DESCRIPTION
by default `controlType` is `style`, this caused dynamic values being assigned as `type: style`. this resulted in a bug where the dynamic value would not actually render as it depends on the `type` to be `key`.