### PR TITLE
Support inline formatting inside headings

### DIFF
--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -26,6 +26,7 @@
 </template>
 
 <script setup lang="ts">
+import { Heading } from "@tiptap/extension-heading";
 import type Block from "@/block";
 import TextBlockBubbleMenu from "@/components/TextBlockBubbleMenu.vue";
 import useCanvasStore from "@/stores/canvasStore";
@@ -253,8 +254,15 @@ if (!props.preview) {
 					content: textContent.value,
 					extensions: [
 						StarterKit.configure({
-							link: { openOnClick: false },
-							underline: false,
+    						link: { openOnClick: false },
+    						underline: false,
+    						heading: false,
+						}),
+						Heading.extend({
+    						content: "inline*",
+    						marks: "bold italic underline textStyle link",
+						}).configure({
+    						levels: [1, 2, 3],
 						}),
 						TextStyle.extend({
 							addGlobalAttributes() {
@@ -278,19 +286,27 @@ if (!props.preview) {
 						FontFamilyPasteRule,
 						Underline,
 					],
-					enablePasteRules: false,
-					onUpdate({ editor }) {
-						let innerHTML = getInnerHTML(editor as Editor);
-						if (props.block.getInnerHTML() === innerHTML) {
-							return;
-						}
-						dataChanged.value = true;
-						if (!getDynamicContent()) {
-							props.block.setInnerHTML(innerHTML);
-						}
-					},
-					autofocus: false,
-					injectCSS: false,
+					                                        enablePasteRules: false,
+                                        onUpdate({ editor }) {
+    const html = editor.getHTML();
+
+    
+
+    if (props.block.getInnerHTML() === html) {
+        return;
+    }
+
+    dataChanged.value = true;
+
+    if (!getDynamicContent()) {
+        props.block.setInnerHTML(html);
+
+        
+    }
+},
+                                        autofocus: false,
+                                        injectCSS: false,
+
 				});
 
 				// @ts-ignore

--- a/frontend/src/components/TextBlockBubbleMenu.vue
+++ b/frontend/src/components/TextBlockBubbleMenu.vue
@@ -59,36 +59,40 @@
 				:class="{ 'bg-surface-gray-3': block.getElement() === 'h3' }">
 				<code>H3</code>
 			</button>
+
+			<!-- Bold Control (Guard Removed) -->
 			<button
-				v-show="!block.isHeader()"
 				@click="editor?.chain().focus().toggleBold().run()"
 				class="rounded px-2 py-1 hover:bg-surface-gray-2"
 				:class="{ 'bg-surface-gray-3': editor.isActive('bold') }">
 				<span class="lucide-bold h-3 w-3" aria-hidden="true" />
 			</button>
+
+			<!-- Italic Control (Guard Removed) -->
 			<button
-				v-show="!block.isHeader()"
 				@click="editor?.chain().focus().toggleItalic().run()"
 				class="rounded px-2 py-1 hover:bg-surface-gray-2"
 				:class="{ 'bg-surface-gray-3': editor.isActive('italic') }">
 				<span class="lucide-italic h-3 w-3" aria-hidden="true" />
 			</button>
+
+			<!-- Strike Control (Guard Removed) -->
 			<button
-				v-show="!block.isHeader()"
 				@click="editor?.chain().focus().toggleStrike().run()"
 				class="rounded px-2 py-1 hover:bg-surface-gray-2"
 				:class="{ 'bg-surface-gray-3': editor.isActive('strike') }">
 				<span class="lucide-strikethrough size-4" />
 			</button>
 
+			<!-- Underline Control (Guard Removed) -->
 			<button
-				v-show="!block.isHeader()"
 				@click="editor?.chain().focus().toggleUnderline().run()"
 				class="rounded px-2 py-1 hover:bg-surface-gray-2"
 				:class="{ 'bg-surface-gray-3': editor.isActive('underline') }">
 				<span class="lucide-underline size-4" />
 			</button>
 
+			<!-- Link Control (Domain Guard Retained) -->
 			<button
 				v-show="!block.isHeader() && !block.isLink() && !block.isButton()"
 				@click="
@@ -101,7 +105,9 @@
 				:class="{ 'bg-surface-gray-3': editor.isActive('link') }">
 				<span class="lucide-link h-3 w-3" aria-hidden="true" />
 			</button>
-			<div v-show="!block.isHeader()">
+
+			<!-- ColorPicker Control (Guard Removed) -->
+			<div>
 				<ColorPicker
 					:modelValue="selectedColor"
 					@update:modelValue="setTextColor"
@@ -110,15 +116,11 @@
 					:appendTo="overlayElement"
 					popoverClass="!min-w-fit">
 					<template #target="{ togglePopover, isOpen }">
-						<button v-show="!block.isHeader()" class="rounded px-2 py-1 hover:bg-surface-gray-2">
+						<button class="rounded px-2 py-1 hover:bg-surface-gray-2">
 							<div class="p-1">
 								<div
 									class="h-4 w-4 rounded shadow-sm"
-									@click="
-										() => {
-											togglePopover();
-										}
-									"
+									@click="() => togglePopover()"
 									:style="{
 										background:
 											editor?.isActive('textStyle') && editor?.getAttributes('textStyle').color
@@ -140,6 +142,7 @@
 		</div>
 	</bubble-menu>
 </template>
+
 
 <script setup lang="ts">
 import type Block from "@/block";


### PR DESCRIPTION
## Overview

This PR improves inline formatting flexibility within Frappe Builder by enabling rich text styling inside _**heading elements**_. By allowing inline marks and expanding the bubble menu controls, users can now style specific text selections within headers without breaking the block layout.

## Key Changes

### Custom Heading Extension
- Disabled TipTap's default `StarterKit` heading extension.
- Added a custom `Heading` extension configured to support inline marks.

### Bubble Menu Enhancements
- Enabled formatting controls in the text bubble menu when heading blocks are active.

### Expanded Formatting Support
Heading blocks now support the following inline styles:
- Bold
- Italic
- Underline
- Strike
- Text Color

## How to Test

1. Add or select a **Heading** block on the builder canvas.
2. Highlight a word or phrase inside the heading text.
3. Verify that the **Bubble Menu** appears with formatting controls enabled.
4. Apply:
   - Bold
   - Italic
   - Underline
   - Strike
   - Text Color
5. Confirm that the formatting is rendered correctly on the canvas.
6. Save the page and verify that the formatting is preserved.
