### PR TITLE
feat: implement last used mode persistence for script editor

### DIFF
--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -205,7 +205,7 @@ const blockData = computed(() => {
 		? blockDataStore.getBlockData(
 				blockController.getFirstSelectedBlock().blockId,
 				showCumulativeBlockData.value ? "all" : "own",
-		  ) || {}
+			) || {}
 		: {};
 });
 


### PR DESCRIPTION
The Script Editor tab used to always reset to "Block" mode. Now Builder remembers the last mode the Editor tab was opened in.