### PR TITLE
refactor: Move dashboard head to a separate component

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -59,6 +59,7 @@ declare module 'vue' {
     CSS: typeof import('./src/components/Icons/CSS.vue')['default']
     CustomSearchPanel: typeof import('./src/components/Controls/CodeMirror/CustomSearchPanel.vue')['default']
     DashboardContent: typeof import('./src/components/DashboardContent.vue')['default']
+    DashboardHead: typeof import('./src/components/DashboardHead.vue')['default']
     DashboardSidebar: typeof import('./src/components/DashboardSidebar.vue')['default']
     DashboardToolbar: typeof import('./src/components/DashboardToolbar.vue')['default']
     DataLoaderBlock: typeof import('./src/components/DataLoaderBlock.vue')['default']

--- a/frontend/src/components/DashboardContent.vue
+++ b/frontend/src/components/DashboardContent.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="no-scrollbar flex-1 overflow-auto">
-		<section class="m-auto mb-32 flex h-fit w-3/4 max-w-6xl flex-col pt-5">
+		<section class="m-auto mb-24 flex h-fit w-3/4 max-w-6xl flex-col pt-5">
 			<!-- pages -->
 			<div>
 				<div v-if="!webPages.data?.length && !searchFilter && !typeFilter" class="col-span-full">
@@ -48,105 +48,6 @@
 				size="sm">
 				Load More
 			</BuilderButton>
-			<!-- list head -->
-			<div class="sticky top-0 order-[-1] mb-4 flex items-center justify-between bg-surface-white px-3 py-5">
-				<h1 class="text-xl font-semibold text-ink-gray-9">
-					{{ builderStore.activeFolder || "All Pages" }}
-				</h1>
-				<div class="flex gap-2">
-					<div>
-						<Button
-							variant="solid"
-							v-if="selectionMode && selectedPages.size"
-							@click="showFolderSelectorDialog = true">
-							Move To Folder
-						</Button>
-					</div>
-					<div class="relative flex" v-show="!selectionMode">
-						<BuilderInput
-							class="w-48"
-							type="text"
-							placeholder="Filter by title or route"
-							v-model="searchFilter"
-							@input="
-								(value: string) => {
-									searchFilter = value;
-								}
-							">
-							<template #prefix>
-								<FeatherIcon name="search" class="size-4 text-ink-gray-5"></FeatherIcon>
-							</template>
-						</BuilderInput>
-					</div>
-					<div class="max-md:hidden" v-show="!selectionMode && displayType !== 'tree'">
-						<Select
-							v-model="typeFilter"
-							:options="[
-								{ label: 'Type', value: '', disabled: true },
-								{ label: 'All', value: 'all' },
-								{ label: 'Draft', value: 'draft' },
-								{ label: 'Published', value: 'published' },
-								{ label: 'Unpublished', value: 'unpublished' },
-							]" />
-					</div>
-					<div v-if="displayType === 'tree' && !selectionMode">
-						<Button
-							variant="subtle"
-							size="sm"
-							class="w-20"
-							@click="
-								treeExpanded
-									? (routeTreeRef?.collapseAll(), (treeExpanded = false))
-									: (routeTreeRef?.expandAll(), (treeExpanded = true))
-							">
-							{{ treeExpanded ? "Collapse" : "Expand" }}
-						</Button>
-					</div>
-					<div class="max-sm:hidden" v-show="displayType !== 'tree' && !selectionMode">
-						<Select
-							v-model="orderBy"
-							:options="[
-								{ label: 'Sort', value: '', disabled: true },
-								{ label: 'Last Created', value: 'creation' },
-								{ label: 'Last Modified', value: 'modified' },
-								{
-									label: 'Alphabetically (A-Z)',
-									value: 'alphabetically_a_z',
-								},
-								{
-									label: 'Alphabetically (Z-A)',
-									value: 'alphabetically_z_a',
-								},
-							]" />
-					</div>
-					<div class="max-md:hidden">
-						<OptionToggle
-							class="[&>div]:min-w-0"
-							:options="[
-								{
-									label: 'Grid',
-									value: 'grid',
-									icon: 'grid',
-									hideLabel: true,
-								},
-								{
-									label: 'List',
-									value: 'list',
-									icon: 'list',
-									hideLabel: true,
-								},
-								{
-									label: 'Route Tree',
-									value: 'tree',
-									icon: ListTreeIcon,
-									hideLabel: true,
-									showTooltip: true,
-								},
-							]"
-							v-model="displayType"></OptionToggle>
-					</div>
-				</div>
-			</div>
 		</section>
 	</div>
 	<SelectFolder
@@ -156,35 +57,46 @@
 </template>
 
 <script setup lang="ts">
-import OptionToggle from "@/components/Controls/OptionToggle.vue";
 import SelectFolder from "@/components/Modals/SelectFolder.vue";
 import PageCard from "@/components/PageCard.vue";
 import PageListItem from "@/components/PageListItem.vue";
 import RouteTreeView from "@/components/RouteTreeView.vue";
+import { useDashboardState } from "@/composables/useDashboardState";
 import { webPages } from "@/data/webPage";
 import vOnClickAndHold from "@/directives/vOnClickAndHold";
 import useBuilderStore from "@/stores/builderStore";
 import { BuilderPage } from "@/types/Builder/BuilderPage";
 import { useShortcut } from "@/utils/useShortcut";
-import { useStorage, watchDebounced } from "@vueuse/core";
-import { Button, createResource, Select } from "frappe-ui";
+import { watchDebounced } from "@vueuse/core";
+import { createResource } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
-import { onActivated, Ref, ref, watch } from "vue";
-import ListTreeIcon from "~icons/lucide/list-tree";
+import { onActivated, onMounted, onUnmounted, ref, watch } from "vue";
 
 const routeTreeRef = ref<InstanceType<typeof RouteTreeView>>();
-const treeExpanded = ref(true);
 
 const { capture } = useTelemetry();
 const builderStore = useBuilderStore();
-const displayType = useStorage("displayType", "grid") as Ref<"grid" | "list" | "tree">;
-const showFolderSelectorDialog = ref(false);
+const {
+	searchFilter,
+	typeFilter,
+	orderBy,
+	displayType,
+	selectionMode,
+	selectedPages,
+	showFolderSelectorDialog,
+	expandTreeFn,
+	collapseTreeFn,
+} = useDashboardState();
 
-const searchFilter = ref("");
-const typeFilter = useStorage("typeFilter", "") as Ref<"" | "draft" | "published" | "unpublished" | "all">;
-const orderBy = useStorage("orderBy", "creation") as Ref<
-	"creation" | "modified" | "alphabetically_a_z" | "alphabetically_z_a"
->;
+onMounted(() => {
+	expandTreeFn.value = () => routeTreeRef.value?.expandAll();
+	collapseTreeFn.value = () => routeTreeRef.value?.collapseAll();
+});
+
+onUnmounted(() => {
+	expandTreeFn.value = null;
+	collapseTreeFn.value = null;
+});
 
 const orderMap = {
 	creation: "creation desc",
@@ -192,9 +104,6 @@ const orderMap = {
 	alphabetically_a_z: "page_title asc",
 	alphabetically_z_a: "page_title desc",
 };
-
-const selectedPages = ref(new Set<string>());
-const selectionMode = ref(false);
 
 onActivated(() => {
 	capture("builder_dashboard_page_visited");

--- a/frontend/src/components/DashboardHead.vue
+++ b/frontend/src/components/DashboardHead.vue
@@ -1,0 +1,122 @@
+<template>
+	<div class="m-auto flex w-3/4 max-w-6xl items-center justify-between bg-surface-white px-3.5 py-5 pt-8">
+		<h1 class="text-xl font-semibold text-ink-gray-9">
+			{{ builderStore.activeFolder || "All Pages" }}
+		</h1>
+		<div class="flex gap-2">
+			<div>
+				<Button
+					variant="solid"
+					v-if="selectionMode && selectedPages.size"
+					@click="showFolderSelectorDialog = true">
+					Move To Folder
+				</Button>
+			</div>
+			<div class="relative flex" v-show="!selectionMode">
+				<BuilderInput
+					class="w-48"
+					type="text"
+					placeholder="Filter by title or route"
+					v-model="searchFilter"
+					@input="
+						(value: string) => {
+							searchFilter = value;
+						}
+					">
+					<template #prefix>
+						<FeatherIcon name="search" class="size-4 text-ink-gray-5"></FeatherIcon>
+					</template>
+				</BuilderInput>
+			</div>
+			<div class="max-md:hidden" v-show="!selectionMode && displayType !== 'tree'">
+				<Select
+					v-model="typeFilter"
+					:options="[
+						{ label: 'Type', value: '', disabled: true },
+						{ label: 'All', value: 'all' },
+						{ label: 'Draft', value: 'draft' },
+						{ label: 'Published', value: 'published' },
+						{ label: 'Unpublished', value: 'unpublished' },
+					]" />
+			</div>
+			<div v-if="displayType === 'tree' && !selectionMode">
+				<Button
+					variant="subtle"
+					size="sm"
+					class="w-20"
+					@click="
+						treeExpanded
+							? (collapseTreeFn?.(), (treeExpanded = false))
+							: (expandTreeFn?.(), (treeExpanded = true))
+					">
+					{{ treeExpanded ? "Collapse" : "Expand" }}
+				</Button>
+			</div>
+			<div class="max-sm:hidden" v-show="displayType !== 'tree' && !selectionMode">
+				<Select
+					v-model="orderBy"
+					:options="[
+						{ label: 'Sort', value: '', disabled: true },
+						{ label: 'Last Created', value: 'creation' },
+						{ label: 'Last Modified', value: 'modified' },
+						{
+							label: 'Alphabetically (A-Z)',
+							value: 'alphabetically_a_z',
+						},
+						{
+							label: 'Alphabetically (Z-A)',
+							value: 'alphabetically_z_a',
+						},
+					]" />
+			</div>
+			<div class="max-md:hidden">
+				<OptionToggle
+					class="[&>div]:min-w-0"
+					:options="[
+						{
+							label: 'Grid',
+							value: 'grid',
+							icon: 'grid',
+							hideLabel: true,
+						},
+						{
+							label: 'List',
+							value: 'list',
+							icon: 'list',
+							hideLabel: true,
+						},
+						{
+							label: 'Route Tree',
+							value: 'tree',
+							icon: ListTreeIcon,
+							hideLabel: true,
+							showTooltip: true,
+						},
+					]"
+					v-model="displayType"></OptionToggle>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import OptionToggle from "@/components/Controls/OptionToggle.vue";
+import { useDashboardState } from "@/composables/useDashboardState";
+import useBuilderStore from "@/stores/builderStore";
+import { Button, Select } from "frappe-ui";
+import ListTreeIcon from "~icons/lucide/list-tree";
+
+const builderStore = useBuilderStore();
+const {
+	searchFilter,
+	selectionMode,
+	selectedPages,
+	showFolderSelectorDialog,
+	treeExpanded,
+	displayType,
+	typeFilter,
+	orderBy,
+	expandTreeFn,
+	collapseTreeFn,
+} = useDashboardState();
+</script>

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -47,21 +47,23 @@
 					<Button
 						v-if="node.hasChildren"
 						variant="ghost"
-						class="!text-ink-gray-4"
+						class="!text-ink-gray-5"
 						@click.stop="toggleNode(node)"
 						:icon="node.expanded ? 'chevron-down' : 'chevron-right'"></Button>
 					<span v-else class="size-6 w-7 shrink-0"></span>
-					<!-- <FeatherIcon v-if="node.hasChildren" name="hash" class="size-3.5 shrink-0 text-ink-gray-5" /> -->
-					<!-- <FeatherIcon v-else name="file-minus" class="-mr-1 size-3.5 shrink-0 text-ink-gray-5" /> -->
 
 					<!-- Page node label row -->
 					<div v-if="node.page" class="flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
-						<code class="shrink-0 px-1.5 py-0.5 font-mono text-xs font-medium text-ink-gray-8">
+						<code
+							class="shrink-0 py-0.5 font-mono text-sm text-ink-gray-6 group-hover:text-ink-gray-9"
+							:class="{
+								'font-semibold': node.hasChildren,
+							}">
 							/{{ node.label }}
 						</code>
 						<span
 							v-if="node.page.page_title"
-							class="truncate text-sm text-ink-gray-5"
+							class="truncate text-sm text-ink-gray-4"
 							:title="node.page.page_title">
 							{{ node.page.page_title }}
 						</span>
@@ -84,8 +86,10 @@
 					<!-- Folder node label -->
 					<div v-else class="flex min-w-0 flex-1 items-center gap-1 py-0.5">
 						<span
-							class="font-mono text-sm font-semibold"
-							:class="node.depth === 0 ? 'text-ink-gray-8' : 'text-ink-gray-6'">
+							class="font-mono text-sm text-ink-gray-6 group-hover:text-ink-gray-9"
+							:class="{
+								'font-semibold': node.hasChildren,
+							}">
 							/{{ node.label }}
 						</span>
 					</div>

--- a/frontend/src/composables/useDashboardState.ts
+++ b/frontend/src/composables/useDashboardState.ts
@@ -1,0 +1,34 @@
+import { useStorage } from "@vueuse/core";
+import { ref, Ref } from "vue";
+
+// Module-level singletons shared across DashboardHead and DashboardContent
+const searchFilter = ref("");
+const selectionMode = ref(false);
+const selectedPages = ref(new Set<string>());
+const showFolderSelectorDialog = ref(false);
+const treeExpanded = ref(true);
+
+const displayType = useStorage("displayType", "grid") as Ref<"grid" | "list" | "tree">;
+const typeFilter = useStorage("typeFilter", "") as Ref<"" | "draft" | "published" | "unpublished" | "all">;
+const orderBy = useStorage("orderBy", "creation") as Ref<
+	"creation" | "modified" | "alphabetically_a_z" | "alphabetically_z_a"
+>;
+
+// Callbacks registered by DashboardContent so DashboardHead can control the tree
+const expandTreeFn = ref<(() => void) | null>(null);
+const collapseTreeFn = ref<(() => void) | null>(null);
+
+export function useDashboardState() {
+	return {
+		searchFilter,
+		selectionMode,
+		selectedPages,
+		showFolderSelectorDialog,
+		treeExpanded,
+		displayType,
+		typeFilter,
+		orderBy,
+		expandTreeFn,
+		collapseTreeFn,
+	};
+}

--- a/frontend/src/composables/useDashboardState.ts
+++ b/frontend/src/composables/useDashboardState.ts
@@ -1,7 +1,6 @@
 import { useStorage } from "@vueuse/core";
 import { ref, Ref } from "vue";
 
-// Module-level singletons shared across DashboardHead and DashboardContent
 const searchFilter = ref("");
 const selectionMode = ref(false);
 const selectedPages = ref(new Set<string>());
@@ -14,7 +13,6 @@ const orderBy = useStorage("orderBy", "creation") as Ref<
 	"creation" | "modified" | "alphabetically_a_z" | "alphabetically_z_a"
 >;
 
-// Callbacks registered by DashboardContent so DashboardHead can control the tree
 const expandTreeFn = ref<(() => void) | null>(null);
 const collapseTreeFn = ref<(() => void) | null>(null);
 

--- a/frontend/src/pages/PageBuilderDashboard.vue
+++ b/frontend/src/pages/PageBuilderDashboard.vue
@@ -1,14 +1,16 @@
 <template>
 	<div class="flex h-screen">
 		<DashboardSidebar></DashboardSidebar>
-		<div class="flex w-full flex-1 flex-col overflow-hidden">
+		<div class="flex w-full flex-1 flex-col overflow-hidden pb-10">
 			<DashboardToolbar class="sticky top-0" />
+			<DashboardHead />
 			<DashboardContent />
 		</div>
 	</div>
 </template>
 <script setup lang="ts">
 import DashboardContent from "@/components/DashboardContent.vue";
+import DashboardHead from "@/components/DashboardHead.vue";
 import DashboardSidebar from "@/components/DashboardSidebar.vue";
 import DashboardToolbar from "@/components/DashboardToolbar.vue";
 </script>


### PR DESCRIPTION
- And move it above dashboard content so that it takes up the top space and dashboard content doesn't partial hide under the head on scroll
- [refactor: Move dashboard head to a separate component](https://github.com/frappe/builder/commit/6f378cb6f678b3dc1423f072fcf1e538ec2a96df)
- [fix(RouteTreeView): Improve UI for better readability and consistency](https://github.com/frappe/builder/commit/035dce21cf09d8bac471f38856fe072b733f531e)