### PR TITLE
fix(RouteTreeView): Misc UX improvements

### DIFF
--- a/frontend/src/components/DashboardContent.vue
+++ b/frontend/src/components/DashboardContent.vue
@@ -35,7 +35,7 @@
 				<div v-if="displayType === 'tree'">
 					<RouteTreeView
 						ref="routeTreeRef"
-						class="pr-3"
+						class="pl-2 pr-3"
 						:search-filter="searchFilter"
 						:active-folder="builderStore.activeFolder" />
 				</div>

--- a/frontend/src/components/DashboardContent.vue
+++ b/frontend/src/components/DashboardContent.vue
@@ -33,13 +33,17 @@
 				</div>
 				<!-- tree -->
 				<div v-if="displayType === 'tree'">
-					<RouteTreeView ref="routeTreeRef" class="pr-3" :pages="webPages.data || []" />
+					<RouteTreeView
+						ref="routeTreeRef"
+						class="pr-3"
+						:search-filter="searchFilter"
+						:active-folder="builderStore.activeFolder" />
 				</div>
 			</div>
 			<BuilderButton
 				class="m-auto mt-12 w-fit text-sm"
 				@click="loadMore"
-				v-if="webPages.data?.length && webPages.hasNextPage"
+				v-if="webPages.data?.length && webPages.hasNextPage && displayType !== 'tree'"
 				variant="subtle"
 				size="sm">
 				Load More
@@ -64,7 +68,6 @@
 							type="text"
 							placeholder="Filter by title or route"
 							v-model="searchFilter"
-							autofocus
 							@input="
 								(value: string) => {
 									searchFilter = value;

--- a/frontend/src/components/PageActionsDropdown.vue
+++ b/frontend/src/components/PageActionsDropdown.vue
@@ -17,6 +17,12 @@
 						condition: () => Boolean(props.page.published),
 					},
 					{
+						label: 'Unpublish',
+						onClick: () => pageStore.unpublishPage(props.page),
+						icon: 'lucide-cloud-off',
+						condition: () => Boolean(props.page.published),
+					},
+					{
 						label: 'View in Desk',
 						onClick: () => openInDesk(props.page),
 						icon: 'arrow-up-right',

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -1,66 +1,138 @@
 <template>
 	<div>
-		<template v-for="(node, idx) in visibleNodes" :key="node.id">
-			<div
-				class="group flex items-center gap-1.5 border-b border-outline-gray-1 px-1 py-1 hover:rounded-md hover:bg-surface-gray-1"
-				:style="{ marginLeft: `${node.depth * 24 + 4}px` }">
-				<Button
-					v-if="node.hasChildren"
-					variant="ghost"
-					@click="toggleNode(node)"
-					:icon="node.expanded ? 'chevron-down' : 'chevron-right'"></Button>
-				<span v-else class="size-6 shrink-0"></span>
-				<FeatherIcon
-					v-if="node.hasChildren"
-					name="hash"
-					class="size-3.5 shrink-0"
-					:class="node.depth === 0 ? 'text-ink-gray-7' : 'text-ink-gray-4'" />
-				<FeatherIcon v-else name="file-minus" class="size-3.5 shrink-0 text-ink-gray-4" />
+		<div v-if="pagesResource.loading && !pages.length" class="px-3 py-6 text-center text-sm text-ink-gray-4">
+			Loading pages…
+		</div>
+		<div
+			v-else-if="!pagesResource.loading && !pages.length"
+			class="px-3 py-6 text-center text-sm text-ink-gray-4">
+			No pages found.
+		</div>
 
-				<router-link
-					v-if="node.page"
-					:to="{ name: 'builder', params: { pageId: node.page.page_name } }"
-					class="flex min-w-0 flex-1 items-center gap-2 py-0.5">
-					<code class="shrink-0 px-1.5 py-0.5 font-mono text-xs font-medium text-ink-gray-8">
-						/{{ node.label }}
-					</code>
-					<span
-						v-if="node.page.page_title"
-						class="truncate text-sm text-ink-gray-5"
-						:title="node.page.page_title">
-						{{ node.page.page_title }}
-					</span>
-				</router-link>
+		<div
+			v-else
+			ref="treeRef"
+			tabindex="0"
+			@focus="isFocused = true"
+			@blur="isFocused = false"
+			class="focus:outline-none">
+			<template v-for="node in visibleNodes" :key="node.id">
+				<!-- Load more row -->
+				<div
+					v-if="node.isLoadMore"
+					class="flex items-center py-0.5"
+					:style="{ marginLeft: `${node.depth * 24 + 4 + 32}px` }">
+					<button
+						class="flex items-center gap-1 text-xs text-ink-gray-4 hover:text-ink-gray-7"
+						@click="loadMore(node)">
+						<FeatherIcon name="more-horizontal" class="size-3" />
+						Load {{ Math.min(PAGE_LIMIT_PER_NODE, node.totalCount - node.loadedCount) }} more
+						<span class="ml-0.5 text-ink-gray-3">({{ node.totalCount - node.loadedCount }} remaining)</span>
+					</button>
+				</div>
 
-				<button v-else class="flex min-w-0 flex-1 items-center gap-1 py-0.5" @click="toggleNode(node)">
-					<span
-						class="font-mono text-sm font-semibold"
-						:class="node.depth === 0 ? 'text-ink-gray-8' : 'text-ink-gray-6'">
-						/{{ node.label }}
-					</span>
-				</button>
+				<!-- Regular tree node -->
+				<div
+					v-else
+					class="group flex cursor-pointer items-center gap-1.5 border-b border-outline-gray-1 px-1 py-1 hover:rounded-md hover:bg-surface-gray-1"
+					:class="{ 'rounded-md bg-surface-gray-2 ring-1 ring-outline-gray-3': focusedNodeId === node.id }"
+					:ref="
+						(el) => {
+							if (el) nodeEls.set(node.id, el as HTMLElement);
+						}
+					"
+					:style="{ marginLeft: `${node.depth * 24 + 4}px` }"
+					@click="selectNode(node)"
+					@dblclick="activateNode(node)">
+					<Button
+						v-if="node.hasChildren"
+						variant="ghost"
+						@click.stop="toggleNode(node)"
+						:icon="node.expanded ? 'chevron-down' : 'chevron-right'"></Button>
+					<span v-else class="size-6 shrink-0"></span>
+					<FeatherIcon
+						v-if="node.hasChildren"
+						name="hash"
+						class="size-3.5 shrink-0"
+						:class="node.depth === 0 ? 'text-ink-gray-7' : 'text-ink-gray-4'" />
+					<FeatherIcon v-else name="file-minus" class="size-3.5 shrink-0 text-ink-gray-4" />
 
-				<PageActionsDropdown v-if="node.page" :page="node.page" size="xs" placement="right">
-					<template v-slot="{ open }">
-						<BuilderButton
-							icon="more-horizontal"
-							size="sm"
-							variant="subtle"
-							class="invisible bg-surface-white !text-ink-gray-5 hover:!text-ink-gray-9 group-hover:visible"
-							@click="open"></BuilderButton>
-					</template>
-				</PageActionsDropdown>
-			</div>
-		</template>
+					<!-- Page node label row -->
+					<div v-if="node.page" class="flex min-w-0 flex-1 items-center gap-2 py-0.5">
+						<code class="shrink-0 px-1.5 py-0.5 font-mono text-xs font-medium text-ink-gray-8">
+							/{{ node.label }}
+						</code>
+						<span
+							v-if="node.page.page_title"
+							class="truncate text-sm text-ink-gray-5"
+							:title="node.page.page_title">
+							{{ node.page.page_title }}
+						</span>
+						<!-- Status icons -->
+						<span class="ml-auto flex shrink-0 items-center gap-1 pr-1">
+							<Tooltip v-if="isHomePage(node.page)" text="Home page" :hoverDelay="0.5">
+								<FeatherIcon name="home" class="size-3 text-ink-gray-4" />
+							</Tooltip>
+							<Tooltip
+								v-if="node.page.authenticated_access"
+								text="Restricted – login required"
+								:hoverDelay="0.5">
+								<FeatherIcon name="lock" class="size-3 text-ink-amber-3" />
+							</Tooltip>
+							<Tooltip v-if="!node.page.published" text="Draft – not published" :hoverDelay="0.5">
+								<FeatherIcon name="eye-off" class="size-3 text-ink-gray-4" />
+							</Tooltip>
+						</span>
+					</div>
+
+					<!-- Folder node label -->
+					<div v-else class="flex min-w-0 flex-1 items-center gap-1 py-0.5">
+						<span
+							class="font-mono text-sm font-semibold"
+							:class="node.depth === 0 ? 'text-ink-gray-8' : 'text-ink-gray-6'">
+							/{{ node.label }}
+						</span>
+					</div>
+
+					<PageActionsDropdown v-if="node.page" :page="node.page" size="xs" placement="right">
+						<template v-slot="{ open }">
+							<BuilderButton
+								icon="more-horizontal"
+								size="sm"
+								variant="subtle"
+								class="invisible bg-surface-white !text-ink-gray-5 hover:!text-ink-gray-9 group-hover:visible"
+								@click.stop></BuilderButton>
+						</template>
+					</PageActionsDropdown>
+				</div>
+			</template>
+		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
 import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
+import { builderSettings } from "@/data/builderSettings";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
-import { computed, ref } from "vue";
+import { useShortcut } from "@/utils/useShortcut";
+import { createListResource, Tooltip } from "frappe-ui";
+import { computed, onBeforeUpdate, ref, watch, watchEffect } from "vue";
+import { useRouter } from "vue-router";
 
-interface TreeNode {
+const props = withDefaults(
+	defineProps<{
+		searchFilter?: string;
+		activeFolder?: string;
+	}>(),
+	{ searchFilter: "", activeFolder: "" },
+);
+
+const PAGE_LIMIT_PER_NODE = 50;
+const AUTO_COLLAPSE_THRESHOLD = 100;
+
+const router = useRouter();
+
+interface Node {
 	id: string;
 	label: string;
 	fullPath: string;
@@ -69,22 +141,65 @@ interface TreeNode {
 	hasChildren: boolean;
 	expanded: boolean;
 	parentId: string | null;
+	isLoadMore?: false;
 }
+
+interface LoadMoreNode {
+	id: string;
+	depth: number;
+	parentId: string | null;
+	isLoadMore: true;
+	targetNodeId: string;
+	loadedCount: number;
+	totalCount: number;
+}
+
+type TreeNode = Node | LoadMoreNode;
 
 type TrieNode = {
 	page: BuilderPage | null;
 	children: Map<string, TrieNode>;
 };
 
-const props = defineProps<{
-	pages: BuilderPage[];
-}>();
+const pagesResource = createListResource({
+	method: "GET",
+	doctype: "Builder Page",
+	fields: ["name", "route", "page_name", "page_title", "published", "authenticated_access", "project_folder"],
+	filters: { is_template: 0 },
+	orderBy: "route asc",
+	pageLength: 9999,
+	auto: true,
+});
+
+const pages = computed<BuilderPage[]>(() => {
+	let result: BuilderPage[] = pagesResource.data ?? [];
+	if (props.activeFolder) {
+		result = result.filter((p) => p.project_folder === props.activeFolder);
+	}
+	if (props.searchFilter) {
+		const q = props.searchFilter.toLowerCase();
+		result = result.filter(
+			(p) => p.page_title?.toLowerCase().includes(q) || p.route?.toLowerCase().includes(q),
+		);
+	}
+	return result;
+});
 
 const collapsedNodes = ref(new Set<string>());
+const loadedCounts = ref(new Map<string, number>());
+const focusedNodeId = ref<string | null>(null);
+const treeRef = ref<HTMLElement | null>(null);
+const nodeEls = ref(new Map<string, HTMLElement>());
+const initialized = ref(false);
+const isFocused = ref(false);
 
-function buildTrie(pages: BuilderPage[]): Map<string, TrieNode> {
+onBeforeUpdate(() => {
+	nodeEls.value.clear();
+});
+
+function buildTrie(pageList: BuilderPage[]): Map<string, TrieNode> {
 	const root: Map<string, TrieNode> = new Map();
-	for (const page of pages) {
+	for (const page of pageList) {
 		const segments = (page.route || "").split("/").filter(Boolean);
 		let current = root;
 		for (let i = 0; i < segments.length; i++) {
@@ -102,16 +217,25 @@ function buildTrie(pages: BuilderPage[]): Map<string, TrieNode> {
 	return root;
 }
 
+function getLimit(nodeId: string): number {
+	return loadedCounts.value.get(nodeId) ?? PAGE_LIMIT_PER_NODE;
+}
+
 const visibleNodes = computed<TreeNode[]>(() => {
-	const trie = buildTrie(props.pages);
+	const trie = buildTrie(pages.value);
 	const result: TreeNode[] = [];
 
 	function traverse(map: Map<string, TrieNode>, depth: number, parentPath: string, parentId: string | null) {
-		for (const [label, trieNode] of map) {
+		const entries = Array.from(map.entries());
+		const limitKey = parentId ?? "__root__";
+		const limit = getLimit(limitKey);
+		const visible = entries.slice(0, limit);
+
+		for (const [label, trieNode] of visible) {
 			const fullPath = parentPath ? `${parentPath}/${label}` : label;
 			const id = fullPath;
 			const hasChildren = trieNode.children.size > 0;
-			const expanded = !collapsedNodes.value.has(id);
+			const expanded = !!props.searchFilter || !collapsedNodes.value.has(id);
 
 			result.push({
 				id,
@@ -128,13 +252,38 @@ const visibleNodes = computed<TreeNode[]>(() => {
 				traverse(trieNode.children, depth + 1, fullPath, id);
 			}
 		}
+
+		if (entries.length > limit) {
+			result.push({
+				id: `__load_more__${limitKey}`,
+				depth,
+				parentId,
+				isLoadMore: true,
+				targetNodeId: limitKey,
+				loadedCount: limit,
+				totalCount: entries.length,
+			});
+		}
 	}
 
 	traverse(trie, 0, "", null);
 	return result;
 });
 
-function toggleNode(node: TreeNode) {
+function selectNode(node: Node) {
+	focusedNodeId.value = node.id;
+	treeRef.value?.focus({ preventScroll: true });
+}
+
+function activateNode(node: Node) {
+	if (node.page?.page_name) {
+		router.push({ name: "builder", params: { pageId: node.page.page_name } });
+	} else if (node.hasChildren) {
+		toggleNode(node);
+	}
+}
+
+function toggleNode(node: Node) {
 	const next = new Set(collapsedNodes.value);
 	if (next.has(node.id)) {
 		next.delete(node.id);
@@ -144,8 +293,14 @@ function toggleNode(node: TreeNode) {
 	collapsedNodes.value = next;
 }
 
+function loadMore(node: LoadMoreNode) {
+	const next = new Map(loadedCounts.value);
+	next.set(node.targetNodeId, node.loadedCount + PAGE_LIMIT_PER_NODE);
+	loadedCounts.value = next;
+}
+
 function getAllParentIds(): string[] {
-	const trie = buildTrie(props.pages);
+	const trie = buildTrie(pages.value);
 	const ids: string[] = [];
 	function collect(map: Map<string, TrieNode>, parentPath: string) {
 		for (const [label, trieNode] of map) {
@@ -168,5 +323,119 @@ function collapseAll() {
 	collapsedNodes.value = new Set(getAllParentIds());
 }
 
-defineExpose({ expandAll, collapseAll });
+function isHomePage(page: BuilderPage): boolean {
+	return builderSettings.doc?.home_page === page.route;
+}
+
+function refresh() {
+	pagesResource.reload();
+}
+
+watchEffect(() => {
+	if (!initialized.value && pages.value.length > 0) {
+		initialized.value = true;
+		if (pages.value.length > AUTO_COLLAPSE_THRESHOLD) {
+			collapseAll();
+		}
+	}
+});
+
+watch([() => props.searchFilter, () => props.activeFolder], () => {
+	if (props.searchFilter) return; // search force-expands nodes in the trie traversal
+	if (pages.value.length > AUTO_COLLAPSE_THRESHOLD) {
+		collapseAll();
+	} else {
+		expandAll();
+	}
+});
+
+function regularNodes(): Node[] {
+	return visibleNodes.value.filter((n): n is Node => !n.isLoadMore);
+}
+
+function currentNodes() {
+	const nodes = regularNodes();
+	const idx = focusedNodeId.value ? nodes.findIndex((n) => n.id === focusedNodeId.value) : -1;
+	return { nodes, idx };
+}
+
+function focusNode(idx: number, nodes: Node[]) {
+	if (idx < 0 || idx >= nodes.length) return;
+	focusedNodeId.value = nodes[idx].id;
+	nodeEls.value.get(nodes[idx].id)?.scrollIntoView({ block: "nearest" });
+}
+
+const treeActive = () => regularNodes().length > 0;
+
+useShortcut([
+	{
+		key: "ArrowDown",
+		description: "Move down in page tree",
+		group: "Page Tree",
+		condition: treeActive,
+		handler: () => {
+			const { nodes, idx } = currentNodes();
+			focusNode(idx === -1 ? 0 : idx + 1, nodes);
+		},
+	},
+	{
+		key: "ArrowUp",
+		description: "Move up in page tree",
+		group: "Page Tree",
+		condition: treeActive,
+		handler: () => {
+			const { nodes, idx } = currentNodes();
+			focusNode(Math.max(0, idx - 1), nodes);
+		},
+	},
+	{
+		key: "ArrowRight",
+		description: "Expand node or move down in page tree",
+		group: "Page Tree",
+		condition: treeActive,
+		handler: () => {
+			const { nodes, idx } = currentNodes();
+			const node = nodes[idx];
+			if (!node) {
+				focusNode(0, nodes);
+				return;
+			}
+			if (node.hasChildren && collapsedNodes.value.has(node.id)) {
+				toggleNode(node);
+			} else {
+				focusNode(idx + 1, nodes);
+			}
+		},
+	},
+	{
+		key: "ArrowLeft",
+		description: "Collapse node or move up in page tree",
+		group: "Page Tree",
+		condition: treeActive,
+		handler: () => {
+			const { nodes, idx } = currentNodes();
+			const node = nodes[idx];
+			if (!node) return;
+			if (node.hasChildren && !collapsedNodes.value.has(node.id)) {
+				toggleNode(node);
+			} else {
+				focusNode(idx - 1, nodes);
+			}
+		},
+	},
+	{
+		key: "Enter",
+		description: "Open page or toggle folder in page tree",
+		group: "Page Tree",
+		condition: treeActive,
+		handler: () => {
+			const { nodes, idx } = currentNodes();
+			const node = nodes[idx];
+			if (!node) return;
+			activateNode(node);
+		},
+	},
+]);
+
+defineExpose({ expandAll, collapseAll, refresh });
 </script>

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -20,7 +20,7 @@
 				<!-- Load more row -->
 				<div
 					v-if="node.isLoadMore"
-					class="flex items-center py-0.5"
+					class="flex items-center pt-2"
 					:style="{ marginLeft: `${node.depth * 24 + 4 + 32}px` }">
 					<button
 						class="flex items-center gap-1 text-xs text-ink-gray-4 hover:text-ink-gray-7"
@@ -35,30 +35,27 @@
 				<div
 					v-else
 					class="group flex cursor-pointer items-center gap-1.5 border-b border-outline-gray-1 px-1 py-1 hover:rounded-md hover:bg-surface-gray-1"
-					:class="{ 'rounded-md bg-surface-gray-2 ring-1 ring-outline-gray-3': focusedNodeId === node.id }"
+					:class="{ 'rounded-md !bg-surface-gray-2 ': focusedNodeId === node.id }"
 					:ref="
 						(el) => {
 							if (el) nodeEls.set(node.id, el as HTMLElement);
 						}
 					"
-					:style="{ marginLeft: `${node.depth * 24 + 4}px` }"
+					:style="{ marginLeft: `${node.depth * 24}px` }"
 					@click="selectNode(node)"
 					@dblclick="activateNode(node)">
 					<Button
 						v-if="node.hasChildren"
 						variant="ghost"
+						class="!text-ink-gray-4"
 						@click.stop="toggleNode(node)"
 						:icon="node.expanded ? 'chevron-down' : 'chevron-right'"></Button>
-					<span v-else class="size-6 shrink-0"></span>
-					<FeatherIcon
-						v-if="node.hasChildren"
-						name="hash"
-						class="size-3.5 shrink-0"
-						:class="node.depth === 0 ? 'text-ink-gray-7' : 'text-ink-gray-4'" />
-					<FeatherIcon v-else name="file-minus" class="size-3.5 shrink-0 text-ink-gray-4" />
+					<span v-else class="size-6 w-7 shrink-0"></span>
+					<FeatherIcon v-if="node.hasChildren" name="hash" class="size-3.5 shrink-0 text-ink-gray-5" />
+					<FeatherIcon v-else name="file-minus" class="-mr-1 size-3.5 shrink-0 text-ink-gray-5" />
 
 					<!-- Page node label row -->
-					<div v-if="node.page" class="flex min-w-0 flex-1 items-center gap-2 py-0.5">
+					<div v-if="node.page" class="flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
 						<code class="shrink-0 px-1.5 py-0.5 font-mono text-xs font-medium text-ink-gray-8">
 							/{{ node.label }}
 						</code>
@@ -68,19 +65,18 @@
 							:title="node.page.page_title">
 							{{ node.page.page_title }}
 						</span>
-						<!-- Status icons -->
-						<span class="ml-auto flex shrink-0 items-center gap-1 pr-1">
+						<span class="ml-auto flex shrink-0 items-center gap-1">
 							<Tooltip v-if="isHomePage(node.page)" text="Home page" :hoverDelay="0.5">
-								<FeatherIcon name="home" class="size-3 text-ink-gray-4" />
+								<HomeIcon class="size-3.5 text-ink-green-3" />
 							</Tooltip>
 							<Tooltip
 								v-if="node.page.authenticated_access"
-								text="Restricted – login required"
+								text="This page has limited access"
 								:hoverDelay="0.5">
-								<FeatherIcon name="lock" class="size-3 text-ink-amber-3" />
+								<AuthenticatedUserIcon class="size-3.5 text-ink-amber-3" />
 							</Tooltip>
 							<Tooltip v-if="!node.page.published" text="Draft – not published" :hoverDelay="0.5">
-								<FeatherIcon name="eye-off" class="size-3 text-ink-gray-4" />
+								<CloudOffIcon class="size-3.5 text-ink-gray-4" />
 							</Tooltip>
 						</span>
 					</div>
@@ -90,7 +86,7 @@
 						<span
 							class="font-mono text-sm font-semibold"
 							:class="node.depth === 0 ? 'text-ink-gray-8' : 'text-ink-gray-6'">
-							/{{ node.label }}
+							{{ node.depth === 0 ? "" : "/" }}{{ node.label }}
 						</span>
 					</div>
 
@@ -100,7 +96,7 @@
 								icon="more-horizontal"
 								size="sm"
 								variant="subtle"
-								class="invisible bg-surface-white !text-ink-gray-5 hover:!text-ink-gray-9 group-hover:visible"
+								class="bg-surface-white !text-ink-gray-5 hover:!text-ink-gray-9"
 								@click.stop></BuilderButton>
 						</template>
 					</PageActionsDropdown>
@@ -111,6 +107,7 @@
 </template>
 
 <script setup lang="ts">
+import AuthenticatedUserIcon from "@/components/Icons/AuthenticatedUser.vue";
 import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
 import { builderSettings } from "@/data/builderSettings";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
@@ -118,6 +115,8 @@ import { useShortcut } from "@/utils/useShortcut";
 import { createListResource, Tooltip } from "frappe-ui";
 import { computed, onBeforeUpdate, ref, watch, watchEffect } from "vue";
 import { useRouter } from "vue-router";
+import CloudOffIcon from "~icons/lucide/cloud-off";
+import HomeIcon from "~icons/lucide/house";
 
 const props = withDefaults(
 	defineProps<{

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -21,7 +21,7 @@
 				<div
 					v-if="node.isLoadMore"
 					class="flex items-center pt-2"
-					:style="{ marginLeft: `${node.depth * 24 + 4 + 32}px` }">
+					:style="{ marginLeft: `${node.depth * 24 + 8 + 32}px` }">
 					<button
 						class="flex items-center gap-1 text-xs text-ink-gray-4 hover:text-ink-gray-7"
 						@click="loadMore(node)">
@@ -51,8 +51,8 @@
 						@click.stop="toggleNode(node)"
 						:icon="node.expanded ? 'chevron-down' : 'chevron-right'"></Button>
 					<span v-else class="size-6 w-7 shrink-0"></span>
-					<FeatherIcon v-if="node.hasChildren" name="hash" class="size-3.5 shrink-0 text-ink-gray-5" />
-					<FeatherIcon v-else name="file-minus" class="-mr-1 size-3.5 shrink-0 text-ink-gray-5" />
+					<!-- <FeatherIcon v-if="node.hasChildren" name="hash" class="size-3.5 shrink-0 text-ink-gray-5" /> -->
+					<!-- <FeatherIcon v-else name="file-minus" class="-mr-1 size-3.5 shrink-0 text-ink-gray-5" /> -->
 
 					<!-- Page node label row -->
 					<div v-if="node.page" class="flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
@@ -86,7 +86,7 @@
 						<span
 							class="font-mono text-sm font-semibold"
 							:class="node.depth === 0 ? 'text-ink-gray-8' : 'text-ink-gray-6'">
-							{{ node.depth === 0 ? "" : "/" }}{{ node.label }}
+							/{{ node.label }}
 						</span>
 					</div>
 

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -194,21 +194,27 @@ const usePageStore = defineStore("pageStore", {
 			}
 		},
 
-		async unpublishPage() {
+		async unpublishPage(page?: BuilderPage) {
+			const targetName = page?.name || this.selectedPage;
+			const targetTitle = page?.page_title || page?.page_name || "this page";
 			const confirmed = await confirm(
-				"Are you sure you want to unpublish this page? It will no longer be accessible on the website.",
+				`Are you sure you want to unpublish "${targetTitle}"? It will no longer be accessible on the website.`,
 			);
 			if (!confirmed) {
 				return;
 			}
 			return webPages.setValue
 				.submit({
-					name: this.selectedPage,
+					name: targetName,
 					published: false,
 				})
 				.then(() => {
 					toast.success("Page unpublished");
-					this.setPage(this.selectedPage as string);
+					if (page) {
+						page.published = 0;
+					} else {
+						this.setPage(this.selectedPage as string);
+					}
 					builderSettings.reload();
 				});
 		},


### PR DESCRIPTION
- Load all pages in the frontend and load in the frontend with some threshold. More pages are loaded on demand by clicking load more
- Add arrow key shortcuts to navigate the tree
- Add unpublish option to the page action dropdown
- Fix node alignment and styling

**Before:**
<img width="1000" height="593" alt="Screenshot 2026-05-10 at 11 22 45 PM" src="https://github.com/user-attachments/assets/f53bc3f2-df31-47f3-ae6f-eb8ebad5667f" />


**After:**

<img width="973" height="571" alt="Screenshot 2026-05-11 at 12 00 18 AM" src="https://github.com/user-attachments/assets/11c60a5b-12d9-49a1-8b8a-82d0872fa88a" />

continuation of: https://github.com/frappe/builder/pull/589
