### PR TITLE
feat: redirect from data script

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -262,7 +262,7 @@ class BuilderPage(WebsiteGenerator):
 				"Builder Settings", "Builder Settings", "disable_auto_dark_mode"
 			)
 
-		page_data = self.get_page_data()
+		page_data = self._get_page_data(for_render=True)
 		if page_data.get("title"):
 			context.title = page_data.get("page_title")
 
@@ -273,7 +273,7 @@ class BuilderPage(WebsiteGenerator):
 
 		content, style, fonts, has_block_script = get_block_html(blocks)
 
-		if self.dynamic_route or page_data or has_block_script:
+		if self.dynamic_route or page_data or has_block_script or self.page_data_script:
 			context.no_cache = 1
 
 		self.set_custom_font(context, fonts)
@@ -374,11 +374,20 @@ class BuilderPage(WebsiteGenerator):
 
 	@frappe.whitelist()
 	def get_page_data(self, route_variables: dict | None = None) -> dict:
+		return self._get_page_data(route_variables=route_variables, for_render=False)
+
+	def _get_page_data(self, route_variables: dict | None = None, for_render: bool = False) -> dict:
 		if route_variables:
 			frappe.form_dict.update({k: v for k, v in route_variables.items()})
 		page_data = frappe._dict()
 		if self.page_data_script:
-			_locals = dict(data=frappe._dict(), page=frappe._dict())
+
+			def redirect(location: str, http_status_code: int = 302):
+				if for_render:
+					frappe.local.flags.redirect_location = location
+					raise frappe.Redirect(http_status_code)
+
+			_locals = dict(data=frappe._dict(), page=frappe._dict(), redirect=redirect)
 			execute_script(self.page_data_script, _locals, self.name)
 			page_data.update(_locals["data"])
 			page_data.update(_locals["page"])

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.desk.form.load import getdoc
 from frappe.tests.utils import FrappeTestCase
-from frappe.website.serve import get_response_content, get_response
+from frappe.website.serve import get_response, get_response_content
 
 from builder.utils import Block
 
@@ -401,7 +401,6 @@ class TestBuilderPage(FrappeTestCase):
 			}
 		).insert()
 		try:
-
 			response = get_response("/redirect-test")
 			self.assertEqual(response.status_code, 302)
 			self.assertEqual(response.headers.get("Location"), "/login")

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.desk.form.load import getdoc
 from frappe.tests.utils import FrappeTestCase
-from frappe.website.serve import get_response_content
+from frappe.website.serve import get_response_content, get_response
 
 from builder.utils import Block
 
@@ -384,6 +384,31 @@ class TestBuilderPage(FrappeTestCase):
 			self.assertTrue("Header H4" in get_html_for(content, "tag", "h4"))
 			self.assertTrue("Header H5" in get_html_for(content, "tag", "h5"))
 		finally:
+			page.delete()
+
+	def test_redirect_from_page_data_script(self):
+		body = Block(element="div", originalElement="body")
+		body.attach_children(Block(element="h1", innerHTML="Should not render"))
+
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Redirect Test",
+				"published": 1,
+				"route": "/redirect-test",
+				"page_data_script": 'redirect("/login", 302)',
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+		try:
+
+			response = get_response("/redirect-test")
+			self.assertEqual(response.status_code, 302)
+			self.assertEqual(response.headers.get("Location"), "/login")
+
+			self.assertEqual(page.get_page_data(), {})
+		finally:
+			frappe.local.flags.redirect_location = None
 			page.delete()
 
 	def test_visibility_condition_from_block_data(self):

--- a/frontend/src/components/AIPageGeneratorModal.vue
+++ b/frontend/src/components/AIPageGeneratorModal.vue
@@ -19,7 +19,7 @@
 					<Transition name="fade">
 						<div
 							v-if="isDragging"
-							class="border-outline-blue-3 bg-surface-blue-1/60 pointer-events-none absolute inset-0 flex items-center justify-center rounded-md border-2 border-dashed">
+							class="border-outline-blue-3 pointer-events-none absolute inset-0 flex items-center justify-center rounded-md border-2 border-dashed bg-surface-blue-1/60">
 							<div class="text-ink-blue-4 flex items-center gap-1.5 text-xs font-medium">
 								<span class="lucide-image h-3.5 w-3.5" aria-hidden="true" />
 								Drop image to attach


### PR DESCRIPTION
## Redirect visitors to a URL from a Data Script

### What
Adds the ability to redirect a page visitor to any URL from within a page **Data Script**.

    # example
    redirect("/login")          # 302 by default
    redirect("/login", 301)   # optional custom status code

### Why
Data scripts already run server-side on every render and can branch on the
session/user, but there was no way to send the visitor elsewhere. This closes that gap with a one-line helper.

### How
- Injects a `redirect(location, http_status_code=302)` helper into the page
  data script namespace. When called during an actual page render it sets
  `frappe.local.flags.redirect_location` and raises `frappe.Redirect`, which the
  Frappe website renderer turns into a real HTTP redirect — entirely
  server-side

### Security
- `get_page_data` is split into a whitelisted wrapper (always
  `for_render=False`) and an internal `_get_page_data(for_render=True)` used
  only by the render path — so a client cannot trigger the redirect via the API.
- Pages with a `page_data_script` are now marked `no_cache`. A data script can
  branch on the user/session, so without this a render for one user could be
  cached and served to another, bypassing a conditional redirect (auth-bypass).
- Redirect targets come from author-written server-side Python (same trust
  level as any data script); external URLs are intentionally allowed.

### Tests
- `test_redirect_from_page_data_script`: asserts the rendered response is a
  302 to the target URL, and that the editor's `get_page_data()` call is a
  no-op returning empty data.
