### PR TITLE
feat: allow dynamic values for custom HTML attributes

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1136,8 +1136,15 @@ def set_dynamic_content_placeholders(block: dict, data_key: dict | None = None):
 
 		if value_type == "attribute":
 			attributes = block.setdefault("attributes", {})
-			current_value = attributes.get(property_name, "")
-			attributes[property_name] = f"{{{{ {key} or '{escape_single_quotes(current_value)}' }}}}"
+			custom_attributes = block.setdefault("customAttributes", {})
+			if property_name in custom_attributes:
+				current_value = custom_attributes.get(property_name, "") or ""
+				custom_attributes[property_name] = (
+					f"{{{{ {key} if {key} or {key} in ['', 0] else '{escape_single_quotes(str(current_value))}' }}}}"
+				)
+			else:
+				current_value = attributes.get(property_name, "")
+				attributes[property_name] = f"{{{{ {key} or '{escape_single_quotes(current_value)}' }}}}"
 
 		elif value_type == "style":
 			attributes = block.setdefault("attributes", {})

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -38,6 +38,7 @@ data.update({
 	"color": "red",
 	"padding": "20px",
 	"link": "https://example.com",
+	"role": "admin",
 })
 """
 
@@ -216,7 +217,9 @@ class TestBuilderPage(FrappeTestCase):
 		sub_header.set_dynamic_value("padding", "style", "padding")
 
 		link.set_dynamic_value("link", "attribute", "href")
-		body.attach_children(header, sub_header, link)
+		custom_attr_block = Block(element="div", customAttributes={"data-role": "guest"})
+		custom_attr_block.set_dynamic_value("role", "attribute", "data-role")
+		body.attach_children(header, sub_header, link, custom_attr_block)
 
 		page = frappe.get_doc(
 			{
@@ -234,6 +237,7 @@ class TestBuilderPage(FrappeTestCase):
 			self.assertTrue("John Doe" in get_html_for(content, "tag", "h1"))
 			self.assertTrue("color: red;padding: 20px;" in get_html_for(content, "tag", "h2"))
 			self.assertTrue('href="https://example.com"' in get_html_for(content, "tag", "a"))
+			self.assertEqual("admin", get_html_for(content, "attribute", "data-role"))
 		finally:
 			page.delete()
 

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -64,6 +64,7 @@ declare module 'vue' {
     Dialog: typeof import('./src/components/Controls/Dialog.vue')['default']
     DimensionInput: typeof import('./src/components/DimensionInput.vue')['default']
     DraggablePopup: typeof import('./src/components/Controls/DraggablePopup.vue')['default']
+    DynamicValueDropdown: typeof import('./src/components/DynamicValueDropdown.vue')['default']
     DynamicValueHandler: typeof import('./src/components/Controls/DynamicValueHandler.vue')['default']
     EditableSpan: typeof import('./src/components/EditableSpan.vue')['default']
     EyeDropper: typeof import('./src/components/Icons/EyeDropper.vue')['default']

--- a/frontend/src/components/BlockPropertySections/CustomAttributesSection.ts
+++ b/frontend/src/components/BlockPropertySections/CustomAttributesSection.ts
@@ -8,6 +8,7 @@ const customAttributesSectionProperties = [
 		getProps: () => {
 			return {
 				obj: blockController.getCustomAttributes() as Record<string, string>,
+				allowDynamicValues: true,
 			};
 		},
 		searchKeyWords: "Attributes, CustomAttributes, Custom Attributes, HTML Attributes, Data Attributes",

--- a/frontend/src/components/DynamicValueDropdown.vue
+++ b/frontend/src/components/DynamicValueDropdown.vue
@@ -1,0 +1,149 @@
+<template>
+	<div class="relative w-full min-w-0">
+		<Autocomplete
+			ref="autocompleteRef"
+			class="w-full"
+			placeholder="Value"
+			:modelValue="autocompleteValue"
+			:getOptions="getOptions"
+			:showInputAsOption="true"
+			@update:modelValue="handleModelValueUpdate" />
+
+		<div
+			v-if="dynamicValue?.key"
+			class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 flex items-center gap-2 rounded bg-surface-violet-2 py-0.5 pl-2.5 pr-7 text-sm text-ink-violet-8">
+			<span class="lucide-zap size-3 shrink-0" aria-hidden="true" />
+			<MiddleTruncate :text="dynamicValue.key" />
+		</div>
+
+		<button
+			v-if="dynamicValue?.key"
+			class="absolute right-1 top-1 cursor-pointer p-1 text-ink-gray-4 hover:text-ink-gray-5"
+			tabindex="-1"
+			@click.stop="clearDynamicValue">
+			<span class="lucide-x size-3.5" />
+		</button>
+	</div>
+</template>
+
+<script setup lang="ts">
+import Autocomplete from "@/components/Controls/Autocomplete.vue";
+import MiddleTruncate from "@/components/MiddleTruncate.vue";
+import usePageStore from "@/stores/pageStore";
+import blockController from "@/utils/blockController";
+import { getDataArray, getDefaultPropsList, getParentProps, getRepeaterScopedData } from "@/utils/helpers";
+import { computed, ref, watch } from "vue";
+
+type DynamicValue = {
+	key: string;
+	comesFrom: BlockDataKey["comesFrom"];
+};
+
+type Option = {
+	label: string;
+	value: string;
+};
+
+const props = defineProps<{
+	modelValue: string;
+	dynamicValue?: DynamicValue;
+}>();
+
+const emit = defineEmits<{
+	(e: "update:modelValue", value: string): void;
+	(e: "setDynamicValue", value: DynamicValue): void;
+	(e: "clearDynamicValue"): void;
+}>();
+
+const pageStore = usePageStore();
+const autocompleteRef = ref<InstanceType<typeof Autocomplete> | null>(null);
+
+const currentBlock = computed(() => blockController.getFirstSelectedBlock());
+
+const pageDataArray = computed(() => {
+	if (!currentBlock.value) return [];
+	return getDataArray(getRepeaterScopedData(currentBlock.value, pageStore.pageData));
+});
+
+const ownProps = computed(() => {
+	if (!currentBlock.value) return [];
+	return Object.keys(currentBlock.value.getBlockProps());
+});
+
+const parentProps = computed(() => {
+	if (!currentBlock.value) return [];
+	return Object.keys(getParentProps(currentBlock.value));
+});
+
+const defaultProps = computed(() => {
+	if (!currentBlock.value) return [];
+	return Object.keys(getDefaultPropsList(currentBlock.value, blockController));
+});
+
+const autocompleteValue = computed(() => {
+	if (!props.dynamicValue?.key) return props.modelValue;
+	return encodeDynamicValue(props.dynamicValue.key, props.dynamicValue.comesFrom);
+});
+
+const dynamicOptions = computed(() => {
+	const options: Option[] = [];
+	const addOption = (key: string, comesFrom: BlockDataKey["comesFrom"]) => {
+		const value = encodeDynamicValue(key, comesFrom);
+		if (!options.some((option) => option.value === value)) {
+			options.push({ label: key, value });
+		}
+	};
+
+	pageDataArray.value.forEach((key) => addOption(key, "dataScript"));
+	[...ownProps.value, ...parentProps.value, ...defaultProps.value].forEach((key) => addOption(key, "props"));
+
+	return options;
+});
+
+const getOptions = async (query: string) => {
+	const normalizedQuery = query.trim().toLowerCase();
+	return dynamicOptions.value.filter((option) => {
+		return !normalizedQuery || option.label.toLowerCase().includes(normalizedQuery);
+	});
+};
+
+const handleModelValueUpdate = (value: string | null) => {
+	if (value == null) {
+		clearDynamicValue();
+		emit("update:modelValue", "");
+		return;
+	}
+
+	const dynamicOption = dynamicOptions.value.find((option) => option.value === value);
+	if (dynamicOption) {
+		emit("setDynamicValue", decodeDynamicValue(dynamicOption.value));
+		return;
+	}
+
+	clearDynamicValue();
+	emit("update:modelValue", value);
+};
+
+const clearDynamicValue = () => {
+	emit("clearDynamicValue");
+	emit("update:modelValue", "");
+};
+
+const encodeDynamicValue = (key: string, comesFrom: BlockDataKey["comesFrom"]) => {
+	return `${key}--${comesFrom}`;
+};
+
+const decodeDynamicValue = (value: string): DynamicValue => {
+	const key = value.split("--").slice(0, -1).join("--");
+	const comesFrom = value.split("--").slice(-1)[0] as BlockDataKey["comesFrom"];
+	return { key, comesFrom };
+};
+
+watch(
+	[pageDataArray, ownProps, parentProps, defaultProps],
+	() => {
+		autocompleteRef.value?.refreshOptions();
+	},
+	{ immediate: true },
+);
+</script>

--- a/frontend/src/components/ObjectEditor.vue
+++ b/frontend/src/components/ObjectEditor.vue
@@ -1,14 +1,26 @@
 <template>
 	<div ref="objectEditor" class="flex flex-col gap-2" @paste="pasteObj">
 		<div v-for="(value, key, index) in obj" :key="index" class="flex gap-2">
-			<BuilderInput
-				placeholder="Property"
-				:modelValue="key"
-				@update:modelValue="(val: string) => replaceKey(key, val)" />
-			<BuilderInput
-				placeholder="Value"
+			<div class="min-w-0 flex-1">
+				<BuilderInput
+					placeholder="Property"
+					:modelValue="key"
+					@update:modelValue="(val: string) => replaceKey(key, val)" />
+			</div>
+			<DynamicValueDropdown
+				v-if="allowDynamicValues"
+				class="min-w-0 flex-1"
 				:modelValue="value"
-				@update:modelValue="(val: string) => updateObjectValue(key, val)" />
+				:dynamicValue="getDynamicValueForKey(key)"
+				@update:modelValue="(val: string) => updateObjectValue(key, val)"
+				@setDynamicValue="(val) => setDynamicValueForKey(key, val.key, val.comesFrom)"
+				@clearDynamicValue="() => clearDynamicValueForKey(key)" />
+			<div v-else class="min-w-0 flex-1">
+				<BuilderInput
+					placeholder="Value"
+					:modelValue="value"
+					@update:modelValue="(val: string) => updateObjectValue(key, val)" />
+			</div>
 			<Button
 				class="flex-shrink-0 text-xs"
 				variant="subtle"
@@ -22,17 +34,57 @@
 	</div>
 </template>
 <script setup lang="ts">
+import DynamicValueDropdown from "@/components/DynamicValueDropdown.vue";
+import blockController from "@/utils/blockController";
 import { mapToObject, replaceMapKey } from "@/utils/helpers";
 import { nextTick, ref } from "vue";
 
 const props = defineProps<{
 	obj: Record<string, string>;
 	description?: string;
+	allowDynamicValues?: boolean;
 }>();
 
 const emit = defineEmits({
 	"update:obj": (obj: Record<string, string>) => true,
 });
+
+const getDynamicValueForKey = (key: string) => {
+	const block = blockController.getFirstSelectedBlock();
+	if (!block) {
+		return { key: "", comesFrom: "dataScript" as BlockDataKey["comesFrom"] };
+	}
+	const dataKeyObj = block.getDynamicValues().find((obj) => obj.type === "attribute" && obj.property === key);
+	return {
+		key: dataKeyObj?.key || "",
+		comesFrom: dataKeyObj?.comesFrom || ("dataScript" as BlockDataKey["comesFrom"]),
+	};
+};
+
+const setDynamicValueForKey = (attrKey: string, dynamicKey: string, comesFrom: BlockDataKey["comesFrom"]) => {
+	blockController.getSelectedBlocks().forEach((block) => {
+		block.setDynamicValue(attrKey, "attribute", dynamicKey, comesFrom);
+	});
+	updateObjectValue(attrKey, dynamicKey);
+};
+
+const clearDynamicValueForKey = (attrKey: string) => {
+	blockController.getSelectedBlocks().forEach((block) => {
+		block.removeDynamicValue(attrKey, "attribute");
+	});
+};
+
+const migrateDynamicValueKey = (oldKey: string, newKey: string) => {
+	if (!props.allowDynamicValues || oldKey === newKey) return;
+	blockController.getSelectedBlocks().forEach((block) => {
+		const dataKeyObj = block
+			.getDynamicValues()
+			.find((obj) => obj.type === "attribute" && obj.property === oldKey);
+		if (!dataKeyObj?.key) return;
+		block.removeDynamicValue(oldKey, "attribute");
+		block.setDynamicValue(newKey, "attribute", dataKeyObj.key, dataKeyObj.comesFrom);
+	});
+};
 
 const addObjectKey = async () => {
 	const map = new Map(Object.entries(props.obj));
@@ -54,12 +106,18 @@ const updateObjectValue = (key: string, value: string) => {
 
 const replaceKey = (oldKey: string, newKey: string) => {
 	const map = new Map(Object.entries(props.obj));
+	migrateDynamicValueKey(oldKey, newKey);
 	emit("update:obj", mapToObject(replaceMapKey(map, oldKey, newKey)));
 };
 
 const deleteObjectKey = (key: string) => {
 	const map = new Map(Object.entries(props.obj));
 	map.delete(key);
+	if (props.allowDynamicValues) {
+		blockController.getSelectedBlocks().forEach((block) => {
+			block.removeDynamicValue(key, "attribute");
+		});
+	}
 	emit("update:obj", mapToObject(map));
 };
 

--- a/frontend/src/utils/blockController.ts
+++ b/frontend/src/utils/blockController.ts
@@ -187,8 +187,9 @@ const blockController = {
 	setCustomAttributes: (customAttributes: BlockAttributeMap) => {
 		canvasStore.activeCanvas?.selectedBlocks.forEach((block) => {
 			Object.keys(block.customAttributes).forEach((key) => {
-				if (!customAttributes[key]) {
+				if (!(key in customAttributes)) {
 					delete block.customAttributes[key];
+					block.removeDynamicValue(key, "attribute");
 				}
 			});
 			Object.assign(block.customAttributes, customAttributes);


### PR DESCRIPTION
## Summary
- Add support for dynamic values in custom HTML attributes while keeping attribute names and static fallback values editable as plain strings.
- Reuse the existing `attribute` dynamic value type for custom attributes instead of introducing a separate type.
- Add a reusable dynamic value dropdown (currently used in object editor), with dynamic selections shown using the existing zap icon/violet background pattern.

https://github.com/user-attachments/assets/e959a515-0893-4faf-b01e-b43db4793ceb

