### PR TITLE
fix: prevent dropping a block into its own descendants

### DIFF
--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -325,12 +325,13 @@ const updateDropIndicator = (blockLayerItem: HTMLElement, relativeY: number, ele
 };
 
 const onMouseMove = (event: MouseEvent) => {
-	if (!dragState.draggedElement) return;
+	const draggedElement = dragState.draggedElement;
+	if (!draggedElement) return;
 
 	const target = document.elementFromPoint(event.clientX, event.clientY);
 	const blockLayerItem = target?.closest(".block-layer-item") as HTMLElement | null;
 
-	if (!blockLayerItem || blockLayerItem === dragState.draggedElement) {
+	if (!blockLayerItem || blockLayerItem === draggedElement || draggedElement.contains(blockLayerItem)) {
 		resetDropIndicators();
 		return;
 	}
@@ -394,7 +395,7 @@ const onDragEnd = () => {
 	document.removeEventListener("mousemove", onMouseMove);
 
 	const { draggedElement, hoverTarget, hoverPosition } = dragState;
-	if (!draggedElement || !hoverTarget || !hoverPosition) {
+	if (!draggedElement || !hoverTarget || !hoverPosition || draggedElement.contains(hoverTarget)) {
 		Object.assign(dragState, { draggedElement: null, hoverTarget: null, hoverPosition: null });
 		return;
 	}


### PR DESCRIPTION
**Before**:

https://github.com/user-attachments/assets/24f2d716-4d62-4dc3-ab0a-9d0aba23de9e

**After**:

https://github.com/user-attachments/assets/22267d9c-026b-4144-b80b-21b705a34f60