### PR TITLE
feat: Allow FC users to set custom domain right from Builder settings

### DIFF
--- a/builder/domain.py
+++ b/builder/domain.py
@@ -3,6 +3,8 @@ from frappe.integrations.frappe_providers.frappecloud_billing import get_base_ur
 
 
 def fc_call(method: str, **params):
+	frappe.only_for("System Manager")
+
 	import requests
 
 	response = requests.post(

--- a/builder/domain.py
+++ b/builder/domain.py
@@ -66,12 +66,28 @@ def fc_call(method: str, **params):
 			)
 		)
 
-	url = f"{get_base_url()}/api/method/press.api.developer.domain.{method}"
+	url = f"https://staging.frappe.cloud/api/method/press.api.developer.domain.{method}"
 	response = requests.post(url, data={"secret_key": secret_key, **params})
 
 	if response.status_code != 200:
-		error = response.json().get("exception") or f"FC API returned {response.status_code}"
-		frappe.throw(error)
+		body = response.json()
+		# Try to surface the real error from the FC response
+		server_msgs = body.get("_server_messages")
+		if server_msgs:
+			import json as _json
+
+			try:
+				msgs = _json.loads(server_msgs)
+				error = (
+					_json.loads(msgs[0]).get("message")
+					if isinstance(msgs[0], str)
+					else msgs[0].get("message")
+				)
+			except Exception:
+				error = None
+		else:
+			error = body.get("exception") or body.get("message")
+		frappe.throw(error or f"FC API returned {response.status_code}")
 
 	return response.json().get("message")
 
@@ -84,7 +100,7 @@ def get_server_ip() -> str | None:
 			ip = "192.0.2.1"
 			frappe.cache().set_value("builder_site_server_ip", ip)
 		return ip
-	return fc_call("get_server_ip")
+	return fc_call("get_inbound_ip")
 
 
 @frappe.whitelist()

--- a/builder/domain.py
+++ b/builder/domain.py
@@ -1,0 +1,187 @@
+import re
+
+import frappe
+
+
+def dev_validate_domain(domain: str) -> str:
+	"""Normalise and validate; raises ValidationError for malformed input."""
+	domain = (domain or "").strip().lower()
+
+	if not domain or "." not in domain or domain.startswith(".") or domain.endswith(".") or ".." in domain:
+		frappe.throw(
+			"Invalid domain format. Enter a fully qualified domain like www.example.com or example.com."
+		)
+
+	labels = domain.split(".")
+	if len(labels[-1]) < 2 or any(
+		not label
+		or len(label) > 63
+		or label.startswith("-")
+		or label.endswith("-")
+		or not re.match(r"^[a-z0-9-]+$", label)
+		for label in labels
+	):
+		frappe.throw(
+			"Invalid domain format. Enter a fully qualified domain like www.example.com or example.com."
+		)
+
+	return domain
+
+
+def dev_load_domains() -> list:
+	domains = frappe.cache().get_value("builder_site_domains")
+	if domains is None:
+		domains = [
+			{
+				"name": frappe.local.site,
+				"domain": frappe.local.site,
+				"status": "Active",
+				"retry_count": 0,
+				"redirect_to_primary": 0,
+				"primary": True,
+			}
+		]
+		frappe.cache().set_value("builder_site_domains", domains)
+	return domains
+
+
+def dev_save_domains(domains: list) -> None:
+	frappe.cache().set_value("builder_site_domains", domains)
+
+
+# ─── Frappe Cloud proxy ───────────────────────────────────────────────────────
+
+
+def fc_call(method: str, **params):
+	"""Proxy to press.api.developer.domain.{method} on Frappe Cloud."""
+	import requests
+	from frappe.integrations.frappe_providers.frappecloud_billing import get_base_url
+
+	secret_key = frappe.conf.get("fc_subscription_secret_key")
+	if not secret_key:
+		frappe.throw(
+			frappe._(
+				"Frappe Cloud subscription secret key is not configured."
+				" Set fc_subscription_secret_key in site_config.json."
+			)
+		)
+
+	url = f"{get_base_url()}/api/method/press.api.developer.domain.{method}"
+	response = requests.post(url, data={"secret_key": secret_key, **params})
+
+	if response.status_code != 200:
+		error = response.json().get("exception") or f"FC API returned {response.status_code}"
+		frappe.throw(error)
+
+	return response.json().get("message")
+
+
+@frappe.whitelist()
+def get_server_ip() -> str | None:
+	if frappe.conf.developer_mode:
+		ip = frappe.cache().get_value("builder_site_server_ip")
+		if ip is None:
+			ip = "192.0.2.1"
+			frappe.cache().set_value("builder_site_server_ip", ip)
+		return ip
+	return fc_call("get_server_ip")
+
+
+@frappe.whitelist()
+def get_domains() -> list:
+	if frappe.conf.developer_mode:
+		return dev_load_domains()
+	return fc_call("get_domains")
+
+
+@frappe.whitelist()
+def check_dns(domain: str) -> dict:
+	if frappe.conf.developer_mode:
+		domain = dev_validate_domain(domain)
+		matched = domain == frappe.local.site or domain.endswith(f".{frappe.local.site}")
+		return {
+			"matched": matched,
+			"type": "CNAME",
+			"CNAME": {"matched": matched, "answer": frappe.local.site if matched else None},
+			"A": {"matched": False, "answer": None},
+		}
+	return fc_call("check_dns", domain=domain)
+
+
+@frappe.whitelist()
+def add_domain(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		domains = dev_load_domains()
+		if not any(d["domain"] == domain for d in domains):
+			domains.append(
+				{
+					"name": domain,
+					"domain": domain,
+					"status": "Active",
+					"retry_count": 0,
+					"redirect_to_primary": 0,
+					"primary": False,
+				}
+			)
+			dev_save_domains(domains)
+		return "ok"
+	return fc_call("add_domain", domain=domain)
+
+
+@frappe.whitelist()
+def remove_domain(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		dev_save_domains([d for d in dev_load_domains() if d["domain"] != domain])
+		return "ok"
+	return fc_call("remove_domain", domain=domain)
+
+
+@frappe.whitelist()
+def retry_add_domain(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		domains = dev_load_domains()
+		for d in domains:
+			if d["domain"] == domain:
+				d["status"] = "Active"
+				d["retry_count"] = d.get("retry_count", 0) + 1
+				break
+		dev_save_domains(domains)
+		return "ok"
+	return fc_call("retry_add_domain", domain=domain)
+
+
+@frappe.whitelist()
+def set_host_name(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		domains = dev_load_domains()
+		for d in domains:
+			d["primary"] = d["domain"] == domain
+		dev_save_domains(domains)
+		return "ok"
+	return fc_call("set_host_name", domain=domain)
+
+
+@frappe.whitelist()
+def set_redirect(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		domains = dev_load_domains()
+		for d in domains:
+			if d["domain"] == domain:
+				d["redirect_to_primary"] = 1
+				break
+		dev_save_domains(domains)
+		return "ok"
+	return fc_call("set_redirect", domain=domain)
+
+
+@frappe.whitelist()
+def unset_redirect(domain: str) -> str:
+	if frappe.conf.developer_mode:
+		domains = dev_load_domains()
+		for d in domains:
+			if d["domain"] == domain:
+				d["redirect_to_primary"] = 0
+				break
+		dev_save_domains(domains)
+		return "ok"
+	return fc_call("unset_redirect", domain=domain)

--- a/builder/domain.py
+++ b/builder/domain.py
@@ -1,81 +1,22 @@
-import re
-
 import frappe
-
-
-def dev_validate_domain(domain: str) -> str:
-	"""Normalise and validate; raises ValidationError for malformed input."""
-	domain = (domain or "").strip().lower()
-
-	if not domain or "." not in domain or domain.startswith(".") or domain.endswith(".") or ".." in domain:
-		frappe.throw(
-			"Invalid domain format. Enter a fully qualified domain like www.example.com or example.com."
-		)
-
-	labels = domain.split(".")
-	if len(labels[-1]) < 2 or any(
-		not label
-		or len(label) > 63
-		or label.startswith("-")
-		or label.endswith("-")
-		or not re.match(r"^[a-z0-9-]+$", label)
-		for label in labels
-	):
-		frappe.throw(
-			"Invalid domain format. Enter a fully qualified domain like www.example.com or example.com."
-		)
-
-	return domain
-
-
-def dev_load_domains() -> list:
-	domains = frappe.cache().get_value("builder_site_domains")
-	if domains is None:
-		domains = [
-			{
-				"name": frappe.local.site,
-				"domain": frappe.local.site,
-				"status": "Active",
-				"retry_count": 0,
-				"redirect_to_primary": 0,
-				"primary": True,
-			}
-		]
-		frappe.cache().set_value("builder_site_domains", domains)
-	return domains
-
-
-def dev_save_domains(domains: list) -> None:
-	frappe.cache().set_value("builder_site_domains", domains)
-
-
-# ─── Frappe Cloud proxy ───────────────────────────────────────────────────────
+from frappe.integrations.frappe_providers.frappecloud_billing import get_base_url, get_headers
 
 
 def fc_call(method: str, **params):
-	"""Proxy to press.api.developer.domain.{method} on Frappe Cloud."""
 	import requests
-	from frappe.integrations.frappe_providers.frappecloud_billing import get_base_url
 
-	secret_key = frappe.conf.get("fc_subscription_secret_key")
-	if not secret_key:
-		frappe.throw(
-			frappe._(
-				"Frappe Cloud subscription secret key is not configured."
-				" Set fc_subscription_secret_key in site_config.json."
-			)
-		)
-
-	url = f"https://staging.frappe.cloud/api/method/press.api.developer.domain.{method}"
-	response = requests.post(url, data={"secret_key": secret_key, **params})
+	response = requests.post(
+		f"{get_base_url()}/api/method/press.saas.api.domain.{method}",
+		headers=get_headers(),
+		json=params or None,
+	)
 
 	if response.status_code != 200:
+		import json as _json
+
 		body = response.json()
-		# Try to surface the real error from the FC response
 		server_msgs = body.get("_server_messages")
 		if server_msgs:
-			import json as _json
-
 			try:
 				msgs = _json.loads(server_msgs)
 				error = (
@@ -94,110 +35,44 @@ def fc_call(method: str, **params):
 
 @frappe.whitelist()
 def get_server_ip() -> str | None:
-	if frappe.conf.developer_mode:
-		ip = frappe.cache().get_value("builder_site_server_ip")
-		if ip is None:
-			ip = "192.0.2.1"
-			frappe.cache().set_value("builder_site_server_ip", ip)
-		return ip
 	return fc_call("get_inbound_ip")
 
 
 @frappe.whitelist()
 def get_domains() -> list:
-	if frappe.conf.developer_mode:
-		return dev_load_domains()
 	return fc_call("get_domains")
 
 
 @frappe.whitelist()
 def check_dns(domain: str) -> dict:
-	if frappe.conf.developer_mode:
-		domain = dev_validate_domain(domain)
-		matched = domain == frappe.local.site or domain.endswith(f".{frappe.local.site}")
-		return {
-			"matched": matched,
-			"type": "CNAME",
-			"CNAME": {"matched": matched, "answer": frappe.local.site if matched else None},
-			"A": {"matched": False, "answer": None},
-		}
 	return fc_call("check_dns", domain=domain)
 
 
 @frappe.whitelist()
 def add_domain(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		domains = dev_load_domains()
-		if not any(d["domain"] == domain for d in domains):
-			domains.append(
-				{
-					"name": domain,
-					"domain": domain,
-					"status": "Active",
-					"retry_count": 0,
-					"redirect_to_primary": 0,
-					"primary": False,
-				}
-			)
-			dev_save_domains(domains)
-		return "ok"
 	return fc_call("add_domain", domain=domain)
 
 
 @frappe.whitelist()
 def remove_domain(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		dev_save_domains([d for d in dev_load_domains() if d["domain"] != domain])
-		return "ok"
 	return fc_call("remove_domain", domain=domain)
 
 
 @frappe.whitelist()
 def retry_add_domain(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		domains = dev_load_domains()
-		for d in domains:
-			if d["domain"] == domain:
-				d["status"] = "Active"
-				d["retry_count"] = d.get("retry_count", 0) + 1
-				break
-		dev_save_domains(domains)
-		return "ok"
 	return fc_call("retry_add_domain", domain=domain)
 
 
 @frappe.whitelist()
 def set_host_name(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		domains = dev_load_domains()
-		for d in domains:
-			d["primary"] = d["domain"] == domain
-		dev_save_domains(domains)
-		return "ok"
 	return fc_call("set_host_name", domain=domain)
 
 
 @frappe.whitelist()
 def set_redirect(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		domains = dev_load_domains()
-		for d in domains:
-			if d["domain"] == domain:
-				d["redirect_to_primary"] = 1
-				break
-		dev_save_domains(domains)
-		return "ok"
 	return fc_call("set_redirect", domain=domain)
 
 
 @frappe.whitelist()
 def unset_redirect(domain: str) -> str:
-	if frappe.conf.developer_mode:
-		domains = dev_load_domains()
-		for d in domains:
-			if d["domain"] == domain:
-				d["redirect_to_primary"] = 0
-				break
-		dev_save_domains(domains)
-		return "ok"
 	return fc_call("unset_redirect", domain=domain)

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -76,6 +76,7 @@ declare module 'vue' {
     GlobalAnalytics: typeof import('./src/components/Settings/GlobalAnalytics.vue')['default']
     GlobalCode: typeof import('./src/components/Settings/GlobalCode.vue')['default']
     GlobalDeveloper: typeof import('./src/components/Settings/GlobalDeveloper.vue')['default']
+    GlobalDomains: typeof import('./src/components/Settings/GlobalDomains.vue')['default']
     GlobalGeneral: typeof import('./src/components/Settings/GlobalGeneral.vue')['default']
     GlobalMeta: typeof import('./src/components/Settings/GlobalMeta.vue')['default']
     GlobalRedirects: typeof import('./src/components/Settings/GlobalRedirects.vue')['default']

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -147,7 +147,7 @@ const globalSettings = {
 			title: "Redirects",
 			icon: RedirectIcon,
 		},
-		...(builderStore.isFCSite || window.is_developer_mode
+		...(true || window.is_developer_mode
 			? [
 					{
 						label: "Domains",

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -39,7 +39,6 @@ import GlobalRedirects from "@/components/Settings/GlobalRedirects.vue";
 import PageCode from "@/components/Settings/PageCode.vue";
 import builderProjectFolder from "@/data/builderProjectFolder";
 import { builderSettings } from "@/data/builderSettings";
-import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { computed, onActivated, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
@@ -69,7 +68,6 @@ const props = defineProps<{
 
 const route = useRoute();
 const pageStore = usePageStore();
-const builderStore = useBuilderStore();
 const emit = defineEmits(["close"]);
 const selectedItem = ref<string>(props.onlyGlobal ? "global_general" : "page_general");
 const settingsLoaded = ref(false);
@@ -147,7 +145,7 @@ const globalSettings = {
 			title: "Redirects",
 			icon: RedirectIcon,
 		},
-		...(true || window.is_developer_mode
+		...(window.is_fc_site || window.is_developer_mode
 			? [
 					{
 						label: "Domains",

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -39,6 +39,7 @@ import GlobalRedirects from "@/components/Settings/GlobalRedirects.vue";
 import PageCode from "@/components/Settings/PageCode.vue";
 import builderProjectFolder from "@/data/builderProjectFolder";
 import { builderSettings } from "@/data/builderSettings";
+import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { computed, onActivated, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
@@ -49,11 +50,14 @@ import SettingsIcon from "./Icons/Settings.vue";
 // @ts-ignore
 import TerminalIcon from "~icons/lucide/terminal";
 // @ts-ignore
+import ExternalLinkIcon from "~icons/lucide/external-link";
+// @ts-ignore
 import SparklesIcon from "~icons/lucide/sparkles";
 import GlobalAI from "./Settings/GlobalAI.vue";
 import GlobalAnalytics from "./Settings/GlobalAnalytics.vue";
 import GlobalCode from "./Settings/GlobalCode.vue";
 import GlobalDeveloper from "./Settings/GlobalDeveloper.vue";
+import GlobalDomains from "./Settings/GlobalDomains.vue";
 import GlobalGeneral from "./Settings/GlobalGeneral.vue";
 import PageAnalytics from "./Settings/PageAnalytics.vue";
 import PageGeneral from "./Settings/PageGeneral.vue";
@@ -65,6 +69,7 @@ const props = defineProps<{
 
 const route = useRoute();
 const pageStore = usePageStore();
+const builderStore = useBuilderStore();
 const emit = defineEmits(["close"]);
 const selectedItem = ref<string>(props.onlyGlobal ? "global_general" : "page_general");
 const settingsLoaded = ref(false);
@@ -142,6 +147,17 @@ const globalSettings = {
 			title: "Redirects",
 			icon: RedirectIcon,
 		},
+		...(builderStore.isFCSite || window.is_developer_mode
+			? [
+					{
+						label: "Domains",
+						value: "global_domains",
+						component: GlobalDomains,
+						title: "Custom Domains",
+						icon: ExternalLinkIcon,
+					},
+				]
+			: []),
 		{
 			label: "Analytics",
 			value: "global_analytics",

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -1,19 +1,17 @@
 <template>
 	<div class="flex flex-col gap-3">
 		<!-- Domain list -->
-		<div v-if="loading" class="text-p-sm text-ink-gray-5">Loading domains…</div>
+		<div v-if="loading && !domains.length" class="text-p-sm text-ink-gray-5">Loading domains…</div>
 		<div v-else-if="!domains.length" class="text-p-sm text-ink-gray-5">No custom domains added yet.</div>
-		<div v-else class="mb-2 flex flex-col gap-2">
-			<div
-				v-for="d in domains"
-				:key="d.domain"
-				class="flex items-center justify-between rounded-md border border-outline-gray-1 px-3 py-2">
-				<div class="flex items-center gap-2">
-					<span class="text-p-sm font-medium leading-7 text-ink-gray-9">{{ d.domain }}</span>
-					<Badge v-if="d.primary" size="sm" theme="green" label="Primary" />
-					<Badge v-else-if="d.redirect_to_primary" size="sm" theme="blue" label="Redirecting" />
+		<div v-else class="mb-2 divide-y divide-outline-gray-1 rounded-md border border-outline-gray-1">
+			<div v-for="d in domains" :key="d.domain" class="flex items-center gap-2 px-3 py-2.5">
+				<div class="min-w-0 flex-1">
+					<p class="truncate text-p-sm font-medium text-ink-gray-9">{{ d.domain }}</p>
+					<p v-if="d.redirect_to_primary" class="text-p-xs text-ink-gray-5">Redirects to primary</p>
 				</div>
-				<Dropdown v-if="!d.primary" :options="getDomainActions(d)" placement="right">
+				<Badge v-if="d.primary" size="sm" theme="green" label="Primary" />
+				<Badge v-else :label="d.status" size="sm" :theme="statusTheme(d.status)" />
+				<Dropdown :options="getDomainActions(d)" placement="right">
 					<Button variant="ghost" icon="more-horizontal" />
 				</Dropdown>
 			</div>
@@ -21,34 +19,20 @@
 
 		<!-- Add domain form -->
 		<form @submit.prevent="handleVerifyOrAdd" class="flex flex-col gap-3">
-			<span class="text-sm text-ink-gray-5">
-				To add a custom domain, you must already own it. If you don't have one, buy it and come back here.
-			</span>
 			<FormControl
-				placeholder="www.example.com"
+				label="Set Domain"
+				placeholder="e.g. yourdomain.com"
 				v-model="newDomain"
 				:readonly="dnsVerified === true"
 				autocomplete="off" />
 
-			<!-- DNS info card -->
-			<div class="overflow-hidden rounded-md border border-outline-gray-1">
-				<div
-					class="flex items-center gap-2 border-b border-outline-gray-1 px-3 py-2 text-p-xs"
-					:class="statusClass">
-					<FeatherIcon :name="statusIcon" class="h-3.5 w-3.5 shrink-0" />
-					<span v-if="dnsVerified === true">
-						DNS verified. Click
-						<strong>Add Domain</strong>
-						to proceed.
-					</span>
-					<span v-else>{{ statusMessage }}</span>
-				</div>
-
-				<div class="space-y-1 p-3">
+			<!-- DNS records -->
+			<div class="overflow-hidden rounded bg-surface-gray-1">
+				<div class="space-y-1">
 					<div
 						v-for="rec in dnsRecords"
 						:key="rec.type"
-						class="flex items-center gap-2 rounded bg-surface-gray-1 px-2.5 py-1.5 font-mono text-p-xs">
+						class="flex items-center gap-2 px-2.5 py-1.5 font-mono text-p-xs">
 						<span class="w-10 shrink-0 font-semibold text-ink-gray-7">{{ rec.type }}</span>
 						<span :class="newDomain ? 'text-ink-gray-5' : 'text-ink-gray-3'">
 							{{ newDomain ? dnsHostLabel : "your-domain.com" }}
@@ -63,6 +47,15 @@
 							<FeatherIcon name="copy" class="h-3.5 w-3.5" />
 						</button>
 					</div>
+				</div>
+				<div class="flex items-center gap-2 rounded px-3 py-2 text-p-xs" :class="statusClass">
+					<FeatherIcon :name="statusIcon" class="h-3.5 w-3.5 shrink-0" />
+					<span v-if="dnsVerified === true">
+						DNS verified. Click
+						<strong>Add Domain</strong>
+						to proceed.
+					</span>
+					<span v-else>{{ statusMessage }}</span>
 				</div>
 			</div>
 
@@ -83,8 +76,10 @@
 <script setup lang="ts">
 import { useDomains } from "@/data/domains";
 import { Badge, Dropdown, ErrorMessage, FeatherIcon, FormControl } from "frappe-ui";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { toast } from "vue-sonner";
+
+const PENDING_STATUSES = ["Pending", "In Progress"];
 
 const currentSite = window.location.hostname;
 const {
@@ -109,16 +104,45 @@ const addDomainError = ref("");
 const checkingDNS = ref(false);
 const addingDomain = ref(false);
 
+let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+const hasPendingDomains = computed(() => domains.value.some((d) => PENDING_STATUSES.includes(d.status)));
+
+watch(hasPendingDomains, (val) => {
+	if (val && !pollInterval) {
+		pollInterval = setInterval(() => {
+			if (!loading.value) fetchDomains();
+		}, 5000);
+	} else if (!val && pollInterval) {
+		clearInterval(pollInterval);
+		pollInterval = null;
+	}
+});
+
+onMounted(() => Promise.all([fetchDomains(), fetchServerIP()]));
+onUnmounted(() => {
+	if (pollInterval) clearInterval(pollInterval);
+});
+
+const isSubdomain = computed(() => newDomain.value.split(".").length > 2);
+
 const dnsHostLabel = computed(() => {
 	const parts = newDomain.value.split(".");
 	return parts.length <= 2 ? newDomain.value : parts[0];
 });
 
+const dnsRecords = computed(() => {
+	const records = [];
+	if (isSubdomain.value) records.push({ type: "CNAME", value: currentSite, copyValue: currentSite });
+	records.push({ type: "A", value: serverIP.value ?? "loading…", copyValue: serverIP.value ?? "" });
+	return records;
+});
+
 const statusClass = computed(() => {
-	if (dnsVerified.value === true) return "text-ink-green-4 bg-green-50";
+	if (dnsVerified.value === true) return "text-ink-green-1 bg-surface-green-1";
 	if (dnsVerified.value === false && dnsCheckError.value) return "bg-red-50 text-ink-red-4";
 	if (dnsVerified.value === false) return "bg-yellow-50 text-yellow-700";
-	return "bg-surface-gray-1 text-ink-gray-5";
+	return "text-ink-gray-6";
 });
 
 const statusIcon = computed(() => {
@@ -132,15 +156,18 @@ const statusMessage = computed(() => {
 	if (dnsVerified.value === false && dnsCheckError.value) return dnsCheckError.value;
 	if (dnsVerified.value === false)
 		return "DNS record not matched. Double-check the values below and allow up to 48h for propagation.";
-	return "Set one of these DNS records at your domain registrar, then click Verify DNS.";
+	return isSubdomain.value
+		? "Set one of these DNS records at your registrar, then click Verify DNS."
+		: "Set this DNS record at your registrar, then click Verify DNS.";
 });
 
-const dnsRecords = computed(() => [
-	{ type: "CNAME", value: currentSite, copyValue: currentSite },
-	{ type: "A", value: serverIP.value ?? "loading…", copyValue: serverIP.value ?? "" },
-]);
-
-onMounted(() => Promise.all([fetchDomains(), fetchServerIP()]));
+function statusTheme(status: string) {
+	return (
+		({ Active: "green", Broken: "red", Pending: "orange", "In Progress": "blue" } as Record<string, string>)[
+			status
+		] ?? "gray"
+	);
+}
 
 async function copyToClipboard(text: string) {
 	if (!text) return;

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -3,15 +3,18 @@
 		<!-- Domain list -->
 		<div v-if="loading && !domains.length" class="text-p-sm text-ink-gray-5">Loading domains…</div>
 		<div v-else-if="!domains.length" class="text-p-sm text-ink-gray-5">No custom domains added yet.</div>
-		<div v-else class="mb-2 divide-y divide-outline-gray-1 rounded-md border border-outline-gray-1">
-			<div v-for="d in domains" :key="d.domain" class="flex items-center gap-2 px-3 py-2.5">
-				<div class="min-w-0 flex-1">
-					<p class="truncate text-p-sm font-medium text-ink-gray-9">{{ d.domain }}</p>
+		<div v-else class="mb-2 flex flex-col gap-2">
+			<div
+				v-for="d in domains"
+				:key="d.domain"
+				class="flex items-center gap-2 rounded-md border border-outline-gray-1 px-3 py-2.5">
+				<div class="flex min-w-0 flex-1 items-center gap-2">
+					<p class="truncate text-p-sm font-medium leading-6 text-ink-gray-9">{{ d.domain }}</p>
 					<p v-if="d.redirect_to_primary" class="text-p-xs text-ink-gray-5">Redirects to primary</p>
+					<Badge v-if="d.primary" size="sm" theme="green" label="Primary" />
+					<Badge v-else :label="d.status" size="sm" :theme="statusTheme(d.status)" />
 				</div>
-				<Badge v-if="d.primary" size="sm" theme="green" label="Primary" />
-				<Badge v-else :label="d.status" size="sm" :theme="statusTheme(d.status)" />
-				<Dropdown :options="getDomainActions(d)" placement="right">
+				<Dropdown v-if="getDomainActions(d).length" :options="getDomainActions(d)" placement="right">
 					<Button variant="ghost" icon="more-horizontal" />
 				</Dropdown>
 			</div>
@@ -20,7 +23,7 @@
 		<!-- Add domain form -->
 		<form @submit.prevent="handleVerifyOrAdd" class="flex flex-col gap-3">
 			<FormControl
-				label="Set Domain"
+				label="Add Domain"
 				placeholder="e.g. yourdomain.com"
 				v-model="newDomain"
 				:readonly="dnsVerified === true"
@@ -28,41 +31,49 @@
 
 			<!-- DNS records -->
 			<div class="overflow-hidden rounded bg-surface-gray-1">
-				<div class="space-y-1">
-					<div
-						v-for="rec in dnsRecords"
-						:key="rec.type"
-						class="flex items-center gap-2 px-2.5 py-1.5 font-mono text-p-xs">
-						<span class="w-10 shrink-0 font-semibold text-ink-gray-7">{{ rec.type }}</span>
-						<span :class="newDomain ? 'text-ink-gray-5' : 'text-ink-gray-3'">
-							{{ newDomain ? dnsHostLabel : "your-domain.com" }}
-						</span>
-						<span class="text-ink-gray-4">→</span>
-						<span class="flex-1 truncate text-ink-gray-9">{{ rec.value }}</span>
+				<template v-for="(rec, i) in dnsRecords" :key="rec.type">
+					<div v-if="i > 0" class="flex items-center gap-3 px-3">
+						<div class="bg-outline-gray-2 h-px flex-1"></div>
+						<span class="text-p-xs text-ink-gray-4">or</span>
+						<div class="bg-outline-gray-2 h-px flex-1"></div>
+					</div>
+					<div class="flex items-center gap-2 px-3 py-2.5">
+						<div class="min-w-0 flex-1">
+							<div class="flex items-baseline gap-1.5">
+								<span class="text-p-sm font-semibold leading-6 text-ink-gray-8">{{ rec.type }} record</span>
+								<span class="font-mono text-p-xs">
+									<span :class="newDomain ? 'text-ink-gray-5' : 'text-ink-gray-3'">{{ rec.host }}</span>
+									<span class="px-1 text-ink-gray-4">→</span>
+									<span class="text-ink-gray-9">{{ rec.value }}</span>
+								</span>
+							</div>
+							<p class="text-p-xs text-ink-gray-5">{{ rec.hint }}</p>
+						</div>
 						<button
 							type="button"
 							:disabled="!rec.copyValue"
 							@click="copyToClipboard(rec.copyValue)"
-							class="text-ink-gray-4 transition-colors hover:text-ink-gray-7 disabled:cursor-not-allowed disabled:opacity-40">
+							class="shrink-0 text-ink-gray-4 transition-colors hover:text-ink-gray-7 disabled:cursor-not-allowed disabled:opacity-40">
 							<FeatherIcon name="copy" class="h-3.5 w-3.5" />
 						</button>
 					</div>
-				</div>
-				<div class="flex items-center gap-2 rounded px-3 py-2 text-p-xs" :class="statusClass">
-					<FeatherIcon :name="statusIcon" class="h-3.5 w-3.5 shrink-0" />
-					<span v-if="dnsVerified === true">
-						DNS verified. Click
-						<strong>Add Domain</strong>
-						to proceed.
-					</span>
-					<span v-else>{{ statusMessage }}</span>
-				</div>
+				</template>
+			</div>
+			<div class="flex items-center gap-1.5 text-p-xs" :class="statusClass">
+				<FeatherIcon :name="statusIcon" class="h-3.5 w-3.5 shrink-0" />
+				<span v-if="dnsVerified === true">
+					DNS verified. Click
+					<strong>Add Domain</strong>
+					to proceed.
+				</span>
+				<span v-else v-html="statusMessage"></span>
 			</div>
 
 			<ErrorMessage v-if="addDomainError" :message="addDomainError" />
 			<div class="flex gap-2">
 				<Button
 					type="submit"
+					:disabled="checkingDNS || addingDomain || !newDomain"
 					:variant="dnsVerified ? 'solid' : 'subtle'"
 					:loading="checkingDNS || addingDomain">
 					{{ dnsVerified ? "Add Domain" : "Verify DNS" }}
@@ -132,17 +143,36 @@ const dnsHostLabel = computed(() => {
 });
 
 const dnsRecords = computed(() => {
+	const host = newDomain.value ? dnsHostLabel.value : "your-domain.com";
 	const records = [];
-	if (isSubdomain.value) records.push({ type: "CNAME", value: currentSite, copyValue: currentSite });
-	records.push({ type: "A", value: serverIP.value ?? "loading…", copyValue: serverIP.value ?? "" });
+	if (isSubdomain.value) {
+		records.push({
+			type: "CNAME",
+			host,
+			value: currentSite,
+			copyValue: currentSite,
+			recommended: true,
+			hint: "Automatically follows server IP changes. Best choice for subdomains.",
+		});
+	}
+	records.push({
+		type: "A",
+		host: isSubdomain.value ? host : "@",
+		value: serverIP.value ?? "loading…",
+		copyValue: serverIP.value ?? "",
+		recommended: !isSubdomain.value,
+		hint: isSubdomain.value
+			? "Use this if your DNS provider doesn't support CNAME for subdomains."
+			: "Points your root domain directly to the server. Use @ as the host name.",
+	});
 	return records;
 });
 
 const statusClass = computed(() => {
-	if (dnsVerified.value === true) return "text-ink-green-1 bg-surface-green-1";
-	if (dnsVerified.value === false && dnsCheckError.value) return "bg-red-50 text-ink-red-4";
-	if (dnsVerified.value === false) return "bg-yellow-50 text-yellow-700";
-	return "text-ink-gray-6";
+	if (dnsVerified.value === true) return "text-ink-green-3";
+	if (dnsVerified.value === false && dnsCheckError.value) return "text-ink-red-4";
+	if (dnsVerified.value === false) return "text-yellow-700";
+	return "text-ink-gray-5";
 });
 
 const statusIcon = computed(() => {
@@ -157,8 +187,8 @@ const statusMessage = computed(() => {
 	if (dnsVerified.value === false)
 		return "DNS record not matched. Double-check the values below and allow up to 48h for propagation.";
 	return isSubdomain.value
-		? "Set one of these DNS records at your registrar, then click Verify DNS."
-		: "Set this DNS record at your registrar, then click Verify DNS.";
+		? "Choose one of the records below and set it at your DNS registrar, then click Verify DNS."
+		: "Set the A record at your registrar, then click Verify DNS.";
 });
 
 function statusTheme(status: string) {
@@ -213,7 +243,7 @@ function getDomainActions(d: any) {
 	const actions: any[] = [];
 	if (d.status === "Active" && !d.primary)
 		actions.push({ label: "Set as Primary", icon: "star", onClick: () => setHostName(d.domain) });
-	if (!d.redirect_to_primary && d.status === "Active")
+	if (!d.primary && !d.redirect_to_primary && d.status === "Active")
 		actions.push({
 			label: "Redirect to Primary",
 			icon: "corner-right-up",
@@ -223,7 +253,8 @@ function getDomainActions(d: any) {
 		actions.push({ label: "Disable Redirect", icon: "slash", onClick: () => unsetRedirect(d.domain) });
 	if (d.status === "Broken")
 		actions.push({ label: "Retry", icon: "refresh-cw", onClick: () => retryDomain(d.domain) });
-	actions.push({ label: "Remove Domain", icon: "trash", onClick: () => removeDomain(d.domain) });
+	if (!d.primary)
+		actions.push({ label: "Remove Domain", icon: "trash", onClick: () => removeDomain(d.domain) });
 	return actions;
 }
 </script>

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -1,0 +1,202 @@
+<template>
+	<div class="flex flex-col gap-3">
+		<!-- Domain list -->
+		<div v-if="loading" class="text-p-sm text-ink-gray-5">Loading domains…</div>
+		<div v-else-if="!domains.length" class="text-p-sm text-ink-gray-5">No custom domains added yet.</div>
+		<div v-else class="mb-2 flex flex-col gap-2">
+			<div
+				v-for="d in domains"
+				:key="d.domain"
+				class="flex items-center justify-between rounded-md border border-outline-gray-1 px-3 py-2">
+				<div class="flex items-center gap-2">
+					<span class="text-p-sm font-medium leading-7 text-ink-gray-9">{{ d.domain }}</span>
+					<Badge v-if="d.primary" size="sm" theme="green" label="Primary" />
+					<Badge v-else-if="d.redirect_to_primary" size="sm" theme="blue" label="Redirecting" />
+				</div>
+				<Dropdown v-if="!d.primary" :options="getDomainActions(d)" placement="right">
+					<Button variant="ghost" icon="more-horizontal" />
+				</Dropdown>
+			</div>
+		</div>
+
+		<!-- Add domain form -->
+		<form @submit.prevent="handleVerifyOrAdd" class="flex flex-col gap-3">
+			<span class="text-sm text-ink-gray-5">
+				To add a custom domain, you must already own it. If you don't have one, buy it and come back here.
+			</span>
+			<FormControl
+				placeholder="www.example.com"
+				v-model="newDomain"
+				:readonly="dnsVerified === true"
+				autocomplete="off" />
+
+			<!-- DNS info card -->
+			<div class="overflow-hidden rounded-md border border-outline-gray-1">
+				<div
+					class="flex items-center gap-2 border-b border-outline-gray-1 px-3 py-2 text-p-xs"
+					:class="statusClass">
+					<FeatherIcon :name="statusIcon" class="h-3.5 w-3.5 shrink-0" />
+					<span v-if="dnsVerified === true">
+						DNS verified. Click
+						<strong>Add Domain</strong>
+						to proceed.
+					</span>
+					<span v-else>{{ statusMessage }}</span>
+				</div>
+
+				<div class="space-y-1 p-3">
+					<div
+						v-for="rec in dnsRecords"
+						:key="rec.type"
+						class="flex items-center gap-2 rounded bg-surface-gray-1 px-2.5 py-1.5 font-mono text-p-xs">
+						<span class="w-10 shrink-0 font-semibold text-ink-gray-7">{{ rec.type }}</span>
+						<span :class="newDomain ? 'text-ink-gray-5' : 'text-ink-gray-3'">
+							{{ newDomain ? dnsHostLabel : "your-domain.com" }}
+						</span>
+						<span class="text-ink-gray-4">→</span>
+						<span class="flex-1 truncate text-ink-gray-9">{{ rec.value }}</span>
+						<button
+							type="button"
+							:disabled="!rec.copyValue"
+							@click="copyToClipboard(rec.copyValue)"
+							class="text-ink-gray-4 transition-colors hover:text-ink-gray-7 disabled:cursor-not-allowed disabled:opacity-40">
+							<FeatherIcon name="copy" class="h-3.5 w-3.5" />
+						</button>
+					</div>
+				</div>
+			</div>
+
+			<ErrorMessage v-if="addDomainError" :message="addDomainError" />
+			<div class="flex gap-2">
+				<Button
+					type="submit"
+					:variant="dnsVerified ? 'solid' : 'subtle'"
+					:loading="checkingDNS || addingDomain">
+					{{ dnsVerified ? "Add Domain" : "Verify DNS" }}
+				</Button>
+				<Button v-if="dnsVerified !== null" variant="ghost" @click="resetForm">Reset</Button>
+			</div>
+		</form>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { useDomains } from "@/data/domains";
+import { Badge, Dropdown, ErrorMessage, FeatherIcon, FormControl } from "frappe-ui";
+import { computed, onMounted, ref } from "vue";
+import { toast } from "vue-sonner";
+
+const currentSite = window.location.hostname;
+const {
+	domains,
+	serverIP,
+	loading,
+	fetchDomains,
+	fetchServerIP,
+	checkDNS,
+	addDomain,
+	removeDomain,
+	retryDomain,
+	setHostName,
+	setRedirect,
+	unsetRedirect,
+} = useDomains();
+
+const newDomain = ref("");
+const dnsVerified = ref<boolean | null>(null);
+const dnsCheckError = ref("");
+const addDomainError = ref("");
+const checkingDNS = ref(false);
+const addingDomain = ref(false);
+
+const dnsHostLabel = computed(() => {
+	const parts = newDomain.value.split(".");
+	return parts.length <= 2 ? newDomain.value : parts[0];
+});
+
+const statusClass = computed(() => {
+	if (dnsVerified.value === true) return "text-ink-green-4 bg-green-50";
+	if (dnsVerified.value === false && dnsCheckError.value) return "bg-red-50 text-ink-red-4";
+	if (dnsVerified.value === false) return "bg-yellow-50 text-yellow-700";
+	return "bg-surface-gray-1 text-ink-gray-5";
+});
+
+const statusIcon = computed(() => {
+	if (dnsVerified.value === true) return "check-circle";
+	if (dnsVerified.value === false && dnsCheckError.value) return "alert-circle";
+	if (dnsVerified.value === false) return "alert-triangle";
+	return "info";
+});
+
+const statusMessage = computed(() => {
+	if (dnsVerified.value === false && dnsCheckError.value) return dnsCheckError.value;
+	if (dnsVerified.value === false)
+		return "DNS record not matched. Double-check the values below and allow up to 48h for propagation.";
+	return "Set one of these DNS records at your domain registrar, then click Verify DNS.";
+});
+
+const dnsRecords = computed(() => [
+	{ type: "CNAME", value: currentSite, copyValue: currentSite },
+	{ type: "A", value: serverIP.value ?? "loading…", copyValue: serverIP.value ?? "" },
+]);
+
+onMounted(() => Promise.all([fetchDomains(), fetchServerIP()]));
+
+async function copyToClipboard(text: string) {
+	if (!text) return;
+	try {
+		await navigator.clipboard.writeText(text);
+		toast.success("Copied to clipboard");
+	} catch {
+		toast.error("Failed to copy");
+	}
+}
+
+function resetForm() {
+	newDomain.value = "";
+	dnsVerified.value = null;
+	dnsCheckError.value = "";
+	addDomainError.value = "";
+}
+
+async function handleVerifyOrAdd() {
+	addDomainError.value = "";
+	if (!newDomain.value) return;
+
+	newDomain.value = newDomain.value
+		.replace(/(^\w+:|^)\/\//, "")
+		.split("/")[0]
+		.toLowerCase();
+
+	if (dnsVerified.value) {
+		addingDomain.value = true;
+		const ok = await addDomain(newDomain.value);
+		addingDomain.value = false;
+		if (ok) resetForm();
+	} else {
+		checkingDNS.value = true;
+		const { matched, error } = await checkDNS(newDomain.value);
+		checkingDNS.value = false;
+		dnsVerified.value = matched;
+		dnsCheckError.value = error;
+	}
+}
+
+function getDomainActions(d: any) {
+	const actions: any[] = [];
+	if (d.status === "Active" && !d.primary)
+		actions.push({ label: "Set as Primary", icon: "star", onClick: () => setHostName(d.domain) });
+	if (!d.redirect_to_primary && d.status === "Active")
+		actions.push({
+			label: "Redirect to Primary",
+			icon: "corner-right-up",
+			onClick: () => setRedirect(d.domain),
+		});
+	if (d.redirect_to_primary)
+		actions.push({ label: "Disable Redirect", icon: "slash", onClick: () => unsetRedirect(d.domain) });
+	if (d.status === "Broken")
+		actions.push({ label: "Retry", icon: "refresh-cw", onClick: () => retryDomain(d.domain) });
+	actions.push({ label: "Remove Domain", icon: "trash", onClick: () => removeDomain(d.domain) });
+	return actions;
+}
+</script>

--- a/frontend/src/data/domains.ts
+++ b/frontend/src/data/domains.ts
@@ -39,7 +39,9 @@ export function useDomains() {
 			const result = (await createResource({ url: `${API}.check_dns` }).submit({ domain })) as any;
 			return { matched: result?.matched ?? false, error: "" };
 		} catch (e: any) {
-			return { matched: false, error: getErrorMessage(e) };
+			const msg = Array.isArray(e?.messages) && e.messages[0];
+			const error = (msg && typeof msg === "string" ? msg : e?.message) || "Something went wrong";
+			return { matched: false, error };
 		}
 	}
 

--- a/frontend/src/data/domains.ts
+++ b/frontend/src/data/domains.ts
@@ -1,0 +1,102 @@
+import { createResource } from "frappe-ui";
+import { ref } from "vue";
+import { toast } from "vue-sonner";
+
+const API = "builder.domain";
+
+function getErrorMessage(e: any): string {
+	const msg = Array.isArray(e?.messages) && e.messages[0];
+	if (msg && typeof msg === "string") return msg.replace(/<[^>]*>/g, "").trim();
+	return e?.message || "Something went wrong";
+}
+
+export function useDomains() {
+	const domains = ref<any[]>([]);
+	const serverIP = ref<string | null>(null);
+	const loading = ref(false);
+
+	async function fetchServerIP() {
+		try {
+			serverIP.value = (await createResource({ url: `${API}.get_server_ip` }).submit()) as string;
+		} catch {
+			// non-critical
+		}
+	}
+
+	async function fetchDomains() {
+		loading.value = true;
+		try {
+			domains.value = (await createResource({ url: `${API}.get_domains` }).submit()) as any[];
+		} catch (e: any) {
+			toast.error(getErrorMessage(e));
+		} finally {
+			loading.value = false;
+		}
+	}
+
+	async function checkDNS(domain: string): Promise<{ matched: boolean; error: string }> {
+		try {
+			const result = (await createResource({ url: `${API}.check_dns` }).submit({ domain })) as any;
+			return { matched: result?.matched ?? false, error: "" };
+		} catch (e: any) {
+			return { matched: false, error: getErrorMessage(e) };
+		}
+	}
+
+	async function addDomain(domain: string): Promise<boolean> {
+		try {
+			await createResource({ url: `${API}.add_domain` }).submit({ domain });
+			toast.success(`Domain ${domain} added successfully`);
+			await fetchDomains();
+			return true;
+		} catch (e: any) {
+			toast.error(getErrorMessage(e));
+			return false;
+		}
+	}
+
+	async function removeDomain(domain: string) {
+		await callAPI("remove_domain", domain, `${domain} removed`);
+	}
+
+	async function retryDomain(domain: string) {
+		await callAPI("retry_add_domain", domain, `Retrying ${domain}`);
+	}
+
+	async function setHostName(domain: string) {
+		await callAPI("set_host_name", domain, `${domain} set as primary`);
+	}
+
+	async function setRedirect(domain: string) {
+		await callAPI("set_redirect", domain, `Redirect enabled for ${domain}`);
+	}
+
+	async function unsetRedirect(domain: string) {
+		await callAPI("unset_redirect", domain, `Redirect disabled for ${domain}`);
+	}
+
+	async function callAPI(method: string, domain: string, successMsg: string) {
+		try {
+			await createResource({ url: `${API}.${method}` }).submit({ domain });
+			toast.success(successMsg);
+			await fetchDomains();
+		} catch (e: any) {
+			toast.error(getErrorMessage(e));
+		}
+	}
+
+	return {
+		domains,
+		serverIP,
+		loading,
+		fetchDomains,
+		fetchServerIP,
+		checkDNS,
+		addDomain,
+		removeDomain,
+		retryDomain,
+		setHostName,
+		setRedirect,
+		unsetRedirect,
+	};
+}


### PR DESCRIPTION
<img width="1025" height="716" alt="Screenshot 2026-04-21 at 10 43 08 AM" src="https://github.com/user-attachments/assets/cb37b0fe-3e1b-4010-8025-065c58dd0076" />
<img width="1052" height="746" alt="Screenshot 2026-04-21 at 10 47 16 AM" src="https://github.com/user-attachments/assets/f9583af5-7408-4ef2-8367-007a9a188c19" />

- Allows you to see current domains, add, remove and delete domain 
- This internally calls [FC endpoints](https://github.com/frappe/press/pull/6190) and everything is managed there
- Only [System Manager](https://github.com/frappe/builder/pull/555/changes#diff-3b77dcccfc8f5d43c8ef0a1c7f590e96b148eb39e4d60fe699ecb1ef320b6600R6) can access this functionality as of now.

This might need more UX fixes. Will be part of separate PR

Dependant on https://github.com/frappe/press/pull/6190