### PR TITLE
fix: avoid DuckDB lock conflicts on concurrent analytics reads

### DIFF
--- a/builder/builder_analytics.py
+++ b/builder/builder_analytics.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import duckdb
 import frappe
@@ -8,13 +9,27 @@ DUCKDB_TABLE = "web_page_views"
 
 
 class DuckDBConnection:
-	def __init__(self):
+	# DuckDB takes a single cross-process file lock: concurrent read-only connections
+	# coexist, but a read-write one is exclusive. Reads pass read_only=True so dashboard
+	# requests don't lock each other out; both kinds retry briefly to ride out the lock
+	# held by the periodic ingestion (or another worker mid-connect).
+	def __init__(self, read_only=False, retries=8, retry_delay=0.25):
 		self.db = None
+		self.read_only = read_only
+		self.retries = retries
+		self.retry_delay = retry_delay
 
 	def __enter__(self):
 		duckdb_path = os.path.join(frappe.get_site_path(), "builder_analytics.duckdb")
-		self.db = duckdb.connect(duckdb_path)
-		return self.db
+		for attempt in range(self.retries):
+			try:
+				self.db = duckdb.connect(duckdb_path, read_only=self.read_only)
+				return self.db
+			except duckdb.IOException as e:
+				# Only the lock conflict is transient; a missing file etc. should surface
+				if "lock" not in str(e).lower() or attempt == self.retries - 1:
+					raise
+				time.sleep(self.retry_delay)
 
 	def __exit__(self, exc_type, exc_val, exc_tb):
 		if self.db:
@@ -244,7 +259,7 @@ def get_page_analytics(
 		# Use provided interval or default to daily
 		interval = interval or "daily"
 
-		with DuckDBConnection() as db:
+		with DuckDBConnection(read_only=True) as db:
 			# Get interval-based data
 			interval_query = get_interval_views_query(where_clause, interval, table_name)
 			rows = db.execute(interval_query, params).fetchall()
@@ -279,7 +294,7 @@ def get_top_pages(
 		inner_clause, params = build_where_clause(route, from_date, to_date, route_filter_type)
 		where_clause = "" if inner_clause == "1=1" else f"WHERE {inner_clause}"
 
-		with DuckDBConnection() as db:
+		with DuckDBConnection(read_only=True) as db:
 			q = f"""
 				SELECT path as route, COUNT(*) as view_count, SUM(is_unique) as unique_view_count
 				FROM {table_name}
@@ -306,7 +321,7 @@ def get_top_referrers(
 	try:
 		where_clause, params = build_where_clause(route, from_date, to_date, route_filter_type)
 
-		with DuckDBConnection() as db:
+		with DuckDBConnection(read_only=True) as db:
 			referrer_query = get_referrer_domain_query(where_clause, 20, table_name)
 			rows = db.execute(referrer_query, params).fetchall()
 			return [{"domain": r[0], "count": r[1], "unique_count": r[2]} for r in rows]


### PR DESCRIPTION
### Problem

`duckdb.connect()` defaults to **read-write**, which takes an exclusive cross-process file lock. When the analytics dashboard fires multiple endpoints at once (e.g. page-views + referrers), they land on different gunicorn workers and the second fails:

```
IO Error: Could not set lock on file "…/builder_analytics.duckdb":
Conflicting lock is held in /usr/bin/python3.14 (PID 252).
```

### Fix

In `DuckDBConnection`:
- **Read paths open `read_only=True`** (`get_page_analytics`, `get_top_pages`, `get_top_referrers`) — DuckDB allows any number of concurrent read-only connections across processes, so dashboard requests no longer lock each other out.
- **Bounded retry** (matched on the "lock" message so a missing file still surfaces) rides out the brief window when the periodic ingestion holds the write lock.

Writers (`setup_duckdb_table`, `ingest_web_page_views_to_duckdb`) stay read-write.