### PR TITLE
fix: InlineInput padding

### DIFF
--- a/frontend/src/components/Controls/Input.vue
+++ b/frontend/src/components/Controls/Input.vue
@@ -22,7 +22,7 @@
 			<template #prefix v-if="$slots.prefix">
 				<slot name="prefix" />
 			</template>
-			<template #suffix>
+			<template v-if="hasSuffix" #suffix>
 				<NumberArrows
 					:modelValue="hasNumber"
 					v-if="!disabled && hasNumber && isStrictNumber"
@@ -32,7 +32,7 @@
 				<slot v-if="$slots.suffix" name="suffix" />
 
 				<button
-					v-if="!['select', 'checkbox'].includes(type) && !hideClearButton && data && !disabled"
+					v-if="showClearButton"
 					class="cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
 					tabindex="-1"
 					@click="clearValue">
@@ -100,6 +100,17 @@ const clearValue = () => {
 	emit("update:modelValue", "");
 	emit("input", "");
 };
+const showClearButton = computed(() => {
+	return (
+		!["select", "checkbox"].includes(props.type) && !props.hideClearButton && data.value && !props.disabled
+	);
+});
+
+const hasSuffix = computed(() => {
+	const hasClearButton = showClearButton.value;
+	const hasNumberArrows = !props.disabled && hasNumber.value && isStrictNumber.value;
+	return hasClearButton || hasNumberArrows || !!attrs.suffix;
+});
 
 const triggerUpdate = useDebounceFn(($event: Event) => {
 	if (props.type === "checkbox") {

--- a/frontend/src/components/Controls/NumberArrows.vue
+++ b/frontend/src/components/Controls/NumberArrows.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="modelValue"
-		class="pointer-events-none flex flex-col gap-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+		class="pointer-events-none flex flex-col gap-0 opacity-100 transition-opacity group-hover:pointer-events-auto">
 		<button
 			type="button"
 			class="circle-cursor duration-250 -mb-[1.5px] flex h-3 w-5 items-center justify-center rounded text-ink-gray-5 transition-all ease-in-out active:-translate-y-[2px] active:text-ink-gray-9"


### PR DESCRIPTION
InlineInput now renders "suffix" conditionally to avoid adding extra padding to the right where not needed.
NumberArrows are always visible if it is a number field to avoid inconsistency.

fixes: #562 