### PR TITLE
fix: re-introduce block clientScript to avoid breakage

### DIFF
--- a/builder/builder/component_versions.py
+++ b/builder/builder/component_versions.py
@@ -34,9 +34,6 @@ COMPONENT_VERSION_KEEP = 50
 # Fields captured per component version (the full state needed to render)
 COMPONENT_VERSION_FIELDS = [
 	"block",
-	"component_css",
-	"component_js",
-	"component_props",
 	"component_data_script",
 ]
 
@@ -122,9 +119,6 @@ def ensure_component_version(
 
 		data = {
 			"block": compact_json(block),
-			"component_css": values.component_css,
-			"component_js": values.component_js,
-			"component_props": values.component_props,
 			"component_data_script": values.component_data_script,
 		}
 		data_json = compact_json(data)
@@ -202,9 +196,6 @@ def resolve_component(component_id: str, pinned_version: str | None = None) -> d
 		return None
 	return {
 		"block": values.block,
-		"component_css": values.component_css,
-		"component_js": values.component_js,
-		"component_props": values.component_props,
 		"component_data_script": values.component_data_script,
 	}
 

--- a/builder/builder/doctype/builder_component/builder_component.json
+++ b/builder/builder/doctype/builder_component/builder_component.json
@@ -10,12 +10,9 @@
  "field_order": [
   "component_name",
   "block",
-  "component_props",
   "for_web_page",
   "component_id",
-  "component_data_script",
-  "component_js",
-  "component_css"
+  "component_data_script"
  ],
  "fields": [
   {
@@ -28,11 +25,6 @@
    "fieldtype": "JSON",
    "label": "Block",
    "read_only": 1
-  },
-  {
-   "fieldname": "component_props",
-   "fieldtype": "JSON",
-   "label": "Component Props"
   },
   {
    "fieldname": "for_web_page",
@@ -55,18 +47,6 @@
     "label": "Component Data Script",
     "options": "Python",
     "description": "Server-side Python script that populates component data. Receives props as input. Use: data.events = frappe.get_list('Event')"
-   },
-   {
-   "fieldname": "component_js",
-   "fieldtype": "Code",
-   "label": "Component JavaScript",
-   "options": "JavaScript"
-  },
-  {
-   "fieldname": "component_css",
-   "fieldtype": "Code",
-   "label": "Component CSS",
-   "options": "CSS"
    }
   ],
  "index_web_pages_for_search": 1,

--- a/builder/builder/doctype/builder_component/builder_component.py
+++ b/builder/builder/doctype/builder_component/builder_component.py
@@ -24,11 +24,8 @@ class BuilderComponent(Document):
 		from frappe.types import DF
 
 		block: DF.JSON | None
-		component_props: DF.JSON | None
-		component_css: DF.Code | None
 		component_data_script: DF.Code | None
 		component_id: DF.Data | None
-		component_js: DF.Code | None
 		component_name: DF.Data | None
 		for_web_page: DF.Link | None
 	# end: auto-generated types
@@ -199,7 +196,7 @@ def get_component_data(
 
 	if script is None:
 		script = component_doc.component_data_script
-	props = props or component_doc.component_props
+	props = props or get_component_prop_values(component_doc.block)
 
 	if isinstance(props, str):
 		props = frappe.parse_json(props)
@@ -215,3 +212,13 @@ def get_component_data(
 	execute_script(script, _locals, component_name)
 
 	return _locals["component"]
+
+
+def get_component_prop_values(block: dict | str | None) -> dict:
+	block = frappe.parse_json(block or "{}")
+	return {
+		name: config.get("value")
+		if config.get("value") is not None
+		else config.get("propOptions", {}).get("options", {}).get("defaultValue")
+		for name, config in (block.get("props") or {}).items()
+	}

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import copy
+import hashlib
 import re
 from typing import Any
 from urllib.parse import quote_plus
@@ -1076,9 +1077,9 @@ def create_client_script_tag(state: dict, script_id: str, script: dict) -> bs.Ta
 	"""Register a client script globally (once) and return its per-block tag."""
 	if script["type"] == "JavaScript":
 		if script_id not in state["used_block_scripts"]:
-			component_script = escape_raw_text_end_tag(script["script"], "script")
+			block_script = escape_raw_text_end_tag(script["script"], "script")
 			state["global_script_tag"].append(
-				f"async function client_script_{script_id}(component_data, props) {{{component_script}}}\n"
+				f"async function client_script_{script_id}(component_data, props) {{{block_script}}}\n"
 			)
 			state["used_block_scripts"].add(script_id)
 
@@ -1086,36 +1087,37 @@ def create_client_script_tag(state: dict, script_id: str, script: dict) -> bs.Ta
 		invocation = (
 			f"(client_script_{script_id}).call("
 			f"document.querySelector('[data-block-uid=\"{{{{ unique_hash }}}}\"]'), "
-			f"{{{{ component.component_data | to_safe_json }}}}, "
-			f"{{{{ props | to_safe_json }}}}"
+			f"{{{{ (component.component_data if component is defined else {{}}) | to_safe_json }}}}, "
+			f"{{{{ (props if props is defined else {{}}) | to_safe_json }}}}"
 			f");"
 		)
 		script_tag.string = invocation
 		return script_tag
 
 	style_tag = state["soup"].new_tag("style")
-	component_style = escape_raw_text_end_tag(script["script"], "style")
-	style_tag.string = f"@scope {{ {component_style} }}"
+	block_style = escape_raw_text_end_tag(script["script"], "style")
+	style_tag.string = f"@scope {{ {block_style} }}"
 	return style_tag
 
 
 def attach_client_script(tag: bs.Tag, block: dict, state: dict):
 	"""Attach client-side JavaScript/CSS to the block."""
-	component_scripts = block.get("componentClientScripts") or []
-	scripts = {
-		str(component_script["name"]): {
-			"script": component_script["script"],
-			"type": component_script["type"],
-		}
-		for component_script in component_scripts
-	}
+	client_script = block.get("clientScript")
+	if client_script is None:
+		client_script = {"js": block.get("blockClientScript")}
+	scripts = [
+		{"script": client_script.get("js"), "type": "JavaScript"},
+		{"script": client_script.get("css"), "type": "CSS"},
+	]
+	scripts = [script for script in scripts if script["script"]]
 
 	if not scripts:
 		return
 
 	tag.attrs["data-block-uid"] = "{{ unique_hash }}"
 
-	for script_id, script in reversed(list(scripts.items())):
+	for script in scripts:
+		script_id = hashlib.sha256(script["script"].encode()).hexdigest()[:16]
 		tag.append(create_client_script_tag(state, script_id, script))
 
 
@@ -1262,43 +1264,11 @@ def extend_block_with_component(block: dict) -> tuple[dict, str | None]:
 
 	component_block = frappe.parse_json(component.get("block") or "{}")
 	if component_block:
-		if component.get("component_props"):
-			component_block["props"] = frappe.parse_json(component["component_props"]) or {}
-
 		extend_block(component_block, block)
-
-		component_scripts = []
-		component_script_base = get_component_script_base(component_id, component_version)
-		if component.get("component_css"):
-			component_scripts.append(
-				{
-					"name": f"{component_script_base}_css",
-					"script": component["component_css"],
-					"type": "CSS",
-				}
-			)
-		if component.get("component_js"):
-			component_scripts.append(
-				{
-					"name": f"{component_script_base}_js",
-					"script": component["component_js"],
-					"type": "JavaScript",
-				}
-			)
-
-		if component_scripts:
-			component_block["componentClientScripts"] = component_scripts
 
 		return component_block, component_id
 
 	return block, None
-
-
-def get_component_script_base(component_id: str, component_version: str | None) -> str:
-	parts = [frappe.scrub(component_id)]
-	if component_version:
-		parts.append(frappe.scrub(component_version))
-	return "_".join(parts)
 
 
 def wrap_with_media_query(style_string, device):

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -7,6 +7,7 @@ from frappe.desk.form.load import getdoc
 from frappe.tests.utils import FrappeTestCase
 from frappe.website.serve import get_response, get_response_content
 
+from builder.builder.component_versions import ensure_component_version
 from builder.utils import Block
 
 repeater_page_data_script = """
@@ -435,15 +436,14 @@ class TestBuilderPage(FrappeTestCase):
 	def test_component_client_script(self):
 		component_root = Block(element="div", blockId="comp-root")
 		component_content = Block(element="h4", blockId="comp-content", innerHTML="Component Content")
+		block_javascript = 'this.innerHTML = "</script><p>Component Script</p>";'
+		block_css = 'h4::after { content: "</style><p>Component Style</p>"; }'
+		component_root.clientScript = {"js": block_javascript, "css": block_css}
 		component_root.attach_children(component_content)
-		component_js = 'this.innerHTML = "</script><p>Component Script</p>";'
-		component_css = 'h4::after { content: "</style><p>Component Style</p>"; }'
 		component = frappe.get_doc(
 			{
 				"doctype": "Builder Component",
 				"block": component_root.as_json(),
-				"component_js": component_js,
-				"component_css": component_css,
 			}
 		).insert()
 
@@ -471,8 +471,8 @@ class TestBuilderPage(FrappeTestCase):
 
 		try:
 			content = get_response_content("/component-client-script-test")
-			self.assertNotIn(component_js, content)
-			self.assertNotIn(component_css, content)
+			self.assertNotIn(block_javascript, content)
+			self.assertNotIn(block_css, content)
 			self.assertIn(r"<\/script><p>Component Script</p>", content)
 			self.assertIn(r"<\/style><p>Component Style</p>", content)
 		finally:
@@ -485,27 +485,31 @@ component.update({
 	"component_data": {"greeting": "hello from component data"},
 })
 """
+		component_root = Block(
+			element="div",
+			blockId="script-root",
+			clientScript={"js": 'this.dataset.received = "ok";'},
+			props={
+				"title": {
+					"label": "Title",
+					"isStandard": True,
+					"isDynamic": False,
+					"isPassedDown": True,
+					"comesFrom": None,
+					"value": "Default Title",
+					"propOptions": {
+						"isRequired": False,
+						"type": "string",
+						"options": {"defaultValue": "Default Title"},
+					},
+				},
+			},
+		)
 		component = frappe.get_doc(
 			{
 				"doctype": "Builder Component",
-				"block": Block(element="div", blockId="script-root").as_json(),
+				"block": component_root.as_json(),
 				"component_data_script": component_data_for_script,
-				"component_props": {
-					"title": {
-						"label": "Title",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": "Default Title",
-						"propOptions": {
-							"isRequired": False,
-							"type": "string",
-							"options": {"defaultValue": "Default Title"},
-						},
-					},
-				},
-				"component_js": 'this.dataset.received = "ok";',
 			}
 		).insert()
 
@@ -557,6 +561,204 @@ component.update({
 			page.delete()
 			component.delete()
 
+	def test_block_client_script_is_registered_once_and_invoked_per_block(self):
+		javascript = 'this.dataset.message = "</script>Block Script";'
+		css = 'span::after { content: "</style>Block Style"; }'
+		body = Block(element="div", originalElement="body")
+		for block_id in ("script-block-one", "script-block-two"):
+			body.attach_children(
+				Block(
+					element="div",
+					blockId=block_id,
+					clientScript={"js": javascript, "css": css},
+				)
+			)
+
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Block Client Script Test",
+				"published": 1,
+				"route": "/block-client-script-test",
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/block-client-script-test")
+			self.assertNotIn(javascript, content)
+			self.assertNotIn(css, content)
+			self.assertIn(r"<\/script>Block Script", content)
+			self.assertIn(r"<\/style>Block Style", content)
+			self.assertEqual(content.count("async function client_script_"), 1)
+			self.assertEqual(content.count(").call(document.querySelector"), 2)
+		finally:
+			page.delete()
+
+	def test_legacy_block_client_script_fallback(self):
+		javascript = 'this.dataset.legacy = "supported";'
+		legacy_block = Block(element="div", blockId="legacy-script-block").as_dict()
+		legacy_block.pop("clientScript")
+		legacy_block["blockClientScript"] = javascript
+		body = Block(element="div", originalElement="body").as_dict()
+		body["children"] = [legacy_block]
+
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Legacy Block Client Script Test",
+				"published": 1,
+				"route": "/legacy-block-client-script-test",
+				"blocks": frappe.as_json([body]),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/legacy-block-client-script-test")
+			self.assertIn(javascript, content)
+		finally:
+			page.delete()
+
+		normalized_block = Block(blockClientScript=javascript).as_dict()
+		self.assertEqual(normalized_block["clientScript"], {"js": javascript})
+		self.assertNotIn("blockClientScript", normalized_block)
+
+	def test_block_template_root_props(self):
+		template_root = Block(
+			element="section",
+			blockId="template-props-root",
+			props={
+				"title": {
+					"label": "Title",
+					"isStandard": True,
+					"isDynamic": False,
+					"isPassedDown": True,
+					"comesFrom": None,
+					"value": None,
+					"propOptions": {
+						"isRequired": False,
+						"type": "string",
+						"options": {"defaultValue": "Template Title"},
+					},
+				}
+			},
+		)
+		title = Block(element="h2", blockId="template-title", innerHTML="Fallback")
+		title.set_dynamic_value("title", "key", "innerHTML", "props")
+		template_root.attach_children(title)
+		body = Block(element="div", originalElement="body")
+		body.attach_children(template_root)
+
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Block Template Props Test",
+				"published": 1,
+				"route": "/block-template-props-test",
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/block-template-props-test")
+			self.assertEqual("Template Title", get_html_for(content, "tag", "h2", only_content=True))
+		finally:
+			page.delete()
+
+	def test_component_data_uses_root_prop_defaults(self):
+		from builder.builder.doctype.builder_component.builder_component import get_component_data
+
+		component_root = Block(
+			element="div",
+			props={
+				"title": {
+					"isStandard": True,
+					"value": None,
+					"propOptions": {
+						"type": "string",
+						"options": {"defaultValue": "Default Title"},
+					},
+				}
+			},
+		)
+		component = frappe.get_doc(
+			{
+				"doctype": "Builder Component",
+				"block": component_root.as_json(),
+				"component_data_script": 'component["title"] = props.title',
+			}
+		).insert()
+
+		try:
+			self.assertEqual(get_component_data(component.name), {"title": "Default Title"})
+		finally:
+			component.delete()
+
+	def test_pinned_component_version_keeps_block_client_script(self):
+		old_script = 'this.dataset.version = "old";'
+		new_script = 'this.dataset.version = "new";'
+		component_root = Block(
+			element="div",
+			blockId="pinned-script-root",
+			clientScript={"js": old_script},
+			props={
+				"title": {
+					"isStandard": True,
+					"isPassedDown": True,
+					"value": "Pinned Prop Old",
+				}
+			},
+		)
+		component = frappe.get_doc(
+			{
+				"doctype": "Builder Component",
+				"block": component_root.as_json(),
+			}
+		).insert()
+		pinned_version = ensure_component_version(component.name)
+
+		component_root.clientScript = {"js": new_script}
+		component_root.props["title"]["value"] = "Pinned Prop New"
+		frappe.db.set_value(
+			"Builder Component",
+			component.name,
+			"block",
+			component_root.as_json(),
+			update_modified=False,
+		)
+		frappe.clear_document_cache("Builder Component", component.name)
+
+		body = Block(element="div", originalElement="body")
+		body.attach_children(
+			Block(
+				extendedFromComponent=component.name,
+				componentVersion=pinned_version,
+			)
+		)
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Pinned Block Client Script Test",
+				"published": 1,
+				"route": "/pinned-block-client-script-test",
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/pinned-block-client-script-test")
+			self.assertIn(old_script, content)
+			self.assertNotIn(new_script, content)
+			self.assertIn("Pinned Prop Old", content)
+			self.assertNotIn("Pinned Prop New", content)
+		finally:
+			page.delete()
+			component.delete()
+			frappe.db.delete(
+				"Builder Snapshot",
+				{"reference_doctype": "Builder Component", "reference_name": component.name},
+			)
+
 	def test_component_props(self):
 		component_root = Block(element="div", blockId="wrapper-block")
 		content_static_prop = Block(
@@ -580,38 +782,38 @@ component.update({
 		component_root.attach_children(
 			content_static_prop, content_dynamic_prop, content_last_name, content_fallback
 		)
+		component_root.props = {
+			"first_name": {
+				"label": "First Name",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": "John",
+				"propOptions": {
+					"isRequired": False,
+					"type": "string",
+					"options": {"defaultValue": ""},
+				},
+			},
+			"last_name": {
+				"label": "Last Name",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": "Doe",
+				"propOptions": {
+					"isRequired": False,
+					"type": "string",
+					"options": {"defaultValue": ""},
+				},
+			},
+		}
 		component = frappe.get_doc(
 			{
 				"doctype": "Builder Component",
 				"block": component_root.as_json(),
-				"component_props": {
-					"first_name": {
-						"label": "First Name",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": "John",
-						"propOptions": {
-							"isRequired": False,
-							"type": "string",
-							"options": {"defaultValue": ""},
-						},
-					},
-					"last_name": {
-						"label": "Last Name",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": "Doe",
-						"propOptions": {
-							"isRequired": False,
-							"type": "string",
-							"options": {"defaultValue": ""},
-						},
-					},
-				},
 				"component_data_script": component_data_script,
 			}
 		).insert()
@@ -677,51 +879,51 @@ component.update({
 		}
 
 		component_root.attach_children(component_title_block, component_age_block, component_badge_block)
+		component_root.props = {
+			"title": {
+				"label": "Title",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": None,
+				"propOptions": {
+					"isRequired": False,
+					"type": "string",
+					"options": {"defaultValue": "Default Header Title"},
+				},
+			},
+			"age": {
+				"label": "Age",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": None,
+				"propOptions": {
+					"isRequired": False,
+					"type": "number",
+					"options": {"defaultValue": 25},
+				},
+			},
+			"show_badge": {
+				"label": "Show Badge",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": None,
+				"propOptions": {
+					"isRequired": False,
+					"type": "boolean",
+					"options": {"defaultValue": False},
+				},
+			},
+		}
 		component = frappe.get_doc(
 			{
 				"doctype": "Builder Component",
 				"block": component_root.as_json(),
-				"component_props": {
-					"title": {
-						"label": "Title",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": None,
-						"propOptions": {
-							"isRequired": False,
-							"type": "string",
-							"options": {"defaultValue": "Default Header Title"},
-						},
-					},
-					"age": {
-						"label": "Age",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": None,
-						"propOptions": {
-							"isRequired": False,
-							"type": "number",
-							"options": {"defaultValue": 25},
-						},
-					},
-					"show_badge": {
-						"label": "Show Badge",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": None,
-						"propOptions": {
-							"isRequired": False,
-							"type": "boolean",
-							"options": {"defaultValue": False},
-						},
-					},
-				},
 			}
 		).insert()
 
@@ -849,34 +1051,34 @@ component.update({
 
 		component_repeater_block.attach_children(component_link_block)
 		component_root.attach_children(component_repeater_block)
+		component_root.props = {
+			"links": {
+				"label": "Links",
+				"isStandard": True,
+				"isDynamic": False,
+				"isPassedDown": True,
+				"comesFrom": None,
+				"value": None,
+				"propOptions": {
+					"isRequired": False,
+					"type": "object",
+					"options": {
+						"minItems": None,
+						"maxItems": None,
+						"defaultValue": {
+							"1. Home": "/",
+							"2. Products": "/products",
+							"3. About Us": "/about",
+						},
+					},
+				},
+			}
+		}
 
 		component = frappe.get_doc(
 			{
 				"doctype": "Builder Component",
 				"block": component_root.as_json(),
-				"component_props": {
-					"links": {
-						"label": "Links",
-						"isStandard": True,
-						"isDynamic": False,
-						"isPassedDown": True,
-						"comesFrom": None,
-						"value": None,
-						"propOptions": {
-							"isRequired": False,
-							"type": "object",
-							"options": {
-								"minItems": None,
-								"maxItems": None,
-								"defaultValue": {
-									"1. Home": "/",
-									"2. Products": "/products",
-									"3. About Us": "/about",
-								},
-							},
-						},
-					}
-				},
 			}
 		).insert()
 

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -99,6 +99,7 @@ class Block:
 	innerText: str | None = None
 	innerHTML: str | None = None
 	extendedFromComponent: str | None = None
+	componentVersion: str | None = None
 	originalElement: str | None = None
 	isChildOfComponent: str | None = None
 	referenceBlockId: str | None = None
@@ -108,8 +109,13 @@ class Block:
 	customAttributes: ClassVar[dict] = {}
 	dynamicValues: ClassVar[list[BlockDataKey]] = []
 	props: ClassVar[dict] = {}
+	clientScript: ClassVar[dict] = {}
 
 	def __init__(self, **kwargs) -> None:
+		legacy_client_script = kwargs.pop("blockClientScript", None)
+		if "clientScript" not in kwargs and legacy_client_script:
+			kwargs["clientScript"] = {"js": legacy_client_script}
+
 		for key, value in kwargs.items():
 			if key == "children":
 				value = [
@@ -164,6 +170,7 @@ class Block:
 			"innerText": self.innerText,
 			"innerHTML": self.innerHTML,
 			"extendedFromComponent": self.extendedFromComponent,
+			"componentVersion": self.componentVersion,
 			"originalElement": self.originalElement,
 			"isChildOfComponent": self.isChildOfComponent,
 			"referenceBlockId": self.referenceBlockId,
@@ -173,6 +180,7 @@ class Block:
 			"customAttributes": self.customAttributes,
 			"dynamicValues": self.dynamicValues,
 			"props": self.props,
+			"clientScript": self.clientScript,
 		}
 
 	def as_json(self, wrap_in_array=False):

--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -79,6 +79,7 @@ class Block implements BlockOptions {
 	dynamicValues: Array<BlockDataKey>;
 	props?: BlockProps;
 	editorConfig?: BlockEditorConfig;
+	clientScript: BlockClientScript;
 	// @ts-expect-error
 	referenceComponent: Block | null;
 	customAttributes: BlockAttributeMap;
@@ -128,7 +129,7 @@ class Block implements BlockOptions {
 					// falling back to the live component
 					const componentBlock = this.componentVersion
 						? componentStore.getComponentVersionBlock(this.componentVersion as string) ||
-						  componentStore.getComponentBlock(this.isChildOfComponent as string)
+							componentStore.getComponentBlock(this.isChildOfComponent as string)
 						: componentStore.getComponentBlock(this.isChildOfComponent as string);
 					return findBlockInTree(this.referenceBlockId as string, [componentBlock]);
 				}
@@ -173,6 +174,9 @@ class Block implements BlockOptions {
 		this.dynamicValues = reactive(options.dynamicValues || []);
 		this.props = reactive(options.props || {});
 		this.editorConfig = options.editorConfig;
+		this.clientScript = reactive(
+			options.clientScript ?? (options.blockClientScript ? { js: options.blockClientScript } : {}),
+		);
 
 		this.blockName = options.blockName;
 		delete this.attributes.style;
@@ -771,6 +775,17 @@ class Block implements BlockOptions {
 		}
 		return block;
 	}
+	getPropsRoot(): Block | null {
+		const componentRoot = this.getComponentRoot();
+		if (componentRoot) return componentRoot;
+
+		let block: Block | null = this;
+		while (block) {
+			if (Object.keys(block.props || {}).length > 0) return block;
+			block = block.getParentBlock();
+		}
+		return null;
+	}
 	convertToRepeater() {
 		this.setBaseStyle("display", "flex");
 		this.setBaseStyle("flexDirection", "column");
@@ -1054,25 +1069,14 @@ class Block implements BlockOptions {
 		return Boolean(this.getRepeaterParent());
 	}
 	getBlockProps(): BlockProps {
-		const componentRoot = this.getComponentRoot();
-		if (!componentRoot) return {};
-		if (componentRoot.props && Object.keys(componentRoot.props).length > 0) {
-			return { ...(componentRoot.props || {}) };
-		} else if (componentRoot.componentVersion) {
-			return (
-				useComponentStore().getComponentVersionDoc(componentRoot.componentVersion as string)
-					?.component_props || {}
-			);
-		} else {
-			return (
-				useComponentStore().getComponent(componentRoot.extendedFromComponent as string)?.component_props || {}
-			);
-		}
+		const propsRoot = this.getPropsRoot();
+		if (!propsRoot) return { ...(this.props || {}) };
+		const referenceProps = propsRoot.extendedFromComponent ? propsRoot.referenceComponent?.props || {} : {};
+		return { ...referenceProps, ...(propsRoot.props || {}) };
 	}
 	setBlockProps(props: BlockProps) {
-		const componentRoot = this.getComponentRoot();
-		if (!componentRoot) return;
-		componentRoot.props = props;
+		const propsRoot = this.getPropsRoot() || this;
+		propsRoot.props = props;
 	}
 }
 

--- a/frontend/src/builder.d.ts
+++ b/frontend/src/builder.d.ts
@@ -41,6 +41,11 @@ declare interface BlockEditorConfig {
 	showChildrenInEditor?: boolean;
 }
 
+declare interface BlockClientScript {
+	js?: string;
+	css?: string;
+}
+
 declare interface BlockOptions {
 	blockId?: string | undefined;
 	element?: string;
@@ -55,6 +60,8 @@ declare interface BlockOptions {
 	draggable?: boolean;
 	editorConfig?: BlockEditorConfig;
 	componentVersion?: string;
+	clientScript?: BlockClientScript;
+	blockClientScript?: string;
 	[key: string]: any;
 }
 

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -49,7 +49,7 @@ import useComponentStore from "@/stores/componentStore";
 import usePageStore from "@/stores/pageStore";
 import { setFont } from "@/utils/fontManager";
 import { extractComponentId, getDataForKey, getParentProps, getPropValue } from "@/utils/helpers";
-import type { ComponentClientScriptEmulator } from "@/utils/scriptSandbox";
+import type { BlockClientScriptEmulator } from "@/utils/scriptSandbox";
 import { useDraggableBlock } from "@/utils/useDraggableBlock";
 import {
 	computed,
@@ -103,7 +103,9 @@ const props = withDefaults(
 );
 
 const editingComponentId = computed(() =>
-	!props.block.getParentBlock() && props.block === canvasStore.fragmentData.block
+	canvasStore.fragmentData.fragmentKind === "component" &&
+	!props.block.getParentBlock() &&
+	props.block === canvasStore.fragmentData.block
 		? canvasStore.fragmentData.fragmentId
 		: null,
 );
@@ -276,8 +278,8 @@ const attributes = computed(() => {
 });
 
 const canvasProps = !props.preview ? (inject("canvasProps") as CanvasProps) : null;
-const emulateComponentClientScript = inject<ComponentClientScriptEmulator>(
-	"emulateComponentClientScript",
+const emulateBlockClientScript = inject<BlockClientScriptEmulator>(
+	"emulateBlockClientScript",
 	() => () => {},
 );
 
@@ -516,38 +518,38 @@ watch(resolvedComponentData, () => {
 	componentDataReady.value = true;
 });
 
-const componentClientScriptDoc = computed(() => {
-	if (editingComponentId.value && !props.block.getParentBlock()) {
-		return {
-			component_js: componentController.componentJavaScript.value,
-			component_css: componentController.componentCSS.value,
-		};
-	}
-	if (!props.block.extendedFromComponent) return null;
-	return props.block.componentVersion
-		? componentStore.getComponentVersionDoc(props.block.componentVersion)
-		: componentStore.getComponent(props.block.extendedFromComponent);
+const blockClientScript = computed(() => {
+	const clientScript = props.block.extendedFromComponent
+		? props.block.referenceComponent?.clientScript
+		: props.block.clientScript;
+	return {
+		javascript: clientScript?.js || "",
+		css: clientScript?.css || "",
+	};
 });
 
 watch(
 	[
 		target,
-		componentClientScriptDoc,
+		blockClientScript,
 		resolvedComponentData,
 		allResolvedProps,
 		() => builderSettings.doc?.execute_block_scripts_in_editor,
 		() => pageStore.settingPage,
 		componentDataReady,
 	],
-	([element, componentDoc, componentData, resolvedProps, , settingPage, dataReady], _, onCleanup) => {
-		if (!element || !componentDoc) return;
-		const cleanup = emulateComponentClientScript({
+	([element, clientScript, componentData, resolvedProps, , settingPage, dataReady], _, onCleanup) => {
+		if (!element || !clientScript) return;
+		const waitsForComponentData = Boolean(props.block.extendedFromComponent);
+		const cleanup = emulateBlockClientScript({
 			key: uidToUse,
 			element,
 			breakpoint: props.breakpoint,
-			css: componentDoc.component_css ?? "",
+			css: clientScript.css ?? "",
 			javascript:
-				settingPage || (!editingComponentId.value && !dataReady) ? "" : (componentDoc.component_js ?? ""),
+				settingPage || (waitsForComponentData && !editingComponentId.value && !dataReady)
+					? ""
+					: (clientScript.javascript ?? ""),
 			componentData: componentData ?? {},
 			props: resolvedProps,
 		});

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -47,6 +47,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
 import usePageStore from "@/stores/pageStore";
+import componentController from "@/utils/componentController.js";
 import { setFont } from "@/utils/fontManager";
 import { extractComponentId, getDataForKey, getParentProps, getPropValue } from "@/utils/helpers";
 import type { BlockClientScriptEmulator } from "@/utils/scriptSandbox";
@@ -67,7 +68,6 @@ import BlockEditor from "./BlockEditor.vue";
 import BlockHTML from "./BlockHTML.vue";
 import DataLoaderBlock from "./DataLoaderBlock.vue";
 import TextBlock from "./TextBlock.vue";
-import componentController from "@/utils/componentController.js";
 
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
@@ -103,7 +103,7 @@ const props = withDefaults(
 );
 
 const editingComponentId = computed(() =>
-	canvasStore.fragmentData.fragmentKind === "component" &&
+	canvasStore.fragmentData.fragmentType === "component" &&
 	!props.block.getParentBlock() &&
 	props.block === canvasStore.fragmentData.block
 		? canvasStore.fragmentData.fragmentId

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -4,7 +4,7 @@
 		:data-builder-canvas="canvasId"
 		@click="handleClick"
 		@mousedown="handleMarqueeStart">
-		<component :is="'style'" v-if="componentClientStyles" v-text="componentClientStyles" />
+		<component :is="'style'" v-if="blockClientStyles" v-text="blockClientStyles" />
 		<Transition name="fade">
 			<div
 				class="absolute bottom-0 left-0 right-0 top-0 grid w-full place-items-center bg-surface-gray-1 p-10 text-ink-gray-5"
@@ -127,7 +127,7 @@ import usePageStore from "@/stores/pageStore";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
 import {
-	type ComponentClientScript,
+	type BlockClientScriptRuntime,
 	executeClientScriptRestricted,
 	executeClientScriptUnrestricted,
 } from "@/utils/scriptSandbox";
@@ -163,7 +163,7 @@ const canvasContainer = ref(null) as Ref<HTMLElement | null>;
 const canvas = ref(null);
 const showBlocks = ref(false);
 const overlay = ref(null);
-const componentStyles = reactive(new Map<string, string>());
+const blockStyles = reactive(new Map<string, string>());
 
 const props = withDefaults(
 	defineProps<{
@@ -177,7 +177,7 @@ const props = withDefaults(
 
 const block = ref(props.blockData) as Ref<Block>;
 const history = ref(null) as Ref<null> | CanvasHistory;
-const componentClientStyles = computed(() => Array.from(componentStyles.values()).join("\n"));
+const blockClientStyles = computed(() => Array.from(blockStyles.values()).join("\n"));
 
 const activeBreakpoint = ref("desktop") as Ref<string | null>;
 const hoveredBreakpoint = ref("desktop") as Ref<string | null>;
@@ -377,7 +377,7 @@ watch(
 );
 
 provide("canvasProps", canvasProps);
-provide("emulateComponentClientScript", emulateComponentClientScript);
+provide("emulateBlockClientScript", emulateBlockClientScript);
 
 defineExpose({
 	setScaleAndTranslate,
@@ -448,12 +448,12 @@ function escapeAttributeValue(value: string) {
 	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
-function emulateComponentClientScript(script: ComponentClientScript) {
+function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 	const registrationKey = `${script.key}:${script.breakpoint}`;
 	const selector = `[data-builder-canvas="${canvasId}"] [data-block-uid="${escapeAttributeValue(
 		script.key,
 	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
-	componentStyles.set(registrationKey, script.css ? `${selector} { ${script.css} }` : "");
+	blockStyles.set(registrationKey, script.css ? `${selector} { ${script.css} }` : "");
 
 	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
 	let cleanup = () => {};
@@ -472,7 +472,7 @@ function emulateComponentClientScript(script: ComponentClientScript) {
 		try {
 			cleanup();
 		} finally {
-			componentStyles.delete(registrationKey);
+			blockStyles.delete(registrationKey);
 		}
 	};
 }

--- a/frontend/src/components/DataLoaderBlock.vue
+++ b/frontend/src/components/DataLoaderBlock.vue
@@ -71,8 +71,8 @@ const blockRepeaterData = computed(() => {
 		return compData || [];
 	} else if (repeatingFrom.value == "props" && key) {
 		const defaultProps: BlockProps[] = [];
-		const componentRoot = props.block.getComponentRoot();
-		const parsedValue = getStandardPropValue(key, componentRoot)?.value;
+		const propsRoot = props.block.getPropsRoot();
+		const parsedValue = propsRoot ? getStandardPropValue(key, propsRoot)?.value : null;
 		if (Array.isArray(parsedValue)) {
 			parsedValue.slice(0, 100).forEach((item: any) =>
 				defaultProps.push({

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -149,17 +149,17 @@
 import Dialog from "@/components/Controls/Dialog.vue";
 import { webPages } from "@/data/webPage";
 import useBuilderStore from "@/stores/builderStore";
+import useCanvasStore from "@/stores/canvasStore.js";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import componentController from "@/utils/componentController";
 import { toast } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
-import { computed, defineComponent, nextTick, ref, watch } from "vue";
+import { computed, defineComponent, ref, watch } from "vue";
 import CodeEditor from "./Controls/CodeEditor.vue";
 import TabButtons from "./Controls/TabButtons.vue";
-import PropsEditor from "./PropsEditor.vue";
-import useCanvasStore from "@/stores/canvasStore.js";
 import PageClientScriptManager from "./PageClientScriptManager.vue";
+import PropsEditor from "./PropsEditor.vue";
 
 const { capture } = useTelemetry();
 
@@ -185,7 +185,7 @@ const blockCSSEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
 const currentScriptEditor = ref<"client" | "data">("client");
 const mode = computed<"page" | "component" | "blockTemplate">(() => {
 	if (canvasStore.editingMode !== "fragment") return "page";
-	return canvasStore.fragmentData.fragmentKind || "component";
+	return canvasStore.fragmentData.fragmentType || "component";
 });
 
 const blockClientScriptTabs = [

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -1,11 +1,11 @@
 <template>
 	<div class="flex h-full flex-col justify-between">
 		<div class="flex h-full flex-col gap-4 p-3">
-			<div
-				class="flex gap-2"
-				v-if="mode == 'page' || mode == 'component' || (mode == 'block' && isBlockSelected)">
+			<div class="flex gap-2">
 				<Button @click="showClientScriptEditor()" class="flex-1">Client Script</Button>
-				<Button v-if="mode != 'block'" @click="showServerScriptEditor()" class="flex-1">Data Script</Button>
+				<Button v-if="mode != 'blockTemplate'" @click="showServerScriptEditor()" class="flex-1">
+					Data Script
+				</Button>
 			</div>
 
 			<div class="h-full" v-if="mode == 'page'">
@@ -24,34 +24,27 @@
 					:autofocus="false"
 					:readonly="true" />
 			</div>
-			<div class="box-border h-full overflow-y-auto pb-12" v-if="mode == 'component'">
+			<div
+				class="box-border h-full overflow-y-auto pb-12"
+				v-if="mode == 'component' || mode == 'blockTemplate'">
 				<div class="flex min-h-full w-full flex-col gap-6">
 					<div>
-						<div class="mb-3 mt-4 text-sm text-ink-gray-8">Component Props</div>
-						<PropsEditor
-							:obj="componentProps"
-							@update:obj="(obj: BlockProps) => componentController.setComponentProps(obj)" />
+						<div class="mb-3 mt-4 text-sm text-ink-gray-8">
+							{{ mode == "component" ? "Component Props" : "Block Props" }}
+						</div>
+						<PropsEditor :obj="fragmentProps" @update:obj="setFragmentProps" />
 					</div>
 				</div>
 			</div>
-			<div v-else-if="mode == 'block'" class="mt-2 text-center text-sm text-ink-gray-6">
-				Select a block to edit script
-			</div>
-		</div>
-		<div
-			v-if="false"
-			class="bg-surface-white absolute bottom-0 left-0 box-border flex w-full items-center justify-between border-t p-4 py-2">
-			<h2 class="text-base text-ink-gray-6">Mode</h2>
-			<TabButtons class="w-fit" :buttons="modeButtons" v-model="mode" />
 		</div>
 		<Dialog class="overscroll-none" :title="dialogTitle" size="7xl" :isDirty="isDirty" v-model="showDialog">
 			<template #title>
 				<div class="flex w-full items-center justify-between gap-3 pr-2">
 					<span class="text-xl font-semibold text-ink-gray-9">{{ dialogTitle }}</span>
 					<TabButtons
-						v-if="showComponentClientScriptToggle"
-						v-model="activeComponentClientScript"
-						:buttons="componentClientScriptTabs"
+						v-if="showBlockClientScriptToggle"
+						v-model="activeBlockClientScript"
+						:buttons="blockClientScriptTabs"
 						class="w-48" />
 				</div>
 			</template>
@@ -91,37 +84,36 @@
 						</div>
 					</div>
 				</div>
-				<div v-if="mode == 'component'">
+				<div v-if="mode == 'component' || mode == 'blockTemplate'">
 					<div v-if="currentScriptEditor == 'client'">
 						<div class="flex h-full flex-col">
 							<CodeEditor
-								v-show="activeComponentClientScript === 'component_js'"
-								ref="componentJavaScriptEditor"
-								:modelValue="componentJavaScript"
+								v-show="activeBlockClientScript === 'js'"
+								ref="blockJavaScriptEditor"
+								:modelValue="blockJavaScript"
 								type="JavaScript"
-								label="Component JavaScript"
-								mode="component"
+								label="Block JavaScript"
 								height="60vh"
 								:readonly="builderStore.readOnlyMode"
 								:autofocus="true"
-								@save="(value: string) => saveComponentClientScript('component_js', value)"
+								@save="(value: string) => saveBlockClientScript('js', value)"
 								:showSaveButton="true"
 								:show-line-numbers="true"></CodeEditor>
 							<CodeEditor
-								v-show="activeComponentClientScript === 'component_css'"
-								ref="componentCSSEditor"
-								:modelValue="componentCSS"
+								v-show="activeBlockClientScript === 'css'"
+								ref="blockCSSEditor"
+								:modelValue="blockCSS"
 								type="CSS"
-								label="Component CSS"
+								label="Block CSS"
 								height="60vh"
 								:readonly="builderStore.readOnlyMode"
 								:autofocus="false"
-								@save="(value: string) => saveComponentClientScript('component_css', value)"
+								@save="(value: string) => saveBlockClientScript('css', value)"
 								:showSaveButton="true"
 								:show-line-numbers="true"></CodeEditor>
 						</div>
 					</div>
-					<div v-else>
+					<div v-else-if="mode == 'component'">
 						<div class="flex gap-4">
 							<CodeEditor
 								class="w-2/3 overscroll-none"
@@ -159,9 +151,7 @@ import { webPages } from "@/data/webPage";
 import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
-import blockController from "@/utils/blockController";
 import componentController from "@/utils/componentController";
-import { useStorage } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
 import { computed, defineComponent, nextTick, ref, watch } from "vue";
@@ -177,18 +167,10 @@ const pageStore = usePageStore();
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 
-const {
-	currentComponentId,
-	componentDataPreview,
-	componentProps,
-	componentDataScript,
-	componentJavaScript,
-	componentCSS,
-} = componentController;
+const { currentComponentId, componentDataPreview, componentDataScript } = componentController;
 
 const showDialog = ref(false);
-const mode = useStorage("builder_last_used_script_editor_mode", "page");
-const activeComponentClientScript = ref<"component_js" | "component_css">("component_js");
+const activeBlockClientScript = ref<"js" | "css">("js");
 
 const props = defineProps<{
 	page: BuilderPage;
@@ -197,61 +179,34 @@ const props = defineProps<{
 const clientScriptManager = ref<null | InstanceType<typeof PageClientScriptManager>>(null);
 const dataScriptEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
 const componentDataScriptEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
-const componentJavaScriptEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
-const componentCSSEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
+const blockJavaScriptEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
+const blockCSSEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
 
 const currentScriptEditor = ref<"client" | "data">("client");
-const isBlockSelected = computed(() => {
-	return blockController.getFirstSelectedBlock();
+const mode = computed<"page" | "component" | "blockTemplate">(() => {
+	if (canvasStore.editingMode !== "fragment") return "page";
+	return canvasStore.fragmentData.fragmentKind || "component";
 });
 
-const isFragmentMode = computed(() => canvasStore.editingMode == "fragment");
-
-// TODO: Remove Block mode
-const modeButtons = computed(() => {
-	if (isFragmentMode.value) {
-		return [
-			{
-				label: "Component",
-				icon: "lucide-component",
-				hideLabel: true,
-				value: "component",
-				showTooltip: true,
-			},
-			{ label: "Block", icon: "lucide-layers", hideLabel: true, value: "block", showTooltip: true },
-		];
-	}
-	return [
-		{ label: "Page", icon: "lucide-layout", hideLabel: true, value: "page", showTooltip: true },
-		{ label: "Block", icon: "lucide-layers", hideLabel: true, value: "block", showTooltip: true },
-	];
-});
-
-const componentClientScriptTabs = [
-	{ label: "JavaScript", value: "component_js", icon: "lucide-braces" },
-	{ label: "CSS", value: "component_css", icon: "lucide-paintbrush" },
+const blockClientScriptTabs = [
+	{ label: "JavaScript", value: "js", icon: "lucide-braces" },
+	{ label: "CSS", value: "css", icon: "lucide-paintbrush" },
 ];
 
-watch(
-	isFragmentMode,
-	() => {
-		if (isFragmentMode.value) {
-			mode.value = "component";
-		} else {
-			mode.value = "page";
-		}
-	},
-	{ immediate: true },
-);
+const blockJavaScript = computed(() => canvasStore.fragmentData.block?.clientScript.js || "");
+const blockCSS = computed(() => canvasStore.fragmentData.block?.clientScript.css || "");
+const fragmentProps = computed(() => canvasStore.fragmentData.block?.props || {});
 
 const dialogTitle = computed(() => {
-	const modeLabel = mode.value.charAt(0).toUpperCase() + mode.value.slice(1);
+	const modeLabel = mode.value === "blockTemplate" ? "Block Template" : capitalize(mode.value);
 	return currentScriptEditor.value == "data" ? `${modeLabel} Data Script` : `${modeLabel} Client Script`;
 });
 
-const showComponentClientScriptToggle = computed(() => {
-	return mode.value === "component" && currentScriptEditor.value === "client";
+const showBlockClientScriptToggle = computed(() => {
+	return mode.value !== "page" && currentScriptEditor.value === "client";
 });
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
 const savePageDataScript = (value: string) => {
 	webPages.setValue
@@ -283,9 +238,18 @@ const saveComponentDataScript = async (value: string) => {
 	componentController.setComponentDataScript(value);
 };
 
-const saveComponentClientScript = (field: "component_js" | "component_css", value: string) => {
-	if (!currentComponentId.value) return;
-	componentController.setComponentClientScript(value, field === "component_js" ? "js" : "css");
+const setFragmentProps = (props: BlockProps) => {
+	const rootBlock = canvasStore.fragmentData.block;
+	if (!rootBlock) return;
+	rootBlock.props = props;
+	canvasStore.activeCanvas?.toggleDirty(true);
+};
+
+const saveBlockClientScript = (field: "js" | "css", value: string) => {
+	const rootBlock = canvasStore.fragmentData.block;
+	if (!rootBlock) return;
+	rootBlock.clientScript[field] = value;
+	canvasStore.activeCanvas?.toggleDirty(true);
 };
 
 const showClientScriptEditor = () => {
@@ -307,8 +271,8 @@ const isDirty = computed(() => {
 			return dataScriptEditor.value.isDirty;
 		}
 	} else if (currentScriptEditor.value === "client") {
-		if (mode.value === "component") {
-			return Boolean(componentJavaScriptEditor.value?.isDirty || componentCSSEditor.value?.isDirty);
+		if (mode.value !== "page") {
+			return Boolean(blockJavaScriptEditor.value?.isDirty || blockCSSEditor.value?.isDirty);
 		}
 		if (clientScriptManager.value?.scriptEditor) {
 			return clientScriptManager.value?.scriptEditor.isDirty;
@@ -321,7 +285,6 @@ watch(
 	() => builderStore.showDataScriptDialog,
 	() => {
 		if (builderStore.showDataScriptDialog !== null) {
-			mode.value = builderStore.showDataScriptDialog;
 			showServerScriptEditor();
 			builderStore.showDataScriptDialog = null;
 		}

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -354,7 +354,9 @@ useEventListener(document, "keyup", (e) => {
 });
 
 async function saveAndExitFragmentMode(e: Event) {
-	componentController.applyComponentDoc();
+	if (canvasStore.fragmentData.fragmentKind === "component") {
+		componentController.applyComponentDoc();
+	}
 	await canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock());
 	fragmentCanvas.value?.toggleDirty(false);
 	canvasStore.exitFragmentMode(e);

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -136,6 +136,7 @@ import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import { getUsersInfo } from "@/usersInfo";
 import blockController from "@/utils/blockController";
+import componentController from "@/utils/componentController.js";
 import { getBlockInstance, getBlockObject, getRootBlockTemplate } from "@/utils/helpers";
 import { useBuilderEvents } from "@/utils/useBuilderEvents";
 import { breakpointsTailwind, useBreakpoints, useDebounceFn, useEventListener } from "@vueuse/core";
@@ -143,7 +144,6 @@ import { createResource, KeyboardShortcutsModal, useShortcut } from "frappe-ui";
 import { computed, onActivated, onDeactivated, onMounted, provide, ref, watch, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import CodeEditor from "../components/Controls/CodeEditor.vue";
-import componentController from "@/utils/componentController.js";
 
 const expandedEditor = ref<null | InstanceType<typeof CodeEditor>>(null);
 const aiGeneratorModal = ref<null | InstanceType<typeof AIPageGeneratorModal>>(null);
@@ -354,7 +354,7 @@ useEventListener(document, "keyup", (e) => {
 });
 
 async function saveAndExitFragmentMode(e: Event) {
-	if (canvasStore.fragmentData.fragmentKind === "component") {
+	if (canvasStore.fragmentData.fragmentType === "component") {
 		componentController.applyComponentDoc();
 	}
 	await canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock());

--- a/frontend/src/stores/blockTemplateStore.ts
+++ b/frontend/src/stores/blockTemplateStore.ts
@@ -36,6 +36,7 @@ const useBlockTemplateStore = defineStore("blockTemplateStore", {
 
 			canvasStore.editOnCanvas(
 				blockTemplateBlock,
+				"blockTemplate",
 				(block: Block) => {
 					this.saveBlockTemplate(block, blockTemplateName);
 				},

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -38,7 +38,7 @@ const useCanvasStore = defineStore("canvasStore", {
 		showEditorDialog: false,
 		fragmentData: {
 			block: <Block | null>null,
-			fragmentKind: <"component" | "blockTemplate" | null>null,
+			fragmentType: <"component" | "blockTemplate" | null>null,
 			saveAction: <Function | null>null,
 			saveActionLabel: <string | null>null,
 			fragmentName: <string | null>null,
@@ -149,7 +149,7 @@ const useCanvasStore = defineStore("canvasStore", {
 
 		editOnCanvas(
 			block: Block,
-			fragmentKind: "component" | "blockTemplate",
+			fragmentType: "component" | "blockTemplate",
 			saveAction: (block: Block) => void,
 			saveActionLabel: string = "Save",
 			fragmentName?: string,
@@ -159,7 +159,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			const blockCopy = getBlockCopy(block, true);
 			this.fragmentData = {
 				block: blockCopy,
-				fragmentKind,
+				fragmentType,
 				saveAction,
 				saveActionLabel,
 				fragmentName: fragmentName || block.getBlockDescription(),
@@ -189,7 +189,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			// reset fragmentData
 			this.fragmentData = {
 				block: null,
-				fragmentKind: null,
+				fragmentType: null,
 				saveAction: null,
 				saveActionLabel: null,
 				fragmentName: null,

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -38,6 +38,7 @@ const useCanvasStore = defineStore("canvasStore", {
 		showEditorDialog: false,
 		fragmentData: {
 			block: <Block | null>null,
+			fragmentKind: <"component" | "blockTemplate" | null>null,
 			saveAction: <Function | null>null,
 			saveActionLabel: <string | null>null,
 			fragmentName: <string | null>null,
@@ -148,6 +149,7 @@ const useCanvasStore = defineStore("canvasStore", {
 
 		editOnCanvas(
 			block: Block,
+			fragmentKind: "component" | "blockTemplate",
 			saveAction: (block: Block) => void,
 			saveActionLabel: string = "Save",
 			fragmentName?: string,
@@ -157,6 +159,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			const blockCopy = getBlockCopy(block, true);
 			this.fragmentData = {
 				block: blockCopy,
+				fragmentKind,
 				saveAction,
 				saveActionLabel,
 				fragmentName: fragmentName || block.getBlockDescription(),
@@ -186,6 +189,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			// reset fragmentData
 			this.fragmentData = {
 				block: null,
+				fragmentKind: null,
 				saveAction: null,
 				saveActionLabel: null,
 				fragmentName: null,

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -7,7 +7,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderComponent } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
-import { alert, confirm, getBlockInstance, getBlockObject, parseJSONWithFallback } from "@/utils/helpers";
+import { alert, confirm, getBlockInstance, getBlockObject } from "@/utils/helpers";
 import { createDocumentResource, createResource, toast } from "frappe-ui";
 import { defineStore } from "pinia";
 import { markRaw } from "vue";
@@ -82,6 +82,7 @@ const useComponentStore = defineStore("componentStore", {
 			const canvasStore = useCanvasStore();
 			canvasStore.editOnCanvas(
 				componentBlock,
+				"component",
 				(block: Block) => this.saveComponent(block, componentName),
 				"Save Component",
 				component.component_name,
@@ -102,10 +103,7 @@ const useComponentStore = defineStore("componentStore", {
 				.submit({
 					name: componentName,
 					block: getBlockObject(block),
-					component_props: doc?.component_props || {},
 					component_data_script: doc?.component_data_script || "",
-					component_js: doc?.component_js || "",
-					component_css: doc?.component_css || "",
 				})
 				.then(async (data: BuilderComponent) => {
 					this.setComponentMap(data);
@@ -194,7 +192,6 @@ const useComponentStore = defineStore("componentStore", {
 			}
 		},
 		setComponentMap(componentDoc: BuilderComponent) {
-			componentDoc.component_props = parseJSONWithFallback(componentDoc.component_props, {});
 			this.componentDocMap.set(componentDoc.name, componentDoc);
 			this.componentMap.set(componentDoc.name, markRaw(getBlockInstance(componentDoc.block)));
 		},
@@ -231,7 +228,6 @@ const useComponentStore = defineStore("componentStore", {
 				const doc = await getVersionedDoc(versionName);
 				if (doc?.block) {
 					const versionedDoc = { ...doc } as BuilderComponent;
-					versionedDoc.component_props = parseJSONWithFallback(versionedDoc.component_props, {});
 					this.componentVersionMap.set(versionName, versionedDoc);
 				} else {
 					// pruned/missing version — show the live component instead

--- a/frontend/src/types/doctypes.ts
+++ b/frontend/src/types/doctypes.ts
@@ -185,16 +185,10 @@ export interface BuilderComponent extends DocType {
   component_name?: string;
   /** Block: JSON */
   block?: any;
-  /** Component Props: JSON */
-  component_props?: any;
   /** For Web Page: Link (Builder Page) */
   for_web_page?: string;
   /** Component ID: Data */
   component_id?: string;
   /** Component Data Script: Code */
   component_data_script?: string;
-  /** Component JavaScript: Code */
-  component_js?: string;
-  /** Component CSS: Code */
-  component_css?: string;
 }

--- a/frontend/src/utils/componentController.ts
+++ b/frontend/src/utils/componentController.ts
@@ -17,17 +17,16 @@ export type ComponentDocDraft = Omit<
 
 const EMPTY_DRAFT: ComponentDocDraft = {
 	component_name: "",
-	component_props: {},
 	component_data_script: "",
-	component_js: "",
-	component_css: "",
 	component_data_preview: {},
 };
 
 const canvasStore = useCanvasStore();
 const componentStore = useComponentStore();
 
-const currentComponentId = computed(() => canvasStore.fragmentData?.fragmentId ?? "");
+const currentComponentId = computed(() =>
+	canvasStore.fragmentData.fragmentKind === "component" ? (canvasStore.fragmentData.fragmentId ?? "") : "",
+);
 const componentDocDraft = reactive<ComponentDocDraft>({ ...EMPTY_DRAFT });
 
 function markCanvasDirty(dirty: boolean = true) {
@@ -39,10 +38,7 @@ function cloneComponentDocFields(
 	preview: Record<string, any> = {},
 ): ComponentDocDraft {
 	return {
-		component_props: parseJSONWithFallback(doc.component_props, {}),
 		component_data_script: doc.component_data_script ?? "",
-		component_js: doc.component_js ?? "",
-		component_css: doc.component_css ?? "",
 		component_data_preview: parseJSONWithFallback(preview, {}),
 	};
 }
@@ -73,7 +69,7 @@ const componentDataPreview = computed(() => {
 
 const componentProps = computed(() => {
 	if (!currentComponentId.value) return {};
-	return componentDocDraft.component_props ?? {};
+	return canvasStore.fragmentData.block?.props ?? {};
 });
 
 const componentDataScript = computed(() => {
@@ -81,48 +77,17 @@ const componentDataScript = computed(() => {
 	return componentDocDraft.component_data_script ?? "";
 });
 
-const componentJavaScript = computed(() => {
-	if (!currentComponentId.value) return "";
-	return componentDocDraft.component_js ?? "";
-});
-
-const componentCSS = computed(() => {
-	if (!currentComponentId.value) return "";
-	return componentDocDraft.component_css ?? "";
-});
-
 const componentController = {
 	currentComponentId,
 	componentDataPreview,
 	componentProps,
 	componentDataScript,
-	componentJavaScript,
-	componentCSS,
-
-	getComponentProps: () => componentProps.value,
-
-	setComponentProps: (props: BlockProps) => {
-		if (!currentComponentId.value) return;
-		componentDocDraft.component_props = props;
-		canvasStore.fragmentData.block?.setBlockProps(props);
-		markCanvasDirty(true);
-	},
 
 	getComponentDataScript: () => componentDataScript.value,
 
 	setComponentDataScript: (script: string) => {
 		if (!currentComponentId.value) return;
 		componentDocDraft.component_data_script = script;
-		markCanvasDirty(true);
-	},
-
-	getComponentClientScript: (type: "js" | "css" = "js") => {
-		return type === "js" ? componentJavaScript.value : componentCSS.value;
-	},
-
-	setComponentClientScript: (script: string, type: "js" | "css" = "js") => {
-		if (!currentComponentId.value) return;
-		componentDocDraft[type === "js" ? "component_js" : "component_css"] = script;
 		markCanvasDirty(true);
 	},
 
@@ -142,7 +107,7 @@ const componentController = {
 		if (!componentId) return;
 
 		// convert props to {propName: propValue} format
-		const props = Object.entries((componentDocDraft.component_props as BlockProps) ?? {}).reduce(
+		const props = Object.entries(componentProps.value).reduce(
 			(acc: Record<string, any>, [key, value]: [string, BlockProps[string]]) => {
 				acc[key] = value.value ?? value.propOptions?.options?.defaultValue;
 				return acc;
@@ -204,8 +169,6 @@ watch(
 	[currentComponentId, () => canvasStore.editingMode],
 	() => {
 		if (canvasStore.editingMode != "fragment") return;
-		const initialProps = componentController.getComponentProps();
-		canvasStore.fragmentData.block?.setBlockProps(initialProps);
 		markCanvasDirty(false);
 	},
 	{ immediate: true },

--- a/frontend/src/utils/componentController.ts
+++ b/frontend/src/utils/componentController.ts
@@ -1,6 +1,6 @@
+import { useLatestRequest } from "@/composables/useLatestRequest";
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
-import { useLatestRequest } from "@/composables/useLatestRequest";
 import { BuilderComponent } from "@/types/doctypes";
 import { createResource } from "frappe-ui";
 import { computed, reactive, watch } from "vue";
@@ -25,7 +25,7 @@ const canvasStore = useCanvasStore();
 const componentStore = useComponentStore();
 
 const currentComponentId = computed(() =>
-	canvasStore.fragmentData.fragmentKind === "component" ? (canvasStore.fragmentData.fragmentId ?? "") : "",
+	canvasStore.fragmentData.fragmentType === "component" ? canvasStore.fragmentData.fragmentId ?? "" : "",
 );
 const componentDocDraft = reactive<ComponentDocDraft>({ ...EMPTY_DRAFT });
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -281,6 +281,14 @@ const diffArray = <T>(src: T[] | undefined, oldComp: T[] | undefined): T[] => {
 const deepEqual = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
 
 function removeEmptyBlockValues(block: BlockOptions): BlockOptions {
+	if (block.clientScript) {
+		block.clientScript = { ...block.clientScript };
+		for (const key of Object.keys(block.clientScript) as Array<keyof BlockClientScript>) {
+			if (isEmptyValue(block.clientScript[key])) {
+				delete block.clientScript[key];
+			}
+		}
+	}
 	for (const key of Object.keys(block)) {
 		if (isEmptyValue(block[key])) {
 			delete block[key];
@@ -662,9 +670,9 @@ const getDefaultPropsList = (block: Block): BlockProps => {
 		const key = repeaterRoot.getDataKey("key");
 		const comesFrom = repeaterRoot.getDataKey("comesFrom");
 		if (key && comesFrom === "props") {
-			const componentRoot = repeaterRoot.getComponentRoot();
-			if (!componentRoot) return {};
-			const parsedValue = getStandardPropValue(key, componentRoot)?.value;
+			const propsRoot = repeaterRoot.getPropsRoot();
+			if (!propsRoot) return {};
+			const parsedValue = getStandardPropValue(key, propsRoot)?.value;
 			if (!parsedValue) return {};
 			if (Array.isArray(parsedValue)) {
 				return {
@@ -919,5 +927,5 @@ export {
 	uploadUserFont,
 	parseJSONWithFallback,
 	deepEqual,
-	diffArray
+	diffArray,
 };

--- a/frontend/src/utils/scriptSandbox.ts
+++ b/frontend/src/utils/scriptSandbox.ts
@@ -1,7 +1,7 @@
 import { builderSettings } from "@/data/builderSettings";
 
 export type ScriptCleanup = () => void;
-export type ComponentClientScript = {
+export type BlockClientScriptRuntime = {
 	key: string;
 	element: HTMLElement;
 	breakpoint: string;
@@ -10,7 +10,7 @@ export type ComponentClientScript = {
 	componentData: Record<string, any>;
 	props: Record<string, any>;
 };
-export type ComponentClientScriptEmulator = (script: ComponentClientScript) => ScriptCleanup;
+export type BlockClientScriptEmulator = (script: BlockClientScriptRuntime) => ScriptCleanup;
 
 type ScriptContext = {
 	componentData?: Record<string, any>;
@@ -231,7 +231,4 @@ function executeClientScriptRestricted(
 	}
 }
 
-export {
-	executeClientScriptRestricted,
-	executeClientScriptUnrestricted,
-};
+export { executeClientScriptRestricted, executeClientScriptUnrestricted };


### PR DESCRIPTION
## Summary
- Blocks have a new field: `clientScript: {js: "...", css: "..."}`
- Move client scripts and component props to root blocks.
- Support scripts/props in Block Templates.
- Preserve legacy `blockClientScript` compatibility.
- Remove obsolete Component DocType fields.
- Client Scripts and Props can be applied to Component root block and Block Template root block only (UI Limitation)
- Client Scripts now also allows scoped CSS.