### PR TITLE
fix: replaced `prev_blocks` with `block` for inherited block data

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -506,12 +506,9 @@ def get_block_data(
 	block_data = frappe._dict()
 	_locals = dict(block=frappe._dict(prev_block_data or {}), props=props)
 	execute_script(block_data_script, _locals, block_id)
-	
+
 	if isinstance(_locals["block"], dict):
-		block_data = frappe._dict({
-			k: v for k, v in _locals["block"].items()
-			if prev_block_data.get(k) != v
-		})
+		block_data = frappe._dict({k: v for k, v in _locals["block"].items() if prev_block_data.get(k) != v})
 	return block_data
 
 

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -504,7 +504,7 @@ def get_block_data(
 	frappe.has_permission("Builder Page", "write", throw=True)
 	props = frappe.parse_json(props or "{}")
 	block_data = frappe._dict()
-	_locals = dict(block=frappe._dict(), prev_blocks=frappe._dict(prev_block_data or {}), props=props)
+	_locals = dict(block=frappe._dict(prev_block_data or {}), props=props)
 	execute_script(block_data_script, _locals, block_id)
 	if isinstance(_locals["block"], dict):
 		block_data.update(_locals["block"])

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -506,8 +506,12 @@ def get_block_data(
 	block_data = frappe._dict()
 	_locals = dict(block=frappe._dict(prev_block_data or {}), props=props)
 	execute_script(block_data_script, _locals, block_id)
+	
 	if isinstance(_locals["block"], dict):
-		block_data.update(_locals["block"])
+		block_data = frappe._dict({
+			k: v for k, v in _locals["block"].items()
+			if prev_block_data.get(k) != v
+		})
 	return block_data
 
 

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -691,4 +691,4 @@ def execute_script_and_combine(prev_block_data, block_data_script, props):
 	_locals = dict(block=to_dict_with_fallback(prev_block_data or {}), props=props)
 	execute_script(unescape_html(block_data_script), _locals, "sample")
 	block_data.update(_locals["block"])
-	return combine(prev_block_data, block_data)
+	return block_data

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -688,7 +688,7 @@ def to_safe_json(data):
 def execute_script_and_combine(prev_block_data, block_data_script, props):
 	props = frappe._dict(frappe.parse_json(props or "{}"))
 	block_data = frappe._dict()
-	_locals = dict(block=frappe._dict(), prev_blocks=to_dict_with_fallback(prev_block_data), props=props)
+	_locals = dict(block=to_dict_with_fallback(prev_block_data or {}), props=props)
 	execute_script(unescape_html(block_data_script), _locals, "sample")
 	block_data.update(_locals["block"])
 	return combine(prev_block_data, block_data)

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -24,10 +24,10 @@
 						:autofocus="false"
 						:readonly="true"></CodeEditor>
 					<div class="flex w-full items-center justify-between py-4">
-						<div class="text-sm text-ink-gray-6">Show cumulative data</div>
+						<div class="text-sm text-ink-gray-6">Show inherited data</div>
 						<Switch
-							:model-value="showCumulativeBlockData"
-							@update:model-value="(val) => (showCumulativeBlockData = val)" />
+							:model-value="showInheritedBlockData"
+							@update:model-value="(val) => (showInheritedBlockData = val)" />
 					</div>
 					<div class="my-3 mt-4 text-sm text-ink-gray-8">Block Props</div>
 					<PropsEditor
@@ -129,18 +129,26 @@
 								@save="saveBlockDataScript"
 								:showSaveButton="true"
 								:show-line-numbers="true"></CodeEditor>
-							<CodeEditor
-								v-model="blockData"
-								type="JSON"
-								label="Data Preview"
-								:showLineNumbers="true"
-								class="-mt-5 w-1/3 [&>div>div]:bg-surface-white"
-								height="calc(100% - 110px)"
-								description='Use Block Data Script to provide dynamic data to your block.<br>
+							<div class="-mt-5 w-1/3 p-4" height="calc(100% - 110px)">
+								<CodeEditor
+									v-model="blockData"
+									type="JSON"
+									label="Data Preview"
+									:showLineNumbers="true"
+									height="calc(100% - 140px)"
+									class="h-full [&>div>div]:bg-surface-white"
+									description='Use Block Data Script to provide dynamic data to your block.<br>
 								<b>Example:</b> block.events = frappe.get_list("Event")<br><br>
 								For more details on how to write block data script, refer to <b><a class="underline" href="https://docs.frappe.io/builder/data-script" target="_blank">this documentation</a></b>.
 								'
-								:readonly="true"></CodeEditor>
+									:readonly="true"></CodeEditor>
+								<div class="flex items-center justify-between gap-4">
+									<div class="text-sm text-ink-gray-6">Show inherited data</div>
+									<Switch
+										:model-value="showInheritedBlockData"
+										@update:model-value="(val) => (showInheritedBlockData = val)" />
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -172,7 +180,7 @@ const blockDataStore = useBlockDataStore();
 
 const showDialog = ref(false);
 const mode = useStorage("builder_last_used_script_editor_mode", "page");
-const showCumulativeBlockData = ref(false);
+const showInheritedBlockData = ref(false);
 
 const props = defineProps<{
 	page: BuilderPage;
@@ -204,8 +212,8 @@ const blockData = computed(() => {
 	return isBlockSelected.value
 		? blockDataStore.getBlockData(
 				blockController.getFirstSelectedBlock().blockId,
-				showCumulativeBlockData.value ? "all" : "own",
-			) || {}
+				showInheritedBlockData.value ? "all" : "own",
+		  ) || {}
 		: {};
 });
 

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -213,7 +213,7 @@ const blockData = computed(() => {
 		? blockDataStore.getBlockData(
 				blockController.getFirstSelectedBlock().blockId,
 				showInheritedBlockData.value ? "all" : "own",
-		  ) || {}
+			) || {}
 		: {};
 });
 


### PR DESCRIPTION
now all blocks can access all prev blocks' data using the `block` keyword itself

ref: https://github.com/frappe/builder/pull/533

new simplified process:
<img width="1440" height="804" alt="Screenshot 2026-03-31 at 5 49 49 PM" src="https://github.com/user-attachments/assets/b96fb089-9a2f-41a4-a992-36c8e5496f4c" />
