### PR TITLE
fix(Routing): Prefer last publish time for resolving routes with conflicts

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -15,7 +15,7 @@
   "page_name",
   "route",
   "dynamic_route",
-  "last_published_time",
+  "published_at",
   "column_break_ymjg",
   "is_standard",
   "is_template",
@@ -246,14 +246,14 @@
    "no_copy": 1
   },
   {
-   "fieldname": "last_published_time",
+   "fieldname": "published_at",
    "fieldtype": "Datetime",
-   "label": "Last Published Time"
+   "label": "Published At"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-14 21:29:01.992686",
+ "modified": "2026-05-14 22:54:25.353324",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Page",

--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_guest_to_view": 1,
  "allow_rename": 1,
  "autoname": "field:page_name",
@@ -14,6 +15,7 @@
   "page_name",
   "route",
   "dynamic_route",
+  "last_published_time",
   "column_break_ymjg",
   "is_standard",
   "is_template",
@@ -242,11 +244,16 @@
    "label": "App",
    "mandatory_depends_on": "is_standard",
    "no_copy": 1
+  },
+  {
+   "fieldname": "last_published_time",
+   "fieldtype": "Datetime",
+   "label": "Last Published Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-05 16:23:52.605250",
+ "modified": "2026-05-14 21:29:01.992686",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Page",

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1345,7 +1345,7 @@ def extend_block(block, overridden_block):
 @redis_cache(ttl=60 * 60)
 def find_page_with_path(route):
 	try:
-		return frappe.db.get_value("Builder Page", dict(route=route, published=1), "name", cache=True)
+		return frappe.db.get_value("Builder Page", dict(route=route, published=1), "name", order_by="modified", cache=True)
 	except frappe.DoesNotExistError:
 		pass
 

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -12,7 +12,7 @@ import frappe
 import frappe.utils
 from frappe.modules import scrub
 from frappe.modules.export_file import export_to_files
-from frappe.utils import set_request
+from frappe.utils import now, set_request
 from frappe.utils.caching import redis_cache
 from frappe.utils.jinja import render_template
 from frappe.utils.telemetry import capture
@@ -117,6 +117,7 @@ class BuilderPage(WebsiteGenerator):
 		is_standard: DF.Check
 		is_template: DF.Check
 		language: DF.Data | None
+		last_published_time: DF.Datetime | None
 		meta_description: DF.SmallText | None
 		meta_image: DF.AttachImage | None
 		page_data_script: DF.Code | None
@@ -225,6 +226,7 @@ class BuilderPage(WebsiteGenerator):
 	@frappe.whitelist()
 	def publish(self):
 		self.published = 1
+		self.last_published_time = now()
 		if self.draft_blocks:
 			self.blocks = self.draft_blocks
 			self.draft_blocks = None
@@ -1346,7 +1348,7 @@ def extend_block(block, overridden_block):
 def find_page_with_path(route):
 	try:
 		return frappe.db.get_value(
-			"Builder Page", dict(route=route, published=1), "name", order_by="modified", cache=True
+			"Builder Page", dict(route=route, published=1), "name", order_by="last_published_time", cache=True
 		)
 	except frappe.DoesNotExistError:
 		pass

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1345,7 +1345,9 @@ def extend_block(block, overridden_block):
 @redis_cache(ttl=60 * 60)
 def find_page_with_path(route):
 	try:
-		return frappe.db.get_value("Builder Page", dict(route=route, published=1), "name", order_by="modified", cache=True)
+		return frappe.db.get_value(
+			"Builder Page", dict(route=route, published=1), "name", order_by="modified", cache=True
+		)
 	except frappe.DoesNotExistError:
 		pass
 

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -117,7 +117,6 @@ class BuilderPage(WebsiteGenerator):
 		is_standard: DF.Check
 		is_template: DF.Check
 		language: DF.Data | None
-		last_published_time: DF.Datetime | None
 		meta_description: DF.SmallText | None
 		meta_image: DF.AttachImage | None
 		page_data_script: DF.Code | None
@@ -126,6 +125,7 @@ class BuilderPage(WebsiteGenerator):
 		preview: DF.Data | None
 		project_folder: DF.Link | None
 		published: DF.Check
+		published_at: DF.Datetime | None
 		route: DF.Data | None
 	# end: auto-generated types
 
@@ -226,7 +226,7 @@ class BuilderPage(WebsiteGenerator):
 	@frappe.whitelist()
 	def publish(self):
 		self.published = 1
-		self.last_published_time = now()
+		self.published_at = now()
 		if self.draft_blocks:
 			self.blocks = self.draft_blocks
 			self.draft_blocks = None
@@ -1348,7 +1348,7 @@ def extend_block(block, overridden_block):
 def find_page_with_path(route):
 	try:
 		return frappe.db.get_value(
-			"Builder Page", dict(route=route, published=1), "name", order_by="last_published_time", cache=True
+			"Builder Page", dict(route=route, published=1), "name", order_by="published_at", cache=True
 		)
 	except frappe.DoesNotExistError:
 		pass


### PR DESCRIPTION
If more than one page has the same route asscoaited with them, the current implementation always favors the last "created" page, so even if another page (having the same route but created before) is edited and published that page is not used for rendering. This PR introduces and uses last published time for resolving the route.

Before:

https://github.com/user-attachments/assets/c8544680-a7f8-45c5-b9f7-9610e0f1ea71

After:


https://github.com/user-attachments/assets/08c15768-ff95-44aa-9506-857548b56a8d

