### PR TITLE
fix: spacing placeholder shows 'unset' correctly

### DIFF
--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -963,7 +963,8 @@ function getBoxSpacing(
 ): string {
 	const nativeOnly = opts?.nativeOnly ?? false;
 	const cascading = opts?.cascading ?? false;
-	const base = String(block.getStyle(type, undefined, nativeOnly, cascading) ?? "0px");
+	const baseValue = block.getStyle(type, undefined, nativeOnly, cascading);
+	const base = String(baseValue ?? (nativeOnly && !cascading ? "" : "unset"));
 	const top = block.getStyle(`${type}Top`, undefined, nativeOnly, cascading) ?? base;
 	const bottom = block.getStyle(`${type}Bottom`, undefined, nativeOnly, cascading) ?? base;
 	const left = block.getStyle(`${type}Left`, undefined, nativeOnly, cascading) ?? base;


### PR DESCRIPTION
**Issue**
Padding and margin values show 0 or blank instead of unset for new components.

**Fix**
Updated spacing fallback logic so padding and margin match the other property controls.

Fixes #535

**Before**

https://github.com/user-attachments/assets/d7d1cf4d-b304-4b02-8628-b9c6658ca954


**After**

https://github.com/user-attachments/assets/2b1aaa08-1ac3-466d-9c34-cb9f968d7748

cc @surajshetty3416 