### PR TITLE
fix(CommandPalette): remove transition-colors for better UX

### DIFF
--- a/frontend/src/components/CommandPaletteItem.vue
+++ b/frontend/src/components/CommandPaletteItem.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="flex w-full min-w-0 items-center rounded px-2 py-2 text-sm text-ink-gray-8 transition-colors"
+		class="flex w-full min-w-0 items-center rounded px-2 py-2 text-sm text-ink-gray-8"
 		:class="{ 'bg-surface-gray-2': active }">
 		<!-- lucide string icon (e.g. "lucide-search") -->
 		<span


### PR DESCRIPTION
Remove transition-colors as it was not the best UX plus it caused jitters and lags trying to do the animations.

Before (mouse hover):

https://github.com/user-attachments/assets/425838d9-4022-4cc4-b6e3-14103326cb40

After (mouse hover):

https://github.com/user-attachments/assets/ceb84107-b201-4673-b56c-49cbcfbb87ec

Before (keyboard nav):

https://github.com/user-attachments/assets/ae3f9964-6776-44b0-8973-969873d1d693

After (keyboard nav):

https://github.com/user-attachments/assets/7c3bafdf-8adf-44ff-af22-e5abe323ceeb


