### PR TITLE
feat: render page previews via framework's bundled Chromium when available

### DIFF
--- a/builder/html_preview_image.py
+++ b/builder/html_preview_image.py
@@ -10,10 +10,10 @@ def generate_preview(html, output_path):
 
 
 def render(html: str) -> bytes:
-	# Frappe v16+ ships a built-in headless-Chromium screenshot generator, so we
-	# render previews in-process — no external service, and local assets resolve.
-	# Builder still supports v15, where that helper doesn't exist; fall back to
-	# the preview_generator HTTP service there.
+	# Newer Frappe versions ship a built-in headless-Chromium screenshot generator,
+	# so we render previews in-process — no external service, and local assets
+	# resolve. Older versions don't have this helper; fall back to the
+	# preview_generator HTTP service there.
 	try:
 		from frappe.utils.preview import get_preview_from_html
 	except ImportError:

--- a/builder/html_preview_image.py
+++ b/builder/html_preview_image.py
@@ -4,12 +4,12 @@ import frappe
 
 
 def generate_preview(html, output_path):
-	image = _render(html)
+	image = render(html)
 	with open(output_path, "wb") as f:
 		f.write(image)
 
 
-def _render(html: str) -> bytes:
+def render(html: str) -> bytes:
 	# Frappe v16+ ships a built-in headless-Chromium screenshot generator, so we
 	# render previews in-process — no external service, and local assets resolve.
 	# Builder still supports v15, where that helper doesn't exist; fall back to
@@ -17,12 +17,12 @@ def _render(html: str) -> bytes:
 	try:
 		from frappe.utils.preview import get_preview_from_html
 	except ImportError:
-		return _render_via_service(html)
+		return render_via_service(html)
 
 	return get_preview_from_html(html, format="webp")
 
 
-def _render_via_service(html: str) -> bytes:
+def render_via_service(html: str) -> bytes:
 	# Note: while working locally, "preview.frappe.cloud" can't reach the local
 	# server for assets, so set `preview_generator_url` to a local/self-hosted
 	# preview_generator (https://github.com/frappe/preview_generator).

--- a/builder/html_preview_image.py
+++ b/builder/html_preview_image.py
@@ -1,24 +1,39 @@
 import html as html_parser
 
 import frappe
-import requests
-
-# TODO: Find better alternative
-# Note: while working locally, "preview.frappe.cloud" won't be able to generate preview properly since it can't access local server for assets
-# So, for local development, better to use local server for preview generation
-# (https://github.com/frappe/preview_generator)
-PREVIEW_GENERATOR_URL = (
-	frappe.conf.preview_generator_url
-	or "https://preview.frappe.cloud/api/method/preview_generator.api.generate_preview"
-)
+from frappe.utils import cint
 
 
 def generate_preview(html, output_path):
-	escaped_html = html_parser.escape(html)
-	response = requests.post(PREVIEW_GENERATOR_URL, json={"html": escaped_html, "format": "webp"})
-	if response.status_code == 200:
-		with open(output_path, "wb") as f:
-			f.write(response.content)
-	else:
-		exception = response.json().get("exc")
-		raise Exception(frappe.parse_json(exception)[0])
+	image = _render(html)
+	with open(output_path, "wb") as f:
+		f.write(image)
+
+
+def _render(html: str) -> bytes:
+	# Frappe v16+ ships a built-in headless-Chromium screenshot generator, so we
+	# render previews in-process — no external service, and local assets resolve.
+	# Builder still supports v15, where that helper doesn't exist; fall back to
+	# the preview_generator HTTP service there.
+	if cint(frappe.__version__.split(".")[0]) >= 16:
+		from frappe.utils.preview import get_preview_from_html
+
+		return get_preview_from_html(html, format="webp")
+
+	return _render_via_service(html)
+
+
+def _render_via_service(html: str) -> bytes:
+	# Note: while working locally, "preview.frappe.cloud" can't reach the local
+	# server for assets, so set `preview_generator_url` to a local/self-hosted
+	# preview_generator (https://github.com/frappe/preview_generator).
+	import requests
+
+	url = (
+		frappe.conf.preview_generator_url
+		or "https://preview.frappe.cloud/api/method/preview_generator.api.generate_preview"
+	)
+	response = requests.post(url, json={"html": html_parser.escape(html), "format": "webp"})
+	if response.status_code != 200:
+		raise Exception(frappe.parse_json(response.json().get("exc"))[0])
+	return response.content

--- a/builder/html_preview_image.py
+++ b/builder/html_preview_image.py
@@ -1,7 +1,6 @@
 import html as html_parser
 
 import frappe
-from frappe.utils import cint
 
 
 def generate_preview(html, output_path):
@@ -15,12 +14,12 @@ def _render(html: str) -> bytes:
 	# render previews in-process — no external service, and local assets resolve.
 	# Builder still supports v15, where that helper doesn't exist; fall back to
 	# the preview_generator HTTP service there.
-	if cint(frappe.__version__.split(".")[0]) >= 16:
+	try:
 		from frappe.utils.preview import get_preview_from_html
+	except ImportError:
+		return _render_via_service(html)
 
-		return get_preview_from_html(html, format="webp")
-
-	return _render_via_service(html)
+	return get_preview_from_html(html, format="webp")
 
 
 def _render_via_service(html: str) -> bytes:


### PR DESCRIPTION
> ⚠️ The in-process path **depends on https://github.com/frappe/frappe/pull/39882** (Frappe v16+). On older frameworks this falls back to the existing `preview_generator` HTTP service, so the PR is safe to merge independently — but the v16 path only renders once that frappe PR is in.

## What

Builder generates page preview images by rendering the page HTML to a screenshot. Until now it POSTed that HTML to the external `preview_generator` service (by default the hosted `preview.frappe.cloud`). Two long-standing annoyances, both flagged in the code's `# TODO: Find better alternative`:

- the hosted service **can't reach a local bench**, so `/assets` and `/files` don't render during local development;
- it's an **external network round-trip** for every preview.

Frappe v16 ships a built-in headless-Chromium screenshot generator (`frappe.utils.preview`), so on v16+ we now render **in-process** — no external call, and local assets resolve.

- **v16+**: `frappe.utils.preview.get_preview_from_html(html, format="webp")`.
- **v15** (still supported by Builder): unchanged — falls back to the `preview_generator` HTTP endpoint; the `preview_generator_url` site-config override is still honoured.

## Related

- frappe/frappe#39882 — adds `frappe.utils.preview` (the in-process renderer this uses on v16+).
- frappe/preview_generator#2 — the fallback service, now itself backed by the same framework renderer.

## Testing

The v16+ in-process path is verified locally (this bench is v17). The v15 fallback is the prior external-HTTP behaviour, unchanged — not exercised on a v17 bench.
