### PR TITLE
fix: Correct `Block Data` ordering and `Block Client Script` emulation in Builder UI

### DIFF
--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -423,8 +423,8 @@ watch(
 		const mode = builderSettings.doc?.execute_block_scripts_in_editor;
 		if (mode === "Don't Execute") return;
 
-		if (mode === "Restricted") executeBlockClientScriptRestricted(uidToUse, script, allResolvedProps.value);
-		else executeBlockClientScriptUnrestricted(uidToUse, script, allResolvedProps.value);
+		if (mode === "Restricted") executeBlockClientScriptRestricted(uidToUse, props.breakpoint, script, allResolvedProps.value);
+		else executeBlockClientScriptUnrestricted(uidToUse, props.breakpoint, script, allResolvedProps.value);
 	},
 	{ immediate: true },
 );

--- a/frontend/src/stores/blockStore.ts
+++ b/frontend/src/stores/blockStore.ts
@@ -48,7 +48,7 @@ const useBlockDataStore = defineStore("blockDataStore", {
 			} else if (filter === "passedDown") {
 				return blockData.passedDownData;
 			}
-			return { ...blockData.ownData, ...blockData.passedDownData };
+			return { ...blockData.passedDownData, ...blockData.ownData };
 		},
 		clearBlockData(blockUid: string) {
 			delete this.blockDataMap[blockUid];

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1360,10 +1360,11 @@ const getDataArray = (collectionObject: Record<string, any>) => {
 
 function executeBlockClientScriptUnrestricted(
 	blockUid: string,
+	breakpoint: string,
 	userScript: string,
 	props: Record<string, any> = {},
 ) {
-	const thisElement = document.querySelector(`[data-block-uid='${blockUid}']`) as HTMLElement;
+	const thisElement = document.querySelector(`[data-block-uid='${blockUid}'][data-breakpoint=${breakpoint}]`) as HTMLElement;
 
 	const context = {
 		thisRef: thisElement,
@@ -1400,6 +1401,7 @@ function executeBlockClientScriptUnrestricted(
 
 function executeBlockClientScriptRestricted(
 	blockUid: string,
+	breakpoint: string,
 	userScript: string,
 	props: Record<string, any> = {},
 ) {
@@ -1491,7 +1493,7 @@ function executeBlockClientScriptRestricted(
 	};
 
 	const sandboxRoot = document.querySelector("[data-block-id='root']") as HTMLElement;
-	const thisElement = document.querySelector(`[data-block-uid='${blockUid}']`) as HTMLElement;
+	const thisElement = document.querySelector(`[data-block-uid='${blockUid}'][data-breakpoint='${breakpoint}']`) as HTMLElement;
 
 	const proxiedRoot = wrap(sandboxRoot);
 	const proxiedThis = wrap(thisElement);


### PR DESCRIPTION
previously the Client Script emulation occurred only in the Desktop breakpoint, now all breakpoints has Client Script emulation.

<img width="1440" height="808" alt="Screenshot 2026-04-18 at 11 05 34 PM" src="https://github.com/user-attachments/assets/c5b46c2a-7a9f-488c-9bc5-e928ec4288cc" />
<img width="1440" height="808" alt="Screenshot 2026-04-18 at 11 05 42 PM" src="https://github.com/user-attachments/assets/c08ea71b-1edd-4a82-83fb-7e13a7e0c162" />

Before:

https://github.com/user-attachments/assets/39831757-5135-4913-a548-ea932a6069af

After:

https://github.com/user-attachments/assets/250eb4e3-d1b1-4cdc-9eb3-4d9a65d7811f

