### PR TITLE
Remove unused path from Tailwind config

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,6 @@ export default {
 		"./index.html",
 		"./src/**/*.{vue,js,ts,jsx,tsx}",
 		"./node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}",
-		"../node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}",
 	],
 	plugins: [
 		plugin(function ({ matchUtilities, theme }) {


### PR DESCRIPTION
The removed path refers to a node_modules folder in the parent directory which is clearly wrong as the node_modules folder in the current directory is where frappe-ui package will be found installed.