### PR TITLE
fix: preserve live request in get_preview_html (preview 500 via run_doc_method)

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -431,14 +431,22 @@ class BuilderPage(WebsiteGenerator):
 		"""Render this page in preview mode (uses draft_blocks when present), so a
 		preview can be generated for unpublished/draft pages too — not just for
 		pages reachable via their published route."""
-		set_request(method="GET", path=f"/{self.route or ''}")
-		frappe.local.request.for_preview = True
-		frappe.local.no_cache = 1
-		renderer = BuilderPageRenderer(path="")
-		renderer.docname = self.name
-		renderer.doctype = "Builder Page"
-		renderer.init_context()
-		return str(renderer.render().data, "utf-8")
+		# set_request() swaps frappe.local.request for a faked GET request. When
+		# this runs synchronously inside a real web request (e.g. run_doc_method),
+		# that clobbers the live request and drops its `after_response`, which
+		# then breaks sync_database. Save and restore the original request.
+		previous_request = getattr(frappe.local, "request", None)
+		try:
+			set_request(method="GET", path=f"/{self.route or ''}")
+			frappe.local.request.for_preview = True
+			frappe.local.no_cache = 1
+			renderer = BuilderPageRenderer(path="")
+			renderer.docname = self.name
+			renderer.doctype = "Builder Page"
+			renderer.init_context()
+			return str(renderer.render().data, "utf-8")
+		finally:
+			frappe.local.request = previous_request
 
 	def set_custom_font(self, context, font_map):
 		all_user_fonts = get_all_user_fonts()

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -92,6 +92,29 @@ class TestBuilderPage(FrappeTestCase):
 		content = get_response_content("/test-page")
 		self.assertTrue("Hello World!" in content)
 
+	def test_get_preview_html_preserves_outer_request(self):
+		"""get_preview_html() fakes a request via set_request(); when it runs
+		synchronously inside a real web request (e.g. run_doc_method) it must not
+		clobber it — doing so dropped the request's after_response and broke
+		sync_database with a 500."""
+		from frappe.utils import CallbackManager
+		from werkzeug.test import EnvironBuilder
+		from werkzeug.wrappers import Request
+
+		previous = getattr(frappe.local, "request", None)
+		try:
+			req = Request(EnvironBuilder(path="/api/method/run_doc_method").get_environ())
+			sentinel = CallbackManager()
+			req.after_response = sentinel
+			frappe.local.request = req
+
+			self.page.get_preview_html()
+
+			self.assertIs(frappe.local.request, req)
+			self.assertIs(frappe.local.request.after_response, sentinel)
+		finally:
+			frappe.local.request = previous
+
 	def test_onload(self):
 		getdoc("Builder Page", self.page.name)
 		self.assertEqual(frappe.response.docs[0].get("__onload").get("builder_path"), "builder")


### PR DESCRIPTION
## Problem

`BuilderPage.get_preview_html()` calls `set_request()`, which **replaces** `frappe.local.request` with a freshly-built faked GET request (to render the page in preview mode). That faked request has no `after_response` attribute — only the real request lifecycle (`init_request`) sets it.

When the preview is generated **synchronously inside a live web request** (e.g. via `run_doc_method`), this clobbers the real request. After the response, `frappe.app.sync_database()` runs `frappe.request.after_response.add(...)` and throws:

```
AttributeError: 'Request' object has no attribute 'after_response'
```

→ HTTP 500. It's latent today because previews are usually enqueued as background jobs, where there's no live web request to clobber — but it fires as soon as `generate_page_preview_image` runs in-request.

## Fix

Save and restore `frappe.local.request` around the `set_request()` call.

## Test

`test_get_preview_html_preserves_outer_request` — installs a request carrying an `after_response` sentinel, calls `get_preview_html()`, and asserts the live request (and its `after_response`) survive. No Chromium needed.

## Related

Surfaced while wiring up in-process previews (frappe/builder#628) but **independent** of it — this bug predates that work and reproduces with the existing external-service path too.
