### PR TITLE
perf: combine Google Fonts request and preconnect gstatic

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -4,6 +4,7 @@
 import copy
 import re
 from typing import Any
+from urllib.parse import quote_plus
 
 import bs4 as bs
 import frappe
@@ -1339,7 +1340,7 @@ def get_google_font_urls(font_map: dict) -> list[str]:
 	normalize_font_weights(font_map)
 	return [
 		"https://fonts.googleapis.com/css2"
-		f"?family={font.replace(' ', '+')}"
+		f"?family={quote_plus(font)}"
 		f":wght@{';'.join(str(weight) for weight in options['weights'])}"
 		"&display=swap"
 		for font, options in font_map.items()

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1343,13 +1343,12 @@ def normalize_font_weights(font_map: dict) -> None:
 def get_google_font_urls(font_map: dict) -> list[str]:
 	"""Build one combined Google Fonts stylesheet URL per font family."""
 	normalize_font_weights(font_map)
-	return [
-		"https://fonts.googleapis.com/css2"
-		f"?family={quote_plus(font)}"
-		f":wght@{';'.join(str(weight) for weight in options['weights'])}"
-		"&display=swap"
-		for font, options in font_map.items()
-	]
+	urls = []
+	for font, options in font_map.items():
+		family = quote_plus(font)
+		weights = ";".join(str(weight) for weight in options["weights"])
+		urls.append(f"https://fonts.googleapis.com/css2?family={family}:wght@{weights}&display=swap")
+	return urls
 
 
 def set_fonts_from_html(soup, font_map):

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -383,7 +383,7 @@ class BuilderPage(WebsiteGenerator):
 		context.has_dual_mode_image = has_dual_mode_image
 
 		self.set_custom_font(context, fonts)
-		context.fonts = fonts
+		context.font_urls = get_google_font_urls(fonts)
 		context.__content = content
 		context.style = render_template(style, page_data)
 		context.editor_link = f"/{builder_path}/page/{self.name}"
@@ -1323,6 +1323,27 @@ def set_fonts(styles, font_map, inherited_font=None):
 					font_map[font]["weights"].sort()
 			else:
 				font_map[font] = {"weights": [weight]}
+
+
+def normalize_font_weights(font_map: dict) -> None:
+	"""Make each font's weights render-ready for the Google Fonts request: numeric,
+	deduped, sorted, and always including 400 so the regular face is loaded."""
+	for options in font_map.values():
+		weights = {int(weight) for weight in options.get("weights", [])}
+		weights.add(400)
+		options["weights"] = sorted(weights)
+
+
+def get_google_font_urls(font_map: dict) -> list[str]:
+	"""Build one combined Google Fonts stylesheet URL per font family."""
+	normalize_font_weights(font_map)
+	return [
+		"https://fonts.googleapis.com/css2"
+		f"?family={font.replace(' ', '+')}"
+		f":wght@{';'.join(str(weight) for weight in options['weights'])}"
+		"&display=swap"
+		for font, options in font_map.items()
+	]
 
 
 def set_fonts_from_html(soup, font_map):

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1259,6 +1259,11 @@ def append_state_style(style_obj, style_tag, style_class, device="desktop"):
 			style_tag.append(wrap_with_media_query(style_string, device))
 
 
+def get_font_family(font: str) -> str:
+	"""Return the first family from a CSS font stack (e.g. 'Inter, sans-serif' -> 'Inter')."""
+	return font.split(",")[0].strip().strip("'\"")
+
+
 def set_fonts(styles, font_map, inherited_font=None):
 	weight_map = {
 		"thin": "100",
@@ -1302,8 +1307,8 @@ def set_fonts(styles, font_map, inherited_font=None):
 			# fontWeight is set but fontFamily is not — use explicitly passed ancestor font
 			font = inherited_font
 		if font:
-			# Remove quotes if present
-			font = font.strip("'\"")
+			# Use the first family from a fallback list, e.g. "Inter, sans-serif" -> "Inter"
+			font = get_font_family(font)
 
 			# Skip if it is a system font
 			if font.lower() in system_fonts:
@@ -1353,7 +1358,7 @@ def set_fonts_from_html(soup, font_map):
 		styles = tag.attrs.get("style").split(";")
 		for style in styles:
 			if "font-family" in style:
-				font = style.split(":")[1].strip().strip("'\"")
+				font = get_font_family(style.split(":")[1])
 				if font:
 					font_map[font] = {"weights": [400]}
 

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -901,6 +901,16 @@ class TestBuilderPage(FrappeTestCase):
 		self.assertEqual(font_map["Inter"]["weights"], [400, 700])
 		self.assertEqual(font_map["Open Sans"]["weights"], [600])
 
+	def test_set_fonts_uses_primary_family_from_fallback_list(self):
+		from builder.builder.doctype.builder_page.builder_page import set_fonts
+
+		font_map = {}
+		set_fonts([{"fontFamily": "Inter, sans-serif", "fontWeight": "500"}], font_map)
+
+		# Only the first family is requested, not the whole CSS stack
+		self.assertIn("Inter", font_map)
+		self.assertNotIn("Inter, sans-serif", font_map)
+
 	def test_get_google_font_urls(self):
 		from builder.builder.doctype.builder_page.builder_page import get_google_font_urls
 

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -907,15 +907,18 @@ class TestBuilderPage(FrappeTestCase):
 		font_map = {
 			"Newsreader": {"weights": [500]},
 			"Open Sans": {"weights": [700, 400]},
+			"Foo & Bar": {"weights": [400]},
 		}
 		urls = get_google_font_urls(font_map)
 
-		# One combined request per family: 400 always included, spaces become +, weights sorted
+		# One combined request per family: 400 always included, weights sorted, family
+		# name URL-encoded (spaces -> +, reserved chars escaped so the URL can't break)
 		self.assertEqual(
 			urls,
 			[
 				"https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500&display=swap",
 				"https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap",
+				"https://fonts.googleapis.com/css2?family=Foo+%26+Bar:wght@400&display=swap",
 			],
 		)
 

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -901,6 +901,24 @@ class TestBuilderPage(FrappeTestCase):
 		self.assertEqual(font_map["Inter"]["weights"], [400, 700])
 		self.assertEqual(font_map["Open Sans"]["weights"], [600])
 
+	def test_get_google_font_urls(self):
+		from builder.builder.doctype.builder_page.builder_page import get_google_font_urls
+
+		font_map = {
+			"Newsreader": {"weights": [500]},
+			"Open Sans": {"weights": [700, 400]},
+		}
+		urls = get_google_font_urls(font_map)
+
+		# One combined request per family: 400 always included, spaces become +, weights sorted
+		self.assertEqual(
+			urls,
+			[
+				"https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500&display=swap",
+				"https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap",
+			],
+		)
+
 	def test_set_fonts_inherits_font_family_from_ancestor(self):
 		"""set_fonts should use inherited_font when a style has fontWeight but no fontFamily."""
 		from builder.builder.doctype.builder_page.builder_page import set_fonts

--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -20,12 +20,9 @@
 	{% block meta_block %}{% include "templates/includes/meta_block.html" %}{% endblock %}
 	<link rel="stylesheet" href="/assets/builder/reset.css?v=4" media="screen">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
-	{% for (font, options) in fonts.items() %}
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ font | replace(' ', '+') }}&display=swap" media="screen">
-	{% set other_weights = options.weights | reject('equalto', '400') | reject('equalto', 400) | list %}
-	{% if other_weights %}
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ font | replace(' ', '+') }}:wght@{{ other_weights | join(';') }}&display=swap" media="screen">
-	{% endif %}
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	{% for font_url in font_urls %}
+	<link rel="stylesheet" href="{{ font_url }}" media="screen">
 	{% endfor %}
 	{{ style }}
 	{%- if preview -%}


### PR DESCRIPTION
## What

Published pages emitted **two** render-blocking Google Fonts stylesheet requests per family when a non-default weight was used — a base `family=Newsreader&display=swap` plus a separate `family=Newsreader:wght@500&display=swap`. This collapses them into a **single combined request** per family with all weights, e.g.:

```
https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500&display=swap
```

Also adds a `preconnect` to `https://fonts.gstatic.com` (where the font binaries are actually served) — previously only `fonts.googleapis.com` (the CSS host) was preconnected.

## Why

- One fewer render-blocking round-trip per multi-weight font (e.g. the `/journeys` page uses Newsreader at 400 + 500 → was 2 requests, now 1).
- Preconnecting `fonts.gstatic.com` warms the TLS connection for the font files, not just the CSS.
- `400` is always included so the regular face is loaded; weights are deduped and sorted ascending (the previous two-request form never sorted the weights axis).

## How

Weight normalization and URL construction moved out of the Jinja template into Python (`normalize_font_weights` / `get_google_font_urls`) so the template is a plain loop and the logic is unit-testable.

```jinja
{% for font_url in font_urls %}
<link rel="stylesheet" href="{{ font_url }}" media="screen">
{% endfor %}
```