### PR TITLE
fix: Page selection with conflicting routes

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -179,6 +179,7 @@ class BuilderPage(WebsiteGenerator):
 			self.has_value_changed("dynamic_route")
 			or self.has_value_changed("route")
 			or self.has_value_changed("published")
+			or self.has_value_changed("published_at")
 			or self.has_value_changed("disable_indexing")
 			or self.has_value_changed("blocks")
 		):
@@ -1354,7 +1355,11 @@ def extend_block(block, overridden_block):
 def find_page_with_path(route):
 	try:
 		return frappe.db.get_value(
-			"Builder Page", dict(route=route, published=1), "name", order_by="published_at", cache=True
+			"Builder Page",
+			dict(route=route, published=1),
+			"name",
+			order_by="published_at desc, creation desc",
+			cache=True,
 		)
 	except frappe.DoesNotExistError:
 		pass

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1051,15 +1051,12 @@ class TestBuilderPage(FrappeTestCase):
 	def test_conflicting_routes_picks_last_published(self):
 		"""Pages sharing a route should resolve to the most recently published one."""
 		from frappe.utils import add_to_date, now_datetime
+		from frappe.website.utils import clear_cache as clear_page_cache
 
 		from builder.builder.doctype.builder_page.builder_page import find_page_with_path
 
-		route = "/conflicting-route-test"
-		blocks = Block(
-			element="div",
-			originalElement="body",
-			children=[Block(element="h1", innerHTML="Content")],
-		).as_json(wrap_in_array=True)
+		# Frappe strips leading slashes from routes during validation; use without slash
+		route = "conflicting-route-test"
 
 		page_older = frappe.get_doc(
 			{
@@ -1067,7 +1064,11 @@ class TestBuilderPage(FrappeTestCase):
 				"page_title": "Older Published Page",
 				"published": 1,
 				"route": route,
-				"blocks": blocks,
+				"blocks": Block(
+					element="div",
+					originalElement="body",
+					children=[Block(element="h1", innerHTML="Older Published Content")],
+				).as_json(wrap_in_array=True),
 			}
 		).insert()
 
@@ -1077,36 +1078,46 @@ class TestBuilderPage(FrappeTestCase):
 				"page_title": "Newer Published Page",
 				"published": 1,
 				"route": route,
-				"blocks": blocks,
+				"blocks": Block(
+					element="div",
+					originalElement="body",
+					children=[Block(element="h1", innerHTML="Newer Published Content")],
+				).as_json(wrap_in_array=True),
 			}
 		).insert()
+
+		def clear_caches():
+			find_page_with_path.clear_cache()
+			clear_page_cache(route)
 
 		try:
 			page_older.db_set("published_at", add_to_date(now_datetime(), days=-2))
 			page_newer.db_set("published_at", add_to_date(now_datetime(), days=-1))
+			clear_caches()
 
-			find_page_with_path.clear_cache()
-			self.assertEqual(find_page_with_path(route), page_newer.name)
+			content = get_response_content(f"/{route}")
+			self.assertIn("Newer Published Content", content)
 
 			# Republish the older page — it should now be picked
 			page_older.db_set("published_at", now_datetime())
-			find_page_with_path.clear_cache()
-			self.assertEqual(find_page_with_path(route), page_older.name)
+			clear_caches()
+
+			content = get_response_content(f"/{route}")
+			self.assertIn("Older Published Content", content)
 		finally:
-			find_page_with_path.clear_cache()
+			clear_caches()
 			page_older.delete()
 			page_newer.delete()
 
 	def test_conflicting_routes_no_published_at_picks_last_created(self):
 		"""When published_at is absent, the most recently created page should win."""
+		from frappe.utils import add_to_date, now_datetime
+		from frappe.website.utils import clear_cache as clear_page_cache
+
 		from builder.builder.doctype.builder_page.builder_page import find_page_with_path
 
-		route = "/conflicting-route-no-published-at-test"
-		blocks = Block(
-			element="div",
-			originalElement="body",
-			children=[Block(element="h1", innerHTML="Content")],
-		).as_json(wrap_in_array=True)
+		# Frappe strips leading slashes from routes during validation; use without slash
+		route = "conflicting-route-no-published-at-test"
 
 		page_first = frappe.get_doc(
 			{
@@ -1114,7 +1125,11 @@ class TestBuilderPage(FrappeTestCase):
 				"page_title": "First Created Page",
 				"published": 1,
 				"route": route,
-				"blocks": blocks,
+				"blocks": Block(
+					element="div",
+					originalElement="body",
+					children=[Block(element="h1", innerHTML="First Created Content")],
+				).as_json(wrap_in_array=True),
 			}
 		).insert()
 
@@ -1124,16 +1139,28 @@ class TestBuilderPage(FrappeTestCase):
 				"page_title": "Second Created Page",
 				"published": 1,
 				"route": route,
-				"blocks": blocks,
+				"blocks": Block(
+					element="div",
+					originalElement="body",
+					children=[Block(element="h1", innerHTML="Second Created Content")],
+				).as_json(wrap_in_array=True),
 			}
 		).insert()
 
+		# Ensure page_first has an older creation timestamp as a tiebreaker
+		page_first.db_set("creation", add_to_date(now_datetime(), seconds=-10))
+
+		def clear_caches():
+			find_page_with_path.clear_cache()
+			clear_page_cache(route)
+
 		try:
 			# Both pages have no published_at; creation order should determine the winner
-			find_page_with_path.clear_cache()
-			self.assertEqual(find_page_with_path(route), page_second.name)
+			clear_caches()
+			content = get_response_content(f"/{route}")
+			self.assertIn("Second Created Content", content)
 		finally:
-			find_page_with_path.clear_cache()
+			clear_caches()
 			page_first.delete()
 			page_second.delete()
 

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1048,6 +1048,95 @@ class TestBuilderPage(FrappeTestCase):
 		finally:
 			page.delete()
 
+	def test_conflicting_routes_picks_last_published(self):
+		"""Pages sharing a route should resolve to the most recently published one."""
+		from frappe.utils import add_to_date, now_datetime
+
+		from builder.builder.doctype.builder_page.builder_page import find_page_with_path
+
+		route = "/conflicting-route-test"
+		blocks = Block(
+			element="div",
+			originalElement="body",
+			children=[Block(element="h1", innerHTML="Content")],
+		).as_json(wrap_in_array=True)
+
+		page_older = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Older Published Page",
+				"published": 1,
+				"route": route,
+				"blocks": blocks,
+			}
+		).insert()
+
+		page_newer = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Newer Published Page",
+				"published": 1,
+				"route": route,
+				"blocks": blocks,
+			}
+		).insert()
+
+		try:
+			page_older.db_set("published_at", add_to_date(now_datetime(), days=-2))
+			page_newer.db_set("published_at", add_to_date(now_datetime(), days=-1))
+
+			find_page_with_path.clear_cache()
+			self.assertEqual(find_page_with_path(route), page_newer.name)
+
+			# Republish the older page — it should now be picked
+			page_older.db_set("published_at", now_datetime())
+			find_page_with_path.clear_cache()
+			self.assertEqual(find_page_with_path(route), page_older.name)
+		finally:
+			find_page_with_path.clear_cache()
+			page_older.delete()
+			page_newer.delete()
+
+	def test_conflicting_routes_no_published_at_picks_last_created(self):
+		"""When published_at is absent, the most recently created page should win."""
+		from builder.builder.doctype.builder_page.builder_page import find_page_with_path
+
+		route = "/conflicting-route-no-published-at-test"
+		blocks = Block(
+			element="div",
+			originalElement="body",
+			children=[Block(element="h1", innerHTML="Content")],
+		).as_json(wrap_in_array=True)
+
+		page_first = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "First Created Page",
+				"published": 1,
+				"route": route,
+				"blocks": blocks,
+			}
+		).insert()
+
+		page_second = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Second Created Page",
+				"published": 1,
+				"route": route,
+				"blocks": blocks,
+			}
+		).insert()
+
+		try:
+			# Both pages have no published_at; creation order should determine the winner
+			find_page_with_path.clear_cache()
+			self.assertEqual(find_page_with_path(route), page_second.name)
+		finally:
+			find_page_with_path.clear_cache()
+			page_first.delete()
+			page_second.delete()
+
 	@classmethod
 	def tearDownClass(cls):
 		cls.page.delete()


### PR DESCRIPTION
Fixes following Issues:
- Sorting of pages based on "published_at" was totally opposite. It used to pick oldest published pages instead of latest one
- Page cache based on route was not getting cleared when latest "published_at" is set for the page which resulted in system showing different already cached page even if the new page is explictly published
- There was no logic to pick latest created page in case of pages with conflicting URL and did not had "published_at" set (it used to pick based on it's internal sorting which is not always correct for our case)

issues introduced with: https://github.com/frappe/builder/pull/598