### PR TITLE
feat: Preview pages on Canvas directly

### DIFF
--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -205,6 +205,12 @@ const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 const pageStore = usePageStore();
 
+const shouldForwardPreviewKeys = (event: KeyboardEvent) => {
+	if (event.key === "Alt") return true;
+	if (event.key === "p" && (event.ctrlKey || event.metaKey)) return true;
+	return false;
+};
+
 const {
 	previewUrl,
 	refreshKey: previewRefreshKey,
@@ -212,7 +218,7 @@ const {
 	previewHeights,
 	setPreviewIframe,
 	onIframeLoad,
-} = usePagePreview();
+} = usePagePreview(shouldForwardPreviewKeys);
 
 const showPagePreviewToggle = computed(
 	() => canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock,

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -70,11 +70,12 @@
 			</div>
 			<template v-if="builderStore.showPagePreview">
 				<div
-					class="canvas relative flex h-full min-h-[inherit] flex-col bg-surface-base shadow-2xl"
+					class="canvas relative bg-surface-base shadow-2xl"
 					:data-breakpoint="breakpoint.device"
 					:style="{
 						...canvasStyles,
 						width: `${breakpoint.width}px`,
+						height: previewHeights[breakpoint.device] || '200px',
 					}"
 					v-for="breakpoint in renderedBreakpoints"
 					v-show="breakpoint.visible"
@@ -97,7 +98,8 @@
 						frameborder="0"
 						:sandbox="PREVIEW_IFRAME_SANDBOX"
 						data-builder-preview-iframe
-						class="h-full min-h-[inherit] w-full flex-1 rounded-sm"
+						class="w-full rounded-sm"
+						style="display: block; height: 100%"
 						@load="onIframeLoad(breakpoint.device)" />
 					<div
 						v-show="previewLoading[breakpoint.device]"
@@ -207,6 +209,7 @@ const {
 	previewUrl,
 	refreshKey: previewRefreshKey,
 	previewLoading,
+	previewHeights,
 	setPreviewIframe,
 	onIframeLoad,
 } = usePagePreview();

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -7,11 +7,11 @@
 				<LoadingIcon></LoadingIcon>
 			</div>
 		</Transition>
-		<BlockSnapGuides></BlockSnapGuides>
+		<BlockSnapGuides v-if="!builderStore.showPagePreview"></BlockSnapGuides>
 		<div
 			class="fixed flex gap-40"
 			:class="{
-				'scheme-dark': builderStore.canvasDarkMode,
+				'scheme-dark': builderStore.canvasDarkMode && !builderStore.showPagePreview,
 			}"
 			ref="canvas"
 			:style="{
@@ -21,7 +21,26 @@
 				colorScheme: builderStore.canvasDarkMode ? 'dark' : 'light',
 			}">
 			<div class="absolute right-0 top-[-60px] flex rounded-md bg-surface-base px-3">
-				<Tooltip text="Toggle Canvas Dark Mode" :hoverDelay="0.6">
+				<Tooltip v-if="showPagePreviewToggle" text="Toggle Page Preview" :hoverDelay="0.6">
+					<div
+						v-show="!canvasProps.scaling && !canvasProps.panning"
+						class="w-auto cursor-pointer p-2"
+						@click.stop="togglePagePreview">
+						<span
+							:class="[
+								builderStore.showPagePreview ? 'lucide-mouse-pointer' : 'lucide-play',
+								'h-8 w-6 text-ink-gray-8',
+							]"
+							aria-hidden="true" />
+					</div>
+				</Tooltip>
+				<div
+					v-if="showPagePreviewToggle"
+					v-show="!canvasProps.scaling && !canvasProps.panning"
+					class="m-2 my-3 w-px bg-[var(--outline-gray-2)]"></div>
+				<Tooltip
+					:text="builderStore.showPagePreview ? 'Toggle Preview Color Scheme' : 'Toggle Canvas Dark Mode'"
+					:hoverDelay="0.6">
 					<div
 						v-show="!canvasProps.scaling && !canvasProps.panning"
 						class="w-auto cursor-pointer p-2"
@@ -49,37 +68,81 @@
 						aria-hidden="true" />
 				</div>
 			</div>
-			<div
-				class="canvas relative flex h-full bg-surface-base shadow-2xl contain-layout"
-				:data-breakpoint="breakpoint.device"
-				:style="{
-					...canvasStyles,
-					background: canvasProps.background,
-					width: `${breakpoint.width}px`,
-				}"
-				v-for="breakpoint in renderedBreakpoints"
-				v-show="breakpoint.visible"
-				:key="breakpoint.device">
+			<template v-if="builderStore.showPagePreview">
 				<div
-					class="absolute left-0 cursor-pointer select-none text-5xl text-ink-gray-7"
+					class="canvas relative flex h-full min-h-[inherit] flex-col bg-surface-base shadow-2xl"
+					:data-breakpoint="breakpoint.device"
 					:style="{
-						fontSize: `calc(${12}px * 1/${canvasProps.scale})`,
-						top: `calc(${-20}px * 1/${canvasProps.scale})`,
+						...canvasStyles,
+						width: `${breakpoint.width}px`,
 					}"
-					v-show="!canvasProps.scaling && !canvasProps.panning"
-					@click="activeBreakpoint = breakpoint.device">
-					{{ breakpoint.displayName }}
+					v-for="breakpoint in renderedBreakpoints"
+					v-show="breakpoint.visible"
+					:key="`preview-${breakpoint.device}`">
+					<div
+						class="absolute left-0 cursor-pointer select-none text-5xl text-ink-gray-7"
+						:style="{
+							fontSize: `calc(${12}px * 1/${canvasProps.scale})`,
+							top: `calc(${-20}px * 1/${canvasProps.scale})`,
+						}"
+						v-show="!canvasProps.scaling && !canvasProps.panning"
+						@click="activeBreakpoint = breakpoint.device">
+						{{ breakpoint.displayName }}
+					</div>
+					<iframe
+						v-if="previewUrl"
+						:src="previewUrl"
+						:key="`${breakpoint.device}-${previewRefreshKey}`"
+						:ref="(el) => setPreviewIframe(breakpoint.device, el as HTMLIFrameElement | null)"
+						frameborder="0"
+						:sandbox="PREVIEW_IFRAME_SANDBOX"
+						data-builder-preview-iframe
+						class="h-full min-h-[inherit] w-full flex-1 rounded-sm"
+						@load="onIframeLoad(breakpoint.device)" />
+					<div
+						v-show="previewLoading[breakpoint.device]"
+						class="absolute inset-0 z-20 grid place-items-center bg-surface-gray-1/80 text-ink-gray-5">
+						<LoadingIcon />
+					</div>
+					<div
+						v-show="builderStore.previewIframeScrollHeld"
+						class="absolute inset-0 z-10"
+						aria-hidden="true" />
 				</div>
-				<BuilderBlock
-					class="h-full min-h-[inherit]"
-					:block="block"
-					:style="variables"
-					:key="block.blockId"
-					:readonly="builderStore.readOnlyMode"
-					v-if="showBlocks"
-					:breakpoint="breakpoint.device"
-					:data="pageStore.pageData" />
-			</div>
+			</template>
+			<template v-else>
+				<div
+					class="canvas relative flex h-full bg-surface-base shadow-2xl contain-layout"
+					:data-breakpoint="breakpoint.device"
+					:style="{
+						...canvasStyles,
+						background: canvasProps.background,
+						width: `${breakpoint.width}px`,
+					}"
+					v-for="breakpoint in renderedBreakpoints"
+					v-show="breakpoint.visible"
+					:key="breakpoint.device">
+					<div
+						class="absolute left-0 cursor-pointer select-none text-5xl text-ink-gray-7"
+						:style="{
+							fontSize: `calc(${12}px * 1/${canvasProps.scale})`,
+							top: `calc(${-20}px * 1/${canvasProps.scale})`,
+						}"
+						v-show="!canvasProps.scaling && !canvasProps.panning"
+						@click="activeBreakpoint = breakpoint.device">
+						{{ breakpoint.displayName }}
+					</div>
+					<BuilderBlock
+						class="h-full min-h-[inherit]"
+						:block="block"
+						:style="variables"
+						:key="block.blockId"
+						:readonly="builderStore.readOnlyMode"
+						v-if="showBlocks"
+						:breakpoint="breakpoint.device"
+						:data="pageStore.pageData" />
+				</div>
+			</template>
 		</div>
 		<div
 			class="text-sm-semibold fixed bottom-12 left-[50%] flex translate-x-[-50%] cursor-default items-center justify-center gap-2 rounded-lg bg-surface-base px-3 py-2 text-center text-ink-gray-7 shadow-md"
@@ -117,6 +180,7 @@ import DraggablePopup from "@/components/Controls/DraggablePopup.vue";
 import SearchBlock from "@/components/Controls/SearchBlock.vue";
 import LoadingIcon from "@/components/Icons/Loading.vue";
 import useBuilderStore from "@/stores/builderStore";
+import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
@@ -127,6 +191,7 @@ import { useCanvasDropZone } from "@/utils/useCanvasDropZone";
 import { useCanvasEvents } from "@/utils/useCanvasEvents";
 import { useCanvasMarqueeSelection } from "@/utils/useCanvasMarqueeSelection";
 import { useCanvasUtils } from "@/utils/useCanvasUtils";
+import { PREVIEW_IFRAME_SANDBOX, usePagePreview } from "@/utils/usePagePreview";
 import { Tooltip } from "frappe-ui";
 import { Ref, computed, onMounted, onUnmounted, provide, reactive, ref, watch } from "vue";
 import setPanAndZoom from "../utils/panAndZoom";
@@ -135,7 +200,24 @@ import BuilderBlock from "./BuilderBlock.vue";
 import FitScreenIcon from "./Icons/FitScreen.vue";
 
 const builderStore = useBuilderStore();
+const canvasStore = useCanvasStore();
 const pageStore = usePageStore();
+
+const {
+	previewUrl,
+	refreshKey: previewRefreshKey,
+	previewLoading,
+	setPreviewIframe,
+	onIframeLoad,
+} = usePagePreview();
+
+const showPagePreviewToggle = computed(
+	() => canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock,
+);
+
+function togglePagePreview() {
+	builderStore.showPagePreview = !builderStore.showPagePreview;
+}
 
 const { cssVariables, darkCssVariables } = useBuilderVariable();
 
@@ -282,6 +364,10 @@ onUnmounted(() => {
 });
 
 const handleClick = (ev: MouseEvent) => {
+	if (builderStore.showPagePreview) {
+		return;
+	}
+
 	if (suppressNextClick.value) {
 		suppressNextClick.value = false;
 		return;

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -292,9 +292,7 @@ provide("showShortcuts", () => {
 });
 
 const canUsePreviewPanOverlay = () =>
-	builderStore.showPagePreview &&
-	canvasStore.editingMode === "page" &&
-	!canvasStore.versionPreviewBlock;
+	builderStore.showPagePreview && canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock;
 
 useEventListener(window, "blur", () => {
 	builderStore.setPreviewIframeScrollHeld(false);
@@ -326,8 +324,7 @@ useShortcut([
 		shift: true,
 		description: "Toggle page preview",
 		group: "View",
-		condition: () =>
-			canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock,
+		condition: () => canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock,
 		handler: () => {
 			builderStore.showPagePreview = !builderStore.showPagePreview;
 		},

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -321,6 +321,18 @@ useShortcut([
 		},
 	},
 	{
+		key: "p",
+		ctrl: true,
+		shift: true,
+		description: "Toggle page preview",
+		group: "View",
+		condition: () =>
+			canvasStore.editingMode === "page" && !canvasStore.versionPreviewBlock,
+		handler: () => {
+			builderStore.showPagePreview = !builderStore.showPagePreview;
+		},
+	},
+	{
 		key: "Alt",
 		alt: true,
 		description: "Hold to pan over preview",

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -321,8 +321,8 @@ useShortcut([
 		},
 	},
 	{
-		key: "Shift",
-		shift: true,
+		key: "Alt",
+		alt: true,
 		description: "Hold to pan over preview",
 		group: "View",
 		condition: canUsePreviewPanOverlay,

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -291,6 +291,15 @@ provide("showShortcuts", () => {
 	shortcutsModalOpen.value = true;
 });
 
+const canUsePreviewPanOverlay = () =>
+	builderStore.showPagePreview &&
+	canvasStore.editingMode === "page" &&
+	!canvasStore.versionPreviewBlock;
+
+useEventListener(window, "blur", () => {
+	builderStore.setPreviewIframeScrollHeld(false);
+});
+
 useShortcut([
 	{
 		key: " ",
@@ -310,6 +319,17 @@ useShortcut([
 		handler: () => {
 			shortcutsModalOpen.value = true;
 		},
+	},
+	{
+		key: "Shift",
+		shift: true,
+		description: "Hold to pan over preview",
+		group: "View",
+		condition: canUsePreviewPanOverlay,
+		triggeredOn: "hold",
+		preventDefault: true,
+		onHold: () => builderStore.setPreviewIframeScrollHeld(true),
+		onRelease: () => builderStore.setPreviewIframeScrollHeld(false),
 	},
 	{
 		key: "i",

--- a/frontend/src/pages/PagePreview.vue
+++ b/frontend/src/pages/PagePreview.vue
@@ -79,7 +79,12 @@ import PanelResizer from "@/components/PanelResizer.vue";
 import PublishButton from "@/components/PublishButton.vue";
 import router from "@/router";
 import usePageStore from "@/stores/pageStore";
-import { PREVIEW_IFRAME_SANDBOX, applyPreviewColorScheme, buildPagePreviewUrl, setupPreviewIframe } from "@/utils/usePagePreview";
+import {
+	PREVIEW_IFRAME_SANDBOX,
+	applyPreviewColorScheme,
+	buildPagePreviewUrl,
+	setupPreviewIframe,
+} from "@/utils/usePagePreview";
 import { useDark, useToggle } from "@vueuse/core";
 import { Tooltip, useShortcut } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";

--- a/frontend/src/pages/PagePreview.vue
+++ b/frontend/src/pages/PagePreview.vue
@@ -55,6 +55,7 @@
 			<iframe
 				:src="previewRoute"
 				frameborder="0"
+				:sandbox="PREVIEW_IFRAME_SANDBOX"
 				v-if="previewRoute"
 				class="flex-1 rounded-sm"
 				ref="previewWindow"></iframe>
@@ -78,6 +79,7 @@ import PanelResizer from "@/components/PanelResizer.vue";
 import PublishButton from "@/components/PublishButton.vue";
 import router from "@/router";
 import usePageStore from "@/stores/pageStore";
+import { PREVIEW_IFRAME_SANDBOX, applyPreviewColorScheme, buildPagePreviewUrl, setupPreviewIframe } from "@/utils/usePagePreview";
 import { useDark, useToggle } from "@vueuse/core";
 import { Tooltip, useShortcut } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
@@ -159,18 +161,6 @@ useShortcut({
 	condition: () => router.currentRoute.value.name === "preview",
 });
 
-const applyColorSchemeToIframe = (scheme: "dark" | "light") => {
-	try {
-		const win = previewWindow.value?.contentWindow;
-		const doc = win?.document;
-		if (doc && doc.documentElement) {
-			doc.documentElement.setAttribute("data-prefers-color-scheme", scheme);
-		}
-	} catch (e) {
-		// ignore cross-origin or timing errors
-	}
-};
-
 watchEffect(() => {
 	if (previewWindow.value) {
 		loading.value = true;
@@ -190,7 +180,7 @@ watchEffect(() => {
 					document.dispatchEvent(new MouseEvent("mousemove", ev));
 				});
 
-				applyColorSchemeToIframe(isDark.value ? "dark" : "light");
+				setupPreviewIframe(previewWindow.value, isDark.value ? "dark" : "light");
 			},
 			{ once: true },
 		);
@@ -200,7 +190,7 @@ watchEffect(() => {
 watch(isDark, async (val) => {
 	setPreviewURL();
 	setTimeout(() => {
-		applyColorSchemeToIframe(val ? "dark" : "light");
+		applyPreviewColorScheme(previewWindow.value, val ? "dark" : "light");
 	}, 100);
 });
 
@@ -216,14 +206,11 @@ const setWidth = (device: string) => {
 };
 
 const setPreviewURL = () => {
-	let queryParams: Record<string, any> = {
-		page: route.params.pageId,
-		...pageStore.routeVariables,
-		prefers_color_scheme: isDark.value ? "dark" : "light",
-	};
-	previewRoute.value = `/api/method/builder.api.get_page_preview_html?${Object.entries(queryParams)
-		.map(([key, value]) => `${key}=${value}`)
-		.join("&")}`;
+	previewRoute.value = buildPagePreviewUrl(
+		route.params.pageId as string,
+		pageStore.routeVariables,
+		isDark.value ? "dark" : "light",
+	);
 };
 
 onActivated(() => {

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -46,6 +46,9 @@ const useBuilderStore = defineStore("builderStore", {
 			attribute: "data-theme",
 		}),
 		canvasDarkMode: useStorage("canvasDarkMode", false),
+		showPagePreview: false,
+		/** True while Shift+X is held — shows overlay on preview iframes for canvas pan/zoom. */
+		previewIframeScrollHeld: false,
 		highlightBlocksWithClientScripts: false,
 		showSettingsDialog: false,
 		settingsActiveTab: <string>"page_general",
@@ -57,6 +60,16 @@ const useBuilderStore = defineStore("builderStore", {
 		},
 	},
 	actions: {
+		clearPagePreview() {
+			this.showPagePreview = false;
+			this.previewIframeScrollHeld = false;
+		},
+		setPreviewIframeScrollHeld(held: boolean) {
+			this.previewIframeScrollHeld = held;
+			if (held && this.mode === "move") {
+				this.mode = "select";
+			}
+		},
 		toggleReadOnlyMode(readonly: boolean | null = null) {
 			this.readOnlyMode = readonly ?? !this.readOnlyMode;
 		},

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1,6 +1,7 @@
 import type Block from "@/block";
 import type BuilderCanvas from "@/components/BuilderCanvas.vue";
 import { getVersionedDoc } from "@/data/snapshot";
+import useBuilderStore from "@/stores/builderStore";
 import { confirm, getBlockCopy, getBlockInstance } from "@/utils/helpers";
 import { toast } from "frappe-ui";
 import { defineStore } from "pinia";
@@ -54,6 +55,8 @@ const useCanvasStore = defineStore("canvasStore", {
 		// watcher), which hibernates history — so swapping the root in/out never touches
 		// the draft's content or undo stack. We just stash the draft root to restore it.
 		async previewVersion(snapshotName: string) {
+			const builderStore = useBuilderStore();
+			builderStore.clearPagePreview();
 			const doc = await getVersionedDoc(snapshotName);
 			const blocks = JSON.parse((doc?.draft_blocks || doc?.blocks || "[]") as string);
 			if (!blocks[0] || !this.activeCanvas) return;

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -67,8 +67,10 @@ const usePageStore = defineStore("pageStore", {
 			await this.setPageData(this.activePage);
 
 			const canvasStore = useCanvasStore();
+			const builderStore = useBuilderStore();
 			// switching pages always exits any active version preview
 			canvasStore.clearVersionPreview();
+			builderStore.clearPagePreview();
 			canvasStore.activeCanvas?.setRootBlock(this.pageBlocks[0], resetCanvas);
 
 			if (page.client_scripts?.length) {

--- a/frontend/src/utils/panAndZoom.ts
+++ b/frontend/src/utils/panAndZoom.ts
@@ -118,14 +118,12 @@ function setPanAndZoom(
 		}, 200);
 	};
 
-	panAndZoomAreaElement.addEventListener(
-		"wheel",
-		(e) => {
-			e.preventDefault();
-			requestAnimationFrame(() => updatePanAndZoom(e));
-		},
-		{ passive: false },
-	);
+	const handleWheel = (e: WheelEvent) => {
+		e.preventDefault();
+		requestAnimationFrame(() => updatePanAndZoom(e));
+	};
+
+	panAndZoomAreaElement.addEventListener("wheel", handleWheel, { passive: false });
 
 	return { setZoom };
 }

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -31,7 +31,7 @@ export function useCanvasDropZone(
 ) {
 	const { isOverDropZone } = useDropZone(canvasContainer, {
 		onDrop: async (files, ev) => {
-			if (builderStore.readOnlyMode) return;
+			if (builderStore.readOnlyMode || builderStore.showPagePreview) return;
 			canvasStore.isDropping = true;
 			if (files && files.length) {
 				handleFileDrop(files, ev);
@@ -43,7 +43,7 @@ export function useCanvasDropZone(
 		},
 
 		onOver: (files, ev) => {
-			if (builderStore.readOnlyMode) return;
+			if (builderStore.readOnlyMode || builderStore.showPagePreview) return;
 			const initialBlock = getInitialParentBlock(ev);
 			const shouldReplaceImage = initialBlock?.isImage();
 

--- a/frontend/src/utils/useCanvasMarqueeSelection.ts
+++ b/frontend/src/utils/useCanvasMarqueeSelection.ts
@@ -229,6 +229,7 @@ export function useCanvasMarqueeSelection(options: UseCanvasMarqueeSelectionOpti
 		if (ev.button !== 0) return false;
 		if (builderStore.mode !== "select") return false;
 		if (builderStore.readOnlyMode) return false;
+		if (builderStore.showPagePreview) return false;
 		if (canvasStore.isDragging || canvasProps.panning || canvasProps.scaling) return false;
 
 		const target = ev.target as HTMLElement | null;

--- a/frontend/src/utils/usePagePreview.ts
+++ b/frontend/src/utils/usePagePreview.ts
@@ -1,0 +1,179 @@
+import useBuilderStore from "@/stores/builderStore";
+import usePageStore from "@/stores/pageStore";
+import { computed, ref, watch } from "vue";
+
+/** Scripts + same-origin DOM access; modals for alert/confirm; no top navigation or popups. */
+export const PREVIEW_IFRAME_SANDBOX = "allow-scripts allow-same-origin allow-modals";
+
+export function buildPagePreviewUrl(
+	pageId: string,
+	routeVariables: Record<string, string>,
+	prefersColorScheme: "light" | "dark",
+	refreshKey = 0,
+) {
+	const queryParams: Record<string, string | number> = {
+		page: pageId,
+		...routeVariables,
+		prefers_color_scheme: prefersColorScheme,
+	};
+	if (refreshKey) {
+		queryParams._refresh = refreshKey;
+	}
+	return `/api/method/builder.api.get_page_preview_html?${Object.entries(queryParams)
+		.map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+		.join("&")}`;
+}
+
+export function applyPreviewColorScheme(
+	iframe: HTMLIFrameElement | null | undefined,
+	scheme: "dark" | "light",
+) {
+	try {
+		const doc = iframe?.contentWindow?.document;
+		if (doc?.documentElement) {
+			doc.documentElement.setAttribute("data-prefers-color-scheme", scheme);
+		}
+	} catch {
+		// ignore cross-origin or timing errors
+	}
+}
+
+/** Block navigation away from the previewed page; in-document hash links still work. */
+export function lockPreviewNavigation(iframe: HTMLIFrameElement | null | undefined) {
+	try {
+		const doc = iframe?.contentWindow?.document;
+		if (!doc || doc.documentElement.dataset.builderPreviewLocked === "true") {
+			return;
+		}
+		doc.documentElement.dataset.builderPreviewLocked = "true";
+
+		doc.addEventListener(
+			"click",
+			(ev) => {
+				const anchor = (ev.target as Element | null)?.closest("a[href]");
+				if (!anchor) {
+					return;
+				}
+				const href = anchor.getAttribute("href")?.trim() ?? "";
+				if (!href || href.startsWith("#")) {
+					return;
+				}
+				ev.preventDefault();
+				ev.stopPropagation();
+			},
+			true,
+		);
+
+		doc.addEventListener(
+			"submit",
+			(ev) => {
+				ev.preventDefault();
+				ev.stopPropagation();
+			},
+			true,
+		);
+	} catch {
+		// ignore cross-origin or timing errors
+	}
+}
+
+export function setupPreviewIframe(iframe: HTMLIFrameElement | null | undefined, scheme: "dark" | "light") {
+	applyPreviewColorScheme(iframe, scheme);
+	lockPreviewNavigation(iframe);
+}
+
+export function usePagePreview() {
+	const builderStore = useBuilderStore();
+	const pageStore = usePageStore();
+	const refreshKey = ref(0);
+	const previewIframes = ref<Record<string, HTMLIFrameElement | null>>({});
+	const previewLoading = ref<Record<string, boolean>>({});
+
+	const previewUrl = computed(() => {
+		if (!pageStore.selectedPage) {
+			return "";
+		}
+		return buildPagePreviewUrl(
+			pageStore.selectedPage,
+			pageStore.routeVariables,
+			builderStore.canvasDarkMode ? "dark" : "light",
+			refreshKey.value,
+		);
+	});
+
+	const setPreviewLoading = (device: string, loading: boolean) => {
+		previewLoading.value = { ...previewLoading.value, [device]: loading };
+	};
+
+	const markPreviewLoading = (devices?: string[]) => {
+		const targets = devices ?? Object.keys(previewIframes.value);
+		for (const device of targets) {
+			if (previewIframes.value[device]) {
+				setPreviewLoading(device, true);
+			}
+		}
+	};
+
+	const refreshPreview = () => {
+		markPreviewLoading();
+		refreshKey.value += 1;
+	};
+
+	const setPreviewIframe = (device: string, el: HTMLIFrameElement | null) => {
+		if (!el) {
+			if (previewIframes.value[device]) {
+				previewIframes.value[device] = null;
+			}
+			return;
+		}
+
+		const isNewIframe = previewIframes.value[device] !== el;
+		previewIframes.value[device] = el;
+		if (isNewIframe) {
+			setPreviewLoading(device, true);
+		}
+	};
+
+	const onIframeLoad = (device: string) => {
+		setupPreviewIframe(
+			previewIframes.value[device],
+			builderStore.canvasDarkMode ? "dark" : "light",
+		);
+		setPreviewLoading(device, false);
+	};
+
+	watch(
+		() => builderStore.showPagePreview,
+		(active) => {
+			if (active) {
+				refreshPreview();
+			} else {
+				previewLoading.value = {};
+			}
+		},
+	);
+
+	watch(previewUrl, () => {
+		if (builderStore.showPagePreview) {
+			markPreviewLoading();
+		}
+	});
+
+	watch(
+		() => pageStore.savingPage,
+		(saving, wasSaving) => {
+			if (wasSaving && !saving && builderStore.showPagePreview) {
+				refreshPreview();
+			}
+		},
+	);
+
+	return {
+		previewUrl,
+		refreshKey,
+		previewLoading,
+		refreshPreview,
+		setPreviewIframe,
+		onIframeLoad,
+	};
+}

--- a/frontend/src/utils/usePagePreview.ts
+++ b/frontend/src/utils/usePagePreview.ts
@@ -77,9 +77,32 @@ export function lockPreviewNavigation(iframe: HTMLIFrameElement | null | undefin
 	}
 }
 
+export function proxyPreviewKeyboardEvents(iframe: HTMLIFrameElement | null | undefined) {
+	try {
+		const win = iframe?.contentWindow;
+		if (!win) return;
+		const builderStore = useBuilderStore();
+
+		win.addEventListener("keydown", (ev: KeyboardEvent) => {
+			if (ev.altKey) {
+				builderStore.setPreviewIframeScrollHeld(true);
+			}
+		});
+
+		win.addEventListener("keyup", (ev: KeyboardEvent) => {
+			if (ev.key === "Alt") {
+				builderStore.setPreviewIframeScrollHeld(false);
+			}
+		});
+	} catch {
+		// ignore cross-origin or timing errors
+	}
+}
+
 export function setupPreviewIframe(iframe: HTMLIFrameElement | null | undefined, scheme: "dark" | "light") {
 	applyPreviewColorScheme(iframe, scheme);
 	lockPreviewNavigation(iframe);
+	proxyPreviewKeyboardEvents(iframe);
 }
 
 export function usePagePreview() {
@@ -135,10 +158,7 @@ export function usePagePreview() {
 	};
 
 	const onIframeLoad = (device: string) => {
-		setupPreviewIframe(
-			previewIframes.value[device],
-			builderStore.canvasDarkMode ? "dark" : "light",
-		);
+		setupPreviewIframe(previewIframes.value[device], builderStore.canvasDarkMode ? "dark" : "light");
 		setPreviewLoading(device, false);
 	};
 

--- a/frontend/src/utils/usePagePreview.ts
+++ b/frontend/src/utils/usePagePreview.ts
@@ -111,6 +111,8 @@ export function usePagePreview() {
 	const refreshKey = ref(0);
 	const previewIframes = ref<Record<string, HTMLIFrameElement | null>>({});
 	const previewLoading = ref<Record<string, boolean>>({});
+	const previewHeights = ref<Record<string, string>>({});
+	const heightObservers: Record<string, ResizeObserver> = {};
 
 	const previewUrl = computed(() => {
 		if (!pageStore.selectedPage) {
@@ -157,9 +159,37 @@ export function usePagePreview() {
 		}
 	};
 
+	function updatePreviewHeight(device: string) {
+		const iframe = previewIframes.value[device];
+		try {
+			const doc = iframe?.contentWindow?.document;
+			if (doc?.body) {
+				previewHeights.value = { ...previewHeights.value, [device]: doc.body.scrollHeight + "px" };
+			}
+		} catch {
+			// ignore cross-origin or timing errors
+		}
+	}
+
+	function observePreviewHeight(device: string) {
+		const iframe = previewIframes.value[device];
+		try {
+			const doc = iframe?.contentWindow?.document;
+			if (!doc?.body) return;
+			heightObservers[device]?.disconnect();
+			const observer = new ResizeObserver(() => updatePreviewHeight(device));
+			observer.observe(doc.body);
+			heightObservers[device] = observer;
+		} catch {
+			// ignore cross-origin or timing errors
+		}
+	}
+
 	const onIframeLoad = (device: string) => {
 		setupPreviewIframe(previewIframes.value[device], builderStore.canvasDarkMode ? "dark" : "light");
 		setPreviewLoading(device, false);
+		updatePreviewHeight(device);
+		observePreviewHeight(device);
 	};
 
 	watch(
@@ -169,6 +199,10 @@ export function usePagePreview() {
 				refreshPreview();
 			} else {
 				previewLoading.value = {};
+				previewHeights.value = {};
+				for (const device of Object.keys(heightObservers)) {
+					heightObservers[device]?.disconnect();
+				}
 			}
 		},
 	);
@@ -192,6 +226,7 @@ export function usePagePreview() {
 		previewUrl,
 		refreshKey,
 		previewLoading,
+		previewHeights,
 		refreshPreview,
 		setPreviewIframe,
 		onIframeLoad,

--- a/frontend/src/utils/usePagePreview.ts
+++ b/frontend/src/utils/usePagePreview.ts
@@ -77,35 +77,47 @@ export function lockPreviewNavigation(iframe: HTMLIFrameElement | null | undefin
 	}
 }
 
-export function proxyPreviewKeyboardEvents(iframe: HTMLIFrameElement | null | undefined) {
+export function proxyPreviewKeyboardEvents(
+	iframe: HTMLIFrameElement | null | undefined,
+	shouldForward?: (event: KeyboardEvent) => boolean,
+) {
 	try {
 		const win = iframe?.contentWindow;
-		if (!win) return;
-		const builderStore = useBuilderStore();
+		if (!win || !shouldForward) return;
 
-		win.addEventListener("keydown", (ev: KeyboardEvent) => {
-			if (ev.altKey) {
-				builderStore.setPreviewIframeScrollHeld(true);
-			}
-		});
+		const forwardKeyEvent = (event: KeyboardEvent) => {
+			if (!shouldForward(event)) return;
+			const synthetic = new KeyboardEvent(event.type, {
+				key: event.key,
+				code: event.code,
+				ctrlKey: event.ctrlKey,
+				altKey: event.altKey,
+				shiftKey: event.shiftKey,
+				metaKey: event.metaKey,
+				bubbles: true,
+				cancelable: true,
+			});
+			document.dispatchEvent(synthetic);
+		};
 
-		win.addEventListener("keyup", (ev: KeyboardEvent) => {
-			if (ev.key === "Alt") {
-				builderStore.setPreviewIframeScrollHeld(false);
-			}
-		});
+		win.addEventListener("keydown", forwardKeyEvent);
+		win.addEventListener("keyup", forwardKeyEvent);
 	} catch {
 		// ignore cross-origin or timing errors
 	}
 }
 
-export function setupPreviewIframe(iframe: HTMLIFrameElement | null | undefined, scheme: "dark" | "light") {
+export function setupPreviewIframe(
+	iframe: HTMLIFrameElement | null | undefined,
+	scheme: "dark" | "light",
+	shouldForward?: (event: KeyboardEvent) => boolean,
+) {
 	applyPreviewColorScheme(iframe, scheme);
 	lockPreviewNavigation(iframe);
-	proxyPreviewKeyboardEvents(iframe);
+	proxyPreviewKeyboardEvents(iframe, shouldForward);
 }
 
-export function usePagePreview() {
+export function usePagePreview(shouldForward?: (event: KeyboardEvent) => boolean) {
 	const builderStore = useBuilderStore();
 	const pageStore = usePageStore();
 	const refreshKey = ref(0);
@@ -186,7 +198,7 @@ export function usePagePreview() {
 	}
 
 	const onIframeLoad = (device: string) => {
-		setupPreviewIframe(previewIframes.value[device], builderStore.canvasDarkMode ? "dark" : "light");
+		setupPreviewIframe(previewIframes.value[device], builderStore.canvasDarkMode ? "dark" : "light", shouldForward);
 		setPreviewLoading(device, false);
 		updatePreviewHeight(device);
 		observePreviewHeight(device);


### PR DESCRIPTION
Introduces iframe preview rendered directly inside the canvas, so users can preview the page without disruption.
Ctrl+Shift+P toggles preview mode. It supports Live Preview so any changes to a block triggers a refresh.

https://github.com/user-attachments/assets/570e2cce-0860-40e4-81b7-1866dd857ff9

https://github.com/user-attachments/assets/0b7c294f-5d04-44d1-9bba-54a264ebad90


> Note: In Preview mode, the iframe captures all mouse events, so scroll and pan does not work when the mouse pointer is over the iframe, holding Alt/Opt puts an overlay on top of the iframe to restore pan and zoom on canvas.