### PR TITLE
fix(UX): Auto fetch container name when saved as component

### DIFF
--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -436,7 +436,8 @@ watch(
 		const mode = builderSettings.doc?.execute_block_scripts_in_editor;
 		if (mode === "Don't Execute") return;
 
-		if (mode === "Restricted") executeBlockClientScriptRestricted(uidToUse, props.breakpoint, script, allResolvedProps.value);
+		if (mode === "Restricted")
+			executeBlockClientScriptRestricted(uidToUse, props.breakpoint, script, allResolvedProps.value);
 		else executeBlockClientScriptUnrestricted(uidToUse, props.breakpoint, script, allResolvedProps.value);
 	},
 	{ immediate: true },

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex h-[90vh] max-h-[800px] overflow-hidden">
+	<div class="flex h-[88vh] max-h-[800px] overflow-hidden">
 		<div class="flex w-48 shrink-0 flex-col gap-5 bg-surface-gray-1 p-4 px-2">
 			<span class="px-2 text-lg font-semibold text-ink-gray-9">Settings</span>
 			<div class="flex flex-col" v-for="(item, index) in settingsSidebarItems" :key="index">

--- a/frontend/src/components/Controls/Input.vue
+++ b/frontend/src/components/Controls/Input.vue
@@ -97,6 +97,8 @@ const { hasNumber, incrementValue, decrementValue } = useNumberInput({
 
 const clearValue = () => {
 	data.value = "";
+	emit("update:modelValue", "");
+	emit("input", "");
 };
 
 const triggerUpdate = useDebounceFn(($event: Event) => {

--- a/frontend/src/components/Modals/NewComponent.vue
+++ b/frontend/src/components/Modals/NewComponent.vue
@@ -49,7 +49,6 @@ const props = defineProps<{
 	block: Block;
 }>();
 
-// Add defineModel and fix the watch
 const model = defineModel<boolean>();
 
 const componentName = ref(props.block.blockName || "");

--- a/frontend/src/components/Modals/NewComponent.vue
+++ b/frontend/src/components/Modals/NewComponent.vue
@@ -1,5 +1,6 @@
 <template>
 	<Dialog
+		v-model="model"
 		:options="{
 			title: 'New Component',
 			size: 'sm',
@@ -38,7 +39,7 @@ import usePageStore from "@/stores/pageStore";
 import { posthog } from "@/telemetry";
 import { BuilderComponent } from "@/types/Builder/BuilderComponent";
 import { getBlockCopy, getBlockString } from "@/utils/helpers";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 const componentStore = useComponentStore();
 const canvasStore = useCanvasStore();
@@ -48,7 +49,16 @@ const props = defineProps<{
 	block: Block;
 }>();
 
-const componentName = ref("");
+// Add defineModel and fix the watch
+const model = defineModel<boolean>();
+
+const componentName = ref(props.block.blockName || "");
+
+watch(model, (isOpen) => {
+	if (isOpen) {
+		componentName.value = props.block.blockName || "";
+	}
+});
 const isGlobalComponent = ref(0);
 
 const createComponentHandler = async (context: { close: () => void }) => {


### PR DESCRIPTION
This improves UX, the New Component modal auto fetches the name of the container as the component name.


Before:

https://github.com/user-attachments/assets/9826b16a-e04f-4ea6-8275-f79e44731f22

After:

https://github.com/user-attachments/assets/8dab3c3e-fabe-4037-95e7-66f5928d3c63



