### PR TITLE
fix: select dropdown rendering as text input in overflow

### DIFF
--- a/frontend/src/components/Controls/BasePropertyControl.vue
+++ b/frontend/src/components/Controls/BasePropertyControl.vue
@@ -97,6 +97,8 @@ const emit = defineEmits<{
 	(clearDynamicValue: void): void;
 }>();
 
+defineOptions({ inheritance: false });
+
 const props = withDefaults(
 	defineProps<{
 		propertyKey: string;

--- a/frontend/src/components/Controls/StylePropertyControl.vue
+++ b/frontend/src/components/Controls/StylePropertyControl.vue
@@ -31,7 +31,7 @@ const props = withDefaults(
 		maxValue?: number | null;
 		component?: Component;
 		events?: Record<string, unknown>;
-		type?: "select";
+		type?: "string";
 		options?: Array<{ label: string; value: string | null }>;
 		defaultValue?: string | number;
 		allowDynamicValue?: boolean;

--- a/frontend/src/components/Controls/StylePropertyControl.vue
+++ b/frontend/src/components/Controls/StylePropertyControl.vue
@@ -31,6 +31,8 @@ const props = withDefaults(
 		maxValue?: number | null;
 		component?: Component;
 		events?: Record<string, unknown>;
+		type?: "select";
+		options?: Array<{ label: string; value: string | null }>;
 		defaultValue?: string | number;
 		allowDynamicValue?: boolean;
 		labelPlacement?: "left" | "top";


### PR DESCRIPTION
Declared types and options as props so it reaches the input component and renders the dropdwon correctly.

Before:

https://github.com/user-attachments/assets/4cfd902f-57b4-4e83-b974-ba7eaa5af00d


After:

https://github.com/user-attachments/assets/f94fa339-df2f-4a7e-bdca-55ff3bdd88da

Fixes: #501 


