### PR TITLE
fix: input suffix padding and visibility for NumberArrows component

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -7,7 +7,10 @@
 		:reset-search-term-on-blur="false">
 		<div class="group/autocomplete relative" ref="containerRef">
 			<div
-				class="group form-input flex h-7 flex-1 items-center gap-2 rounded bg-surface-gray-2 p-0 text-sm text-ink-gray-8 transition-colors focus-within:bg-surface-white focus-within:ring-2 focus-within:ring-outline-gray-3">
+				class="group form-input flex h-7 flex-1 items-center gap-2 rounded bg-surface-gray-2 p-0 text-sm text-ink-gray-8 transition-colors focus-within:bg-surface-white focus-within:ring-2 focus-within:ring-outline-gray-3"
+				:class="{
+					'can-show-arrows': canShowArrows,
+				}">
 				<div v-if="$slots.prefix" class="flex items-center pl-2">
 					<slot name="prefix" />
 				</div>
@@ -28,12 +31,11 @@
 					class="h-full w-full flex-1 border-none bg-transparent px-0 text-base placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 					:class="{
 						'pl-2': !$slots.prefix,
-						'pr-2': !hasValue,
+						'pr-2': !hasValue && !canShowArrows,
 					}" />
-				<div class="flex items-center gap-0">
+				<div class="flex items-center gap-0.5">
 					<NumberArrows
-						v-if="hasNumber && isStrictNumber"
-						class="ml-1"
+						v-if="canShowArrows"
 						:modelValue="hasNumber"
 						@increment="incrementValue"
 						@decrement="decrementValue" />
@@ -189,6 +191,8 @@ const isStrictNumber = computed(() => {
 	return /^\d*\.?\d+(px|%|em|rem)?$/.test(props.modelValue.trim());
 });
 
+const canShowArrows = computed(() => hasNumber.value && isStrictNumber.value);
+
 const displayOptions = computed(() => {
 	let options = allOptions.value;
 	if (
@@ -313,3 +317,8 @@ defineExpose({
 	clearSelection,
 });
 </script>
+<style scoped>
+.can-show-arrows:hover {
+	gap: 3px !important;
+}
+</style>

--- a/frontend/src/components/Controls/InlineInput.vue
+++ b/frontend/src/components/Controls/InlineInput.vue
@@ -1,9 +1,5 @@
 <template>
-	<div
-		class="flex items-center justify-between gap-2"
-		:class="{
-			'[&>div>input]:pr-6': !hideClearButton,
-		}">
+	<div class="flex items-center justify-between gap-2">
 		<InputLabel
 			v-if="label"
 			:class="{

--- a/frontend/src/components/Controls/Input.vue
+++ b/frontend/src/components/Controls/Input.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="group relative w-full">
+	<div ref="containerRef" class="group relative w-full" :class="paddingClass">
 		<Select
 			v-if="type === 'select'"
 			:modelValue="data as string"
@@ -22,22 +22,24 @@
 			<template #prefix v-if="$slots.prefix">
 				<slot name="prefix" />
 			</template>
-			<template #suffix>
-				<NumberArrows
-					:modelValue="hasNumber"
-					v-if="!disabled && hasNumber && isStrictNumber"
-					@increment="incrementValue"
-					@decrement="decrementValue" />
+			<template #suffix v-if="hasSuffix">
+				<div class="flex items-center gap-0.5">
+					<NumberArrows
+						:modelValue="hasNumber"
+						v-if="canShowArrows"
+						@increment="incrementValue"
+						@decrement="decrementValue" />
 
-				<slot v-if="$slots.suffix" name="suffix" />
+					<slot v-if="$slots.suffix" name="suffix" />
 
-				<button
-					v-if="!['select', 'checkbox'].includes(type) && !hideClearButton && data && !disabled"
-					class="cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
-					tabindex="-1"
-					@click="clearValue">
-					<CrossIcon />
-				</button>
+					<button
+						v-if="hasClearButton"
+						class="cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
+						tabindex="-1"
+						@click="clearValue">
+						<CrossIcon />
+					</button>
+				</div>
 			</template>
 		</FormControl>
 	</div>
@@ -46,9 +48,9 @@
 import NumberArrows from "@/components/Controls/NumberArrows.vue";
 import CrossIcon from "@/components/Icons/Cross.vue";
 import { useNumberInput } from "@/utils/useNumberInput";
-import { useDebounceFn, useVModel } from "@vueuse/core";
+import { useDebounceFn, useResizeObserver, useVModel } from "@vueuse/core";
 import { Select } from "frappe-ui";
-import { computed, useAttrs } from "vue";
+import { computed, ref, useAttrs, useSlots } from "vue";
 
 const props = withDefaults(
 	defineProps<{
@@ -85,6 +87,31 @@ defineOptions({
 });
 
 const attrs = useAttrs();
+const slots = useSlots();
+
+const containerRef = ref<HTMLElement | null>(null);
+const containerWidth = ref(Infinity);
+useResizeObserver(containerRef, (entries) => {
+	containerWidth.value = entries[0].contentRect.width;
+});
+
+const canShowArrows = computed(
+	() => !props.disabled && hasNumber.value && isStrictNumber.value && containerWidth.value >= 60,
+);
+
+const hasClearButton = computed(
+	() =>
+		!["select", "checkbox"].includes(props.type) && !props.hideClearButton && !!data.value && !props.disabled,
+);
+
+const hasSuffix = computed(() => canShowArrows.value || hasClearButton.value || !!slots.suffix);
+
+const paddingClass = computed(() => {
+	if (canShowArrows.value && hasClearButton.value) return "has-both-suffix";
+	if (canShowArrows.value && !hasClearButton.value) return "arrows-only-suffix";
+	if (!canShowArrows.value && hasClearButton.value) return "cross-only-suffix";
+	return "";
+});
 
 const { hasNumber, incrementValue, decrementValue } = useNumberInput({
 	getValue: () => data.value,
@@ -129,6 +156,31 @@ input[type="number"]::-webkit-inner-spin-button {
 input[type="number"] {
 	-moz-appearance: textfield !important;
 	appearance: textfield !important;
-	padding-right: 0.75rem !important;
+}
+</style>
+
+<style scoped>
+.arrows-only-suffix :deep(input + div) {
+	padding-inline-end: 3px;
+}
+
+.arrows-only-suffix :deep(input) {
+	padding-inline-end: 3px;
+}
+
+.arrows-only-suffix:hover :deep(input) {
+	padding-right: 1.4rem !important;
+}
+
+.cross-only-suffix :deep(input) {
+	padding-right: 1.8rem !important;
+}
+
+.has-both-suffix :deep(input) {
+	padding-right: 1.5rem !important;
+}
+
+.has-both-suffix:hover :deep(input) {
+	padding-right: 2.8rem !important;
 }
 </style>

--- a/frontend/src/components/Controls/NumberArrows.vue
+++ b/frontend/src/components/Controls/NumberArrows.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="modelValue"
-		class="pointer-events-none flex flex-col gap-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+		class="pointer-events-none hidden flex-col gap-0 transition-opacity group-hover:pointer-events-auto group-hover:flex">
 		<button
 			type="button"
 			class="circle-cursor duration-250 -mb-[1.5px] flex h-3 w-5 items-center justify-center rounded text-ink-gray-5 transition-all ease-in-out active:-translate-y-[2px] active:text-ink-gray-9"


### PR DESCRIPTION
This now considers everything (presence of number arrows with clear button, hover state, only number arrows and only clear button) and sets padding accordingly

**Before:**
<img height="200" alt="image" src="https://github.com/user-attachments/assets/f3ec1d4a-bf04-4bce-8be8-df195c4d26e5" />



**Now:**
- Hovering over input with only number arrows

	https://github.com/user-attachments/assets/e3ba2cef-366d-4e77-ac43-58bae11ceed9

- Hovering over input with both number and clear button

	https://github.com/user-attachments/assets/d39e8e6e-e8f5-442e-b6b3-8e3a52beb3fa

- Only with clear button
	<img width="276" height="50" alt="Screenshot 2026-05-05 at 12 06 15 PM" src="https://github.com/user-attachments/assets/0dfaddc6-5853-4f08-a919-eaf432e3bb79" />

- No padding unless value is set

	https://github.com/user-attachments/assets/b6f109d8-a3fe-44a3-9e73-03b197a1765e

