### PR TITLE
fix: Traceback now provides block_id which caused the error

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1032,7 +1032,9 @@ def append_child_with_context(parent: bs.Tag, child: bs.Tag, context: dict):
 
 	if context.get("block_data_script"):
 		escaped_script = escape_single_quotes(context["block_data_script"])
-		parent.append(f"{{% with block = block | execute_script_and_combine('{escaped_script}', props, block_id) %}}")
+		parent.append(
+			f"{{% with block = block | execute_script_and_combine('{escaped_script}', props, block_id) %}}"
+		)
 
 	if context.get("visibility_key"):
 		parent.append(f"{{% if {context['visibility_key']} %}}")

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -631,6 +631,7 @@ def get_block_context(block: dict, props: dict) -> dict:
 	passed_down_props = {name: info["value"] for name, info in props.items() if info["is_passed_down"]}
 
 	return {
+		"block_id": block.get("blockId"),
 		"all_props": all_props,
 		"passed_down_props": passed_down_props,
 		"block_data_script": block.get("blockDataScript"),
@@ -1016,6 +1017,7 @@ def append_child_with_context(parent: bs.Tag, child: bs.Tag, context: dict):
 	# Generate unique hash for this block instance
 	# This is unique for each block irrespective of loops or components
 	parent.append("{% with unique_hash = (loop.index if loop is defined else 0) | hash %}")
+	parent.append(f"{{% with block_id = '{context['block_id']}' %}}")
 
 	if context.get("default_props"):
 		props_str = ", ".join([f"'{var}': {var}" for var in context["default_props"]])
@@ -1030,7 +1032,7 @@ def append_child_with_context(parent: bs.Tag, child: bs.Tag, context: dict):
 
 	if context.get("block_data_script"):
 		escaped_script = escape_single_quotes(context["block_data_script"])
-		parent.append(f"{{% with block = block | execute_script_and_combine('{escaped_script}', props) %}}")
+		parent.append(f"{{% with block = block | execute_script_and_combine('{escaped_script}', props, block_id) %}}")
 
 	if context.get("visibility_key"):
 		parent.append(f"{{% if {context['visibility_key']} %}}")
@@ -1049,6 +1051,7 @@ def append_child_with_context(parent: bs.Tag, child: bs.Tag, context: dict):
 	if context.get("default_props"):
 		parent.append("{% endwith %}{% endwith %}")
 
+	parent.append("{% endwith %}")
 	parent.append("{% endwith %}")
 
 
@@ -1121,7 +1124,7 @@ def wrap_html_with_context(html: str, context: dict) -> str:
 
 	script_escaped = escape_single_quotes(context.get("block_data_script") or "")
 	html = (
-		f"{{% with block = {{}} | execute_script_and_combine('{script_escaped}', {all_props_literal}) %}}"
+		f"{{% with block = {{}} | execute_script_and_combine('{script_escaped}', {all_props_literal}, 'root') %}}"
 		f"{html}"
 		f"{{% endwith %}}"
 	)

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1020,6 +1020,34 @@ class TestBuilderPage(FrappeTestCase):
 		self.assertNotIn("InterVar", font_map)
 		self.assertNotIn("intervar", font_map)
 
+	def test_block_script_error_traceback(self):
+		body = Block(
+			element="div",
+			originalElement="body",
+		)
+		div = Block(
+			element="div",
+			blockId="test-block",
+			innerHTML="Test Block",
+			blockDataScript="block.data = sample_error",
+		)
+		body.attach_children(div)
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Block Script Error Test",
+				"published": 1,
+				"route": "/block-script-error-test",
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+		try:
+			content = get_response_content("/block-script-error-test")
+			self.assertTrue("block_script_for_test_block" in content)
+			self.assertTrue("NameError: name &#x27;sample_error&#x27; is not defined" in content)
+		finally:
+			page.delete()
+
 	@classmethod
 	def tearDownClass(cls):
 		cls.page.delete()

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -708,11 +708,11 @@ def to_safe_json(data):
 	return frappe.as_json(data or {})
 
 
-def execute_script_and_combine(prev_block_data, block_data_script, props):
+def execute_script_and_combine(prev_block_data, block_data_script, props, block_id):
 	props = frappe._dict(frappe.parse_json(props or "{}"))
 	block_data = frappe._dict()
 	_locals = dict(block=to_dict_with_fallback(prev_block_data or {}), props=props)
-	execute_script(unescape_html(block_data_script), _locals, "sample")
+	execute_script(unescape_html(block_data_script), _locals, f"block_script_for_{block_id}")
 	block_data.update(_locals["block"])
 	return combine(prev_block_data, block_data)
 


### PR DESCRIPTION
It was very difficult to track which block caused an error. We now pass `block_id` to the filename parameter of `execute_script` function to help traceback the block which is the source of the error.

<img width="1440" height="812" alt="Screenshot 2026-05-19 at 8 40 21 AM" src="https://github.com/user-attachments/assets/81eb4a86-7e3a-478c-915b-07004d58b8c8" />


<img width="1440" height="812" alt="Screenshot 2026-05-19 at 8 39 54 AM" src="https://github.com/user-attachments/assets/c822ec3a-f186-4e22-a36c-c08e71f2424b" />
