### PR TITLE
 feat: shortcut for highlighting blocks with scripts

### DIFF
--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -21,14 +21,11 @@
 					:data-block-layer-id="element.blockId"
 					:data-indent="indent"
 					:title="element.blockId"
-					class="block-layer-item relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7 transition-[color] duration-50 ease-out"
-					:class="[
-						{
-							'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
-								canvasStore.layerDraggingOverBlock === element.blockId,
-						},
-						getBlockScriptClasses(element),
-					]"
+					class="block-layer-item relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7"
+					:class="{
+						'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
+							canvasStore.layerDraggingOverBlock === element.blockId,
+					}"
 					@click.stop="selectBlock(element, $event)"
 					@mouseover.stop="
 						!canvasStore.isDragging && canvasStore.activeCanvas?.setHoveredBlock(element.blockId)
@@ -58,14 +55,19 @@
 								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
 									element.isExtendedFromComponent(),
 							}"
-							v-if="!Boolean(element.extendedFromComponent)" />
+							v-if="!Boolean(element.extendedFromComponent) && !showCodeIcon(element)" />
 						<BlocksIcon
 							class="mr-1 h-3 w-3"
 							:class="{
 								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
 									element.isExtendedFromComponent(),
 							}"
-							v-if="Boolean(element.extendedFromComponent)" />
+							v-if="Boolean(element.extendedFromComponent) && !showCodeIcon(element)" />
+						<FeatherIcon
+							name="terminal"
+							:stroke-width="3"
+							class="h-3 w-3 text-orange-500"
+							v-if="showCodeIcon(element)" />
 						<span
 							class="layer-label min-h-[1em] min-w-[2em] max-w-64 truncate"
 							:contenteditable="element.editable && !readonly"
@@ -88,6 +90,7 @@
 							@blur="setBlockName($event, element)">
 							{{ element.getBlockDescription() }}
 						</span>
+
 						<!-- toggle visibility -->
 						<FeatherIcon
 							v-if="!element.isRoot() && !isParentHidden && !readonly"
@@ -128,10 +131,12 @@ import { ref, watch } from "vue";
 import draggable from "vuedraggable";
 import BlockLayers from "./BlockLayers.vue";
 import BlocksIcon from "./Icons/Blocks.vue";
+import useBuilderStore from "@/stores/builderStore";
 
 type LayerInstance = InstanceType<typeof BlockLayers>;
 
 const canvasStore = useCanvasStore();
+const builderStore = useBuilderStore();
 
 const rootContainer = ref<HTMLElement | null>(null);
 const childLayers = ref<LayerInstance[]>([]);
@@ -180,6 +185,13 @@ const expandedLayers = ref(new Set(["root"]));
 
 const isExpanded = (block: Block) => {
 	return expandedLayers.value.has(block.blockId);
+};
+
+const showCodeIcon = (block: Block) => {
+	return (
+		(builderStore.highlightBlocksWithClientScripts && block.getBlockClientScript()) ||
+		(builderStore.highlightBlocksWithDataScripts && block.getBlockDataScript())
+	);
 };
 
 // TODO: Refactor this!
@@ -259,18 +271,6 @@ const blockExitsInTree = (block: Block) => {
 
 const selectBlock = (block: Block, event: MouseEvent) => {
 	canvasStore.selectBlock(block, event, false, true);
-};
-
-const getBlockScriptClasses = (block: Block) => {
-	const hasClientScript = Boolean(block.getBlockClientScript());
-	const hasDataScript = Boolean(block.getBlockDataScript());
-
-	return {
-		"has-client-script": hasClientScript && !hasDataScript,
-		"has-data-script": hasDataScript && !hasClientScript,
-		"has-both-scripts": hasDataScript && hasClientScript,
-		"no-scripts": !hasDataScript && !hasClientScript,
-	};
 };
 
 interface DragState {
@@ -416,13 +416,5 @@ defineExpose({
 }
 .block-selected {
 	@apply border-blue-400 text-gray-900 dark:border-blue-700 dark:text-gray-200;
-}
-
-.highlight-block-script {
-	@apply border-dashed border-outline-gray-3 text-gray-800 dark:border-outline-gray-4 dark:text-gray-300;
-}
-
-.lowlight-nonscript-block {
-	@apply text-gray-400 dark:text-gray-700;
 }
 </style>

--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -21,11 +21,14 @@
 					:data-block-layer-id="element.blockId"
 					:data-indent="indent"
 					:title="element.blockId"
-					class="block-layer-item relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7"
-					:class="{
-						'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
-							canvasStore.layerDraggingOverBlock === element.blockId,
-					}"
+					class="block-layer-item relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-surface-white bg-opacity-50 text-base text-ink-gray-7 transition-[color] duration-50 ease-out"
+					:class="[
+						{
+							'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
+								canvasStore.layerDraggingOverBlock === element.blockId,
+						},
+						getBlockScriptClasses(element),
+					]"
 					@click.stop="selectBlock(element, $event)"
 					@mouseover.stop="
 						!canvasStore.isDragging && canvasStore.activeCanvas?.setHoveredBlock(element.blockId)
@@ -258,6 +261,18 @@ const selectBlock = (block: Block, event: MouseEvent) => {
 	canvasStore.selectBlock(block, event, false, true);
 };
 
+const getBlockScriptClasses = (block: Block) => {
+	const hasClientScript = Boolean(block.getBlockClientScript());
+	const hasDataScript = Boolean(block.getBlockDataScript());
+
+	return {
+		"has-client-script": hasClientScript && !hasDataScript,
+		"has-data-script": hasDataScript && !hasClientScript,
+		"has-both-scripts": hasDataScript && hasClientScript,
+		"no-scripts": !hasDataScript && !hasClientScript,
+	};
+};
+
 interface DragState {
 	draggedElement: HTMLElement | null;
 	hoverTarget: HTMLElement | null;
@@ -401,5 +416,13 @@ defineExpose({
 }
 .block-selected {
 	@apply border-blue-400 text-gray-900 dark:border-blue-700 dark:text-gray-200;
+}
+
+.highlight-block-script {
+	@apply border-dashed border-outline-gray-3 text-gray-800 dark:border-outline-gray-4 dark:text-gray-300;
+}
+
+.lowlight-nonscript-block {
+	@apply text-gray-400 dark:text-gray-700;
 }
 </style>

--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -192,4 +192,30 @@ watch(
 	},
 	{ deep: true },
 );
+
+watch(
+	[() => builderStore.highlightBlocksWithDataScripts, () => builderStore.highlightBlocksWithClientScripts],
+	([highlightDataScripts, highlightClientScripts]) => {
+		const toggleScriptClasses = (selector: string, highlight: boolean, lowlight: boolean) => {
+			document.querySelectorAll(selector).forEach((el) => {
+				el.classList.toggle("highlight-block-script", highlight);
+				el.classList.toggle("lowlight-nonscript-block", lowlight);
+			});
+		};
+
+		toggleScriptClasses(
+			".has-data-script",
+			highlightDataScripts,
+			!highlightDataScripts && highlightClientScripts,
+		);
+		toggleScriptClasses(
+			".has-client-script",
+			highlightClientScripts,
+			!highlightClientScripts && highlightDataScripts,
+		);
+		toggleScriptClasses(".has-both-scripts", highlightDataScripts || highlightClientScripts, false);
+		toggleScriptClasses(".no-scripts", false, highlightDataScripts || highlightClientScripts);
+	},
+	{ immediate: true },
+);
 </script>

--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -192,30 +192,4 @@ watch(
 	},
 	{ deep: true },
 );
-
-watch(
-	[() => builderStore.highlightBlocksWithDataScripts, () => builderStore.highlightBlocksWithClientScripts],
-	([highlightDataScripts, highlightClientScripts]) => {
-		const toggleScriptClasses = (selector: string, highlight: boolean, lowlight: boolean) => {
-			document.querySelectorAll(selector).forEach((el) => {
-				el.classList.toggle("highlight-block-script", highlight);
-				el.classList.toggle("lowlight-nonscript-block", lowlight);
-			});
-		};
-
-		toggleScriptClasses(
-			".has-data-script",
-			highlightDataScripts,
-			!highlightDataScripts && highlightClientScripts,
-		);
-		toggleScriptClasses(
-			".has-client-script",
-			highlightClientScripts,
-			!highlightClientScripts && highlightDataScripts,
-		);
-		toggleScriptClasses(".has-both-scripts", highlightDataScripts || highlightClientScripts, false);
-		toggleScriptClasses(".no-scripts", false, highlightDataScripts || highlightClientScripts);
-	},
-	{ immediate: true },
-);
 </script>

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -44,6 +44,8 @@ const useBuilderStore = defineStore("builderStore", {
 		isDark: useDark({
 			attribute: "data-theme",
 		}),
+		highlightBlocksWithDataScripts: false,
+		highlightBlocksWithClientScripts: false,
 	}),
 	getters: {
 		isAIEnabled(): boolean {

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -509,6 +509,33 @@ export function useBuilderEvents(
 				builderStore.mode = "move";
 			},
 		},
+		{
+			key: "l",
+			ctrl: true,
+			triggeredOn: "hold",
+			description: "Highlight Blocks with Data Scripts",
+			group: "View",
+			onHold: () => {
+				builderStore.highlightBlocksWithDataScripts = true;
+			},
+			onRelease: () => {
+				builderStore.highlightBlocksWithDataScripts = false;
+			},
+		},
+		{
+			key: "l",
+			ctrl: true,
+			shift: true,
+			triggeredOn: "hold",
+			description: "Highlight Blocks with Client Scripts",
+			group: "View",
+			onHold: () => {
+				builderStore.highlightBlocksWithClientScripts = true;
+			},
+			onRelease: () => {
+				builderStore.highlightBlocksWithClientScripts = false;
+			},
+		},
 	]);
 
 	// on tab activation, reload for latest data

--- a/frontend/src/utils/useShortcut.ts
+++ b/frontend/src/utils/useShortcut.ts
@@ -12,8 +12,14 @@ export interface ShortcutConfig {
 	description: string;
 	/** Group name for categorizing in the shortcuts modal */
 	group?: string;
-	/** Handler to execute when the shortcut is triggered */
-	handler: (e: KeyboardEvent) => void;
+	/** Whether the action should be triggered on press or hold */
+	triggeredOn?: "press" | "hold";
+	/** Handler to execute when the shortcut is triggered (on keydown) */
+	handler?: (e: KeyboardEvent) => void;
+	/** Handler to execute while the shortcut keys are held down (on keydown) */
+	onHold?: (e: KeyboardEvent) => void;
+	/** Handler to execute when the shortcut keys are released (on keyup) */
+	onRelease?: (e: KeyboardEvent) => void;
 	/** Whether to prevent default browser behavior (default: true) */
 	preventDefault?: boolean;
 	/** Whether the shortcut should work when an input/textarea is focused (default: false) */
@@ -38,6 +44,9 @@ export interface RegisteredShortcut {
 const activeShortcuts = reactive<RegisteredShortcut[]>([]);
 const shortcutHandlers = new Map<symbol, ShortcutConfig>();
 
+// Track which shortcut keys are currently held down
+const heldShortcuts = new Set<symbol>();
+
 let listenerAttached = false;
 
 function attachGlobalListener() {
@@ -45,6 +54,7 @@ function attachGlobalListener() {
 	listenerAttached = true;
 
 	document.addEventListener("keydown", globalKeydownHandler);
+	document.addEventListener("keyup", globalKeyupHandler);
 }
 
 function globalKeydownHandler(e: KeyboardEvent) {
@@ -64,9 +74,73 @@ function globalKeydownHandler(e: KeyboardEvent) {
 			e.preventDefault();
 		}
 
-		config.handler(e);
+		config.handler?.(e);
+		// Mark as held if not already held
+		if (config.triggeredOn === "hold" && !heldShortcuts.has(id)) {
+			heldShortcuts.add(id);
+
+			// Call onHold if provided and this is the initial press
+			if (config.onHold) {
+				config.onHold(e);
+			}
+		}
+
 		return; // Only fire the first match
 	}
+}
+
+function globalKeyupHandler(e: KeyboardEvent) {
+	if (isDialogOpen()) return;
+
+	// Check all held shortcuts to see if any are still active
+	// If a modifier key is released, we need to detect that the combo is no longer valid
+	const idsToRelease: symbol[] = [];
+
+	for (const id of heldShortcuts) {
+		const config = shortcutHandlers.get(id);
+		if (!config || config.triggeredOn !== "hold") continue;
+
+		// Check if the combo is still valid. If not, it's time to release.
+		if (!isShortcutStillPressed(e, config)) {
+			idsToRelease.push(id);
+		}
+	}
+
+	// Process releases
+	for (const id of idsToRelease) {
+		const config = shortcutHandlers.get(id);
+		if (!config) continue;
+
+		// Call onRelease if provided
+		if (config.onRelease) {
+			config.onRelease(e);
+		}
+
+		// Remove from held shortcuts
+		heldShortcuts.delete(id);
+	}
+
+	if (idsToRelease.length > 0 && !shortcutHandlers.values().next().value?.preventDefault === false) {
+		// e.preventDefault();
+	}
+}
+
+function isShortcutStillPressed(e: KeyboardEvent, config: ShortcutConfig): boolean {
+	// Check if the main key is still being pressed (heuristic: if this key was released, the combo isn't pressed)
+	// However, we can't directly tell which keys are still pressed from a keyup event
+	// So we check if the modifiers that are required are no longer all satisfied
+
+	const wantsCtrl = config.ctrl ?? false;
+	const wantsShift = config.shift ?? false;
+	const hasCtrl = isCtrlOrCmd(e);
+	const hasShift = e.shiftKey;
+
+	// If we want Ctrl but it's not pressed (user released Ctrl), combo is no longer valid
+	if (wantsCtrl && !hasCtrl) return false;
+	// If we want Shift but it's not pressed (user released Shift), combo is no longer valid
+	if (wantsShift && !hasShift) return false;
+
+	return true;
 }
 
 function matchesShortcut(e: KeyboardEvent, config: ShortcutConfig): boolean {
@@ -159,6 +233,7 @@ export function useShortcut(shortcuts: ShortcutConfig | ShortcutConfig[]) {
 	const removeShortcuts = () => {
 		for (const id of registeredIds) {
 			shortcutHandlers.delete(id);
+			heldShortcuts.delete(id);
 			const idx = activeShortcuts.findIndex((s) => s.id === id);
 			if (idx !== -1) activeShortcuts.splice(idx, 1);
 		}


### PR DESCRIPTION
Now users can use shortcuts to highlight and visually distinguish blocks which have scripts. This solves the poor user experience of having to hunt through blocks to find which one had script(s).

There are two "press and hold" shortcuts - one shows blocks having data scripts and the other shows blocks having client scripts.

This PR also now allows "press and hold" shortcuts to be coded.

https://github.com/user-attachments/assets/7ca64ccc-a91d-439c-bc1e-8a1028948d50

