### PR TITLE
refactor: Use styled frappe-ui toasts instead of vue-sonner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ repos:
         types_or:
           - javascript
           - vue
+        args:
+          - --plugin=prettier-plugin-tailwindcss
         additional_dependencies:
           - prettier@3.3.3
           - prettier-plugin-tailwindcss@0.6.11

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -7,6 +7,5 @@
   "printWidth": 110,
   "arrowParens": "always",
   "trailingComma": "all",
-  "plugins": ["prettier-plugin-tailwindcss"],
   "tailwindConfig": "./tailwind.config.js"
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,7 @@
 			</keep-alive>
 		</router-view>
 		<UseDark attribute="data-theme"></UseDark>
-		<Toaster :theme="builderStore.isDark ? 'dark' : 'light'" richColors class="mr-10" />
+		<ToastProvider />
 		<Dialogs></Dialogs>
 		<component v-for="dialog in builderStore.appDialogs" :is="dialog"></component>
 	</div>
@@ -16,10 +16,9 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
-import { Dialogs } from "frappe-ui";
+import { Dialogs, ToastProvider } from "frappe-ui";
 import { computed, provide } from "vue";
 import { useRoute } from "vue-router";
-import { Toaster } from "vue-sonner";
 import { sessionUser } from "./router";
 
 // do not remove this

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,8 +6,7 @@
 			</keep-alive>
 		</router-view>
 		<UseDark attribute="data-theme"></UseDark>
-		<ToastProvider />
-		<Dialogs></Dialogs>
+		<FrappeUIProvider />
 		<component v-for="dialog in builderStore.appDialogs" :is="dialog"></component>
 	</div>
 </template>
@@ -16,7 +15,7 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
-import { Dialogs, ToastProvider } from "frappe-ui";
+import { FrappeUIProvider } from "frappe-ui";
 import { computed, provide } from "vue";
 import { useRoute } from "vue-router";
 import { sessionUser } from "./router";

--- a/frontend/src/components/BlockContextMenu.vue
+++ b/frontend/src/components/BlockContextMenu.vue
@@ -17,7 +17,7 @@ import getBlockTemplate from "@/utils/blockTemplate";
 import { confirm, detachBlockFromComponent, getBlockCopy, triggerCopyEvent } from "@/utils/helpers";
 import { useStorage } from "@vueuse/core";
 import { Ref, inject, nextTick, ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const builderStore = useBuilderStore();
 const componentStore = useComponentStore();

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -68,7 +68,7 @@ import {
 	watch,
 	watchEffect,
 } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import BlockEditor from "./BlockEditor.vue";
 import BlockHTML from "./BlockHTML.vue";
 import DataLoaderBlock from "./DataLoaderBlock.vue";

--- a/frontend/src/components/BuilderToolbar.vue
+++ b/frontend/src/components/BuilderToolbar.vue
@@ -154,7 +154,7 @@ import { useDark, useToggle } from "@vueuse/core";
 import { Badge, Popover, Tooltip } from "frappe-ui";
 import { DialogDescription, DialogTitle } from "reka-ui";
 import { computed, defineAsyncComponent, inject, ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 // @ts-ignore
 import SparklesIcon from "~icons/lucide/sparkles";
 import MainMenu from "./MainMenu.vue";

--- a/frontend/src/components/Controls/SearchBlock.vue
+++ b/frontend/src/components/Controls/SearchBlock.vue
@@ -151,7 +151,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import { watchDebounced } from "@vueuse/core";
 import { Input, Popover } from "frappe-ui";
 import { computed, nextTick, onMounted, Ref, ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import BuilderButton from "./BuilderButton.vue";
 import OptionToggle from "./OptionToggle.vue";
 

--- a/frontend/src/components/EditableSpan.vue
+++ b/frontend/src/components/EditableSpan.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts" setup>
 import { nextTick, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const props = withDefaults(
 	defineProps<{

--- a/frontend/src/components/Modals/NewBuilderVariable.vue
+++ b/frontend/src/components/Modals/NewBuilderVariable.vue
@@ -51,7 +51,7 @@ import { BuilderVariable } from "@/types/Builder/BuilderVariable";
 import { defaultBuilderVariable, useBuilderVariable } from "@/utils/useBuilderVariable";
 import { Dialog } from "frappe-ui";
 import { computed, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const props = defineProps<{
 	modelValue: boolean;

--- a/frontend/src/components/Modals/VariableManager.vue
+++ b/frontend/src/components/Modals/VariableManager.vue
@@ -169,7 +169,7 @@ import { useBuilderVariable } from "@/utils/useBuilderVariable";
 import { useDebounceFn } from "@vueuse/core";
 import { Button, ListView, Tooltip } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 defineProps<{
 	modelValue: boolean;

--- a/frontend/src/components/PaddingHandler.vue
+++ b/frontend/src/components/PaddingHandler.vue
@@ -114,7 +114,7 @@ import { clamp } from "@vueuse/core";
 import { computed, inject, ref, watchEffect } from "vue";
 import { getNumberFromPx } from "../utils/helpers";
 
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 const canvasProps = inject("canvasProps") as CanvasProps;
 
 const props = withDefaults(

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -140,7 +140,7 @@ import { BuilderPage } from "@/types/Builder/BuilderPage";
 import { Autocomplete, createListResource, createResource, Dropdown } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
 import { computed, nextTick, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import draggable from "vuedraggable";
 import CodeEditor from "./Controls/CodeEditor.vue";
 import CSSIcon from "./Icons/CSS.vue";

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -164,7 +164,7 @@ import blockController from "@/utils/blockController";
 import { useStorage } from "@vueuse/core";
 import { useTelemetry } from "frappe-ui/frappe";
 import { computed, defineComponent, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import CodeEditor from "./Controls/CodeEditor.vue";
 import Switch from "./Controls/Switch.vue";
 import TabButtons from "./Controls/TabButtons.vue";

--- a/frontend/src/components/PropsOptions/ArrayOptions.vue
+++ b/frontend/src/components/PropsOptions/ArrayOptions.vue
@@ -27,7 +27,7 @@ import Input from "@/components/Controls/Input.vue";
 import ArrayEditor from "@/components/ArrayEditor.vue";
 import { nextTick, ref, watch } from "vue";
 import { Ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import InlineInput from "../Controls/InlineInput.vue";
 
 const props = defineProps<{

--- a/frontend/src/components/PropsOptions/NumberOptions.vue
+++ b/frontend/src/components/PropsOptions/NumberOptions.vue
@@ -35,7 +35,7 @@
 
 <script setup lang="ts">
 import { nextTick, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import InlineInput from "@/components/Controls/InlineInput.vue";
 
 const props = defineProps<{

--- a/frontend/src/components/PropsOptions/ObjectOptions.vue
+++ b/frontend/src/components/PropsOptions/ObjectOptions.vue
@@ -28,7 +28,7 @@ import InlineInput from "@/components/Controls/InlineInput.vue";
 
 import { nextTick, ref, watch } from "vue";
 import { Ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const props = defineProps<{
 	options: Record<string, any>;

--- a/frontend/src/components/RouteTreeNode.vue
+++ b/frontend/src/components/RouteTreeNode.vue
@@ -5,7 +5,7 @@
 				class="group flex cursor-pointer select-none items-center gap-1.5 border-b border-outline-gray-1 px-1 hover:rounded-md hover:bg-surface-gray-1"
 				:class="[
 					node.hasChildren ? 'sticky bg-surface-white shadow-[0_1px_0_var(--border-color)]' : '',
-					{ 'rounded-md !bg-surface-gray-2 ': focusedNodeId === node.id },
+					{ 'rounded-md !bg-surface-gray-2': focusedNodeId === node.id },
 				]"
 				:ref="
 					(el) => {

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -82,7 +82,7 @@
 import { useDomains } from "@/data/domains";
 import { Badge, Dropdown, ErrorMessage, FormControl } from "frappe-ui";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const PENDING_STATUSES = ["Pending", "In Progress"];
 

--- a/frontend/src/components/Settings/GlobalRedirects.vue
+++ b/frontend/src/components/Settings/GlobalRedirects.vue
@@ -81,7 +81,7 @@
 import routeRedirects from "@/data/routeRedirects";
 import { confirm } from "@/utils/helpers";
 import { computed, onMounted, ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const redirectMap = ref({ from: "", to: "" });
 const searchQuery = ref({ from: "", to: "" });

--- a/frontend/src/components/Settings/PageGeneral.vue
+++ b/frontend/src/components/Settings/PageGeneral.vue
@@ -187,7 +187,7 @@ import { BuilderProjectFolder } from "@/types/Builder/BuilderProjectFolder";
 import { toTitleCase } from "@/utils/helpers";
 import { createResource } from "frappe-ui";
 import { computed } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const pageStore = usePageStore();
 const builderStore = useBuilderStore();

--- a/frontend/src/components/TextBlockBubbleMenu.vue
+++ b/frontend/src/components/TextBlockBubbleMenu.vue
@@ -153,7 +153,7 @@ import { vOnClickOutside } from "@vueuse/components";
 import { debouncedWatch } from "@vueuse/core";
 import { debounce } from "frappe-ui";
 import { computed, nextTick, ref, watch, type Ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const props = defineProps<{
 	block: Block;

--- a/frontend/src/data/domains.ts
+++ b/frontend/src/data/domains.ts
@@ -1,6 +1,6 @@
 import { createResource } from "frappe-ui";
 import { ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const API = "builder.domain";
 

--- a/frontend/src/stores/blockTemplateStore.ts
+++ b/frontend/src/stores/blockTemplateStore.ts
@@ -5,7 +5,7 @@ import { getBlockInstance, getBlockString } from "@/utils/helpers";
 import { createDocumentResource } from "frappe-ui";
 import { defineStore } from "pinia";
 import { nextTick } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import useBuilderStore from "./builderStore";
 import useCanvasStore from "./canvasStore";
 

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -5,7 +5,7 @@ import RealTimeHandler from "@/utils/realtimeHandler";
 import { useDark, useStorage } from "@vueuse/core";
 import { useTelemetry } from "frappe-ui/frappe";
 import { defineStore } from "pinia";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import type Dialog from "../components/Controls/Dialog.vue";
 import BlockLayers from "./components/BlockLayers.vue";
 

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -8,7 +8,7 @@ import { alert, confirm, getBlockInstance, getBlockObject } from "@/utils/helper
 import { createDocumentResource, createResource } from "frappe-ui";
 import { defineStore } from "pinia";
 import { markRaw } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const useComponentStore = defineStore("componentStore", {
 	state: () => ({

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -17,7 +17,7 @@ import {
 import { createDocumentResource, createListResource, createResource } from "frappe-ui";
 import { defineStore } from "pinia";
 import { nextTick } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import { BuilderClientScript } from "../types/Builder/BuilderClientScript";
 
 const usePageStore = defineStore("pageStore", {

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -18,7 +18,7 @@ import {
 } from "@/utils/helpers";
 import { createListResource } from "frappe-ui";
 import { nextTick } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import { webPages } from "../data/webPage";
 import { BuilderClientScript } from "../types/Builder/BuilderClientScript";
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -8,7 +8,7 @@ import { BuilderPage } from "@/types/Builder/BuilderPage";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { FileUploadHandler } from "frappe-ui";
 import { defineComponent, h, markRaw, reactive, ref, toRaw } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 import Dialog from "../components/Controls/Dialog.vue";
 
 function getNumberFromPx(px: string | number | null | undefined): number {

--- a/frontend/src/utils/imageUtils.ts
+++ b/frontend/src/utils/imageUtils.ts
@@ -1,5 +1,5 @@
 import { createResource } from "frappe-ui";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 export interface ImageOptimizationOptions {
 	imageUrl: string;

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -24,7 +24,7 @@ import { useShortcut } from "@/utils/useShortcut";
 import { useEventListener, useStorage } from "@vueuse/core";
 import { Ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();

--- a/frontend/src/utils/useCanvasUtils.ts
+++ b/frontend/src/utils/useCanvasUtils.ts
@@ -5,7 +5,7 @@ import { getRootBlockTemplate } from "@/utils/helpers";
 import { useCanvasHistory } from "@/utils/useCanvasHistory";
 import { useElementBounding } from "@vueuse/core";
 import { nextTick, reactive, ref, Ref } from "vue";
-import { toast } from "vue-sonner";
+import { toast } from "frappe-ui";
 
 const canvasStore = useCanvasStore();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4724,7 +4724,7 @@ fraction.js@^5.3.4:
 
 frappe-ui@frappe/frappe-ui#main:
   version "0.1.278"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/a989d1fa50e96746b9a7203ba8c9552aacfd5d0b"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/4d012187fd2f9654d9a42f489ff8b506783bf79a"
   dependencies:
     "@headlessui/vue" "^1.7.14"
     "@popperjs/core" "^2.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4724,7 +4724,7 @@ fraction.js@^5.3.4:
 
 frappe-ui@frappe/frappe-ui#main:
   version "0.1.278"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/363163361069ff3a106a06dd0a01a98ed14aa7b9"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/a989d1fa50e96746b9a7203ba8c9552aacfd5d0b"
   dependencies:
     "@headlessui/vue" "^1.7.14"
     "@popperjs/core" "^2.11.2"


### PR DESCRIPTION
Use styled `frappe-ui` toasts instead of `vue-sonner`