### PR TITLE
feat: welcoming onboarding wizard with full-page template picker

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -133,6 +133,7 @@ declare module 'vue' {
     StringOptions: typeof import('./src/components/PropsOptions/StringOptions.vue')['default']
     StylePropertyControl: typeof import('./src/components/Controls/StylePropertyControl.vue')['default']
     TabButtons: typeof import('./src/components/Controls/TabButtons.vue')['default']
+    TemplateGallery: typeof import('./src/components/Templates/TemplateGallery.vue')['default']
     TemplateGroupCard: typeof import('./src/components/Templates/TemplateGroupCard.vue')['default']
     TemplatePageCard: typeof import('./src/components/Templates/TemplatePageCard.vue')['default']
     TemplatePageGrid: typeof import('./src/components/Templates/TemplatePageGrid.vue')['default']

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -1,0 +1,202 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<div class="mx-auto flex h-full w-full flex-col overflow-hidden" :class="contentClass">
+			<!-- header -->
+			<div class="px-8 pb-4 pr-5 pt-7">
+				<Button
+					v-if="activeGroup"
+					icon-left="lucide-arrow-left"
+					variant="ghost"
+					class="-ml-3 mb-5"
+					@click="selectedGroup = ''">
+					Back to all templates
+				</Button>
+				<div class="mb-2 flex flex-col gap-2">
+					<div class="flex items-center justify-between">
+						<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
+						<Button
+							v-if="activeGroup"
+							variant="outline"
+							:loading="importingAll"
+							icon-left="lucide-copy-plus"
+							@click="importAll">
+							Use all {{ activeGroup?.pages.length }} pages
+						</Button>
+					</div>
+					<p v-if="activeGroup?.description" class="max-w-2xl text-sm leading-relaxed text-ink-gray-5">
+						{{ activeGroup.description }}
+					</p>
+					<p v-else-if="!activeGroup" class="text-p-sm text-ink-gray-5">
+						{{ subtitle }}
+					</p>
+				</div>
+			</div>
+
+			<!-- pages within the selected group -->
+			<TemplatePageGrid
+				v-if="activeGroup"
+				:group="activeGroup"
+				:loading="Boolean(templateGroups.loading)"
+				@select="useTemplate"
+				@edit="editTemplate"></TemplatePageGrid>
+
+			<!-- gallery: blank page + a preview card per template group -->
+			<div v-else class="no-scrollbar flex-1 overflow-y-auto px-8 pb-8">
+				<div v-if="templateGroups.loading && !groups.length" class="grid gap-3 auto-fill-[190px]">
+					<div v-for="i in 6" :key="i" class="flex flex-col gap-2">
+						<div class="aspect-video w-full animate-pulse rounded-lg bg-surface-gray-2"></div>
+						<div class="h-3.5 w-2/3 animate-pulse rounded bg-surface-gray-2"></div>
+					</div>
+				</div>
+				<div v-else class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
+					<button
+						class="flex w-full flex-col self-start rounded-lg border border-dashed border-outline-gray-3 p-1.5 text-ink-gray-5 transition-colors duration-150 hover:border-outline-gray-4 hover:bg-surface-gray-1 hover:text-ink-gray-7"
+						@click="createBlankPage">
+						<span class="flex aspect-video w-full flex-col items-center justify-center gap-2">
+							<PlusIcon class="size-5" />
+							<span class="text-sm">{{ blankLabel }}</span>
+						</span>
+					</button>
+					<TemplateGroupCard
+						v-for="group in visibleGroups"
+						:key="group.name"
+						:group="group"
+						@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+<script setup lang="ts">
+import { useDashboardState } from "@/composables/useDashboardState";
+import router from "@/router";
+import useBuilderStore from "@/stores/builderStore";
+import usePageStore from "@/stores/pageStore";
+import { templateGroups, webPages } from "@/data/webPage";
+import { TemplateGroup, TemplatePageSummary } from "@/types/doctypes";
+import { Button, createResource, toast } from "frappe-ui";
+import { useTelemetry } from "frappe-ui/frappe";
+import { computed, onMounted, ref } from "vue";
+import PlusIcon from "~icons/lucide/plus";
+import TemplateGroupCard from "./TemplateGroupCard.vue";
+import TemplatePageGrid from "./TemplatePageGrid.vue";
+
+const props = withDefaults(
+	defineProps<{
+		heading?: string;
+		subtitle?: string;
+		blankLabel?: string;
+		// extra classes for the centered content column (e.g. a max-width for full-page use)
+		contentClass?: string;
+		// cap the number of template groups shown (0 = show all); the blank tile is extra
+		maxGroups?: number;
+	}>(),
+	{
+		heading: "New page",
+		subtitle: "Start from a blank page or pick a template.",
+		blankLabel: "Blank page",
+		contentClass: "",
+		maxGroups: 0,
+	},
+);
+
+const { showTemplatesDialog, lastTemplateGroup } = useDashboardState();
+const builderStore = useBuilderStore();
+const pageStore = usePageStore();
+const { capture } = useTelemetry();
+
+// "" = top-level gallery; a group name = drilled into that group's pages.
+// persisted so reopening the picker lands on the last template you viewed.
+const selectedGroup = lastTemplateGroup;
+
+const groups = computed<TemplateGroup[]>(() => templateGroups.data || []);
+const visibleGroups = computed<TemplateGroup[]>(() =>
+	props.maxGroups > 0 ? groups.value.slice(0, props.maxGroups) : groups.value,
+);
+const activeGroup = computed<TemplateGroup | null>(
+	() => groups.value.find((group) => group.name === selectedGroup.value) || null,
+);
+const heading = computed(() => activeGroup.value?.title || props.heading);
+const subtitle = computed(() => props.subtitle);
+
+onMounted(() => {
+	// revalidate on mount — the cache (IndexedDB-backed) renders instantly
+	// but goes stale when new template groups are synced on migrate
+	if (!templateGroups.loading) {
+		templateGroups.fetch();
+	}
+});
+
+const createBlankPage = () => {
+	showTemplatesDialog.value = false;
+	router.push({ name: "builder", params: { pageId: "new" } });
+};
+
+const creatingPage = ref(false);
+const useTemplate = (page: TemplatePageSummary) => {
+	if (creatingPage.value) return;
+	creatingPage.value = true;
+	const promise = createResource({
+		url: "builder.api.create_page_from_template",
+	})
+		.submit({
+			template_page: page.name,
+			project_folder: builderStore.activeFolder || undefined,
+		})
+		.then((newPageName: string) => {
+			capture("builder_page_template_used", {
+				template_page: page.name,
+				template_group: page.template_group,
+				source: page.live_url ? "hub" : "local",
+			});
+			showTemplatesDialog.value = false;
+			router.push({ name: "builder", params: { pageId: newPageName }, force: true });
+			pageStore.setPage(newPageName);
+		});
+	toast.promise(promise, {
+		loading: "Creating page from template...",
+		success: () => "Page created",
+		error: () => "Could not create page from template",
+	});
+	promise.finally(() => {
+		creatingPage.value = false;
+	});
+};
+
+const importingAll = ref(false);
+const importAll = () => {
+	if (importingAll.value || !activeGroup.value) return;
+	importingAll.value = true;
+	const promise = createResource({
+		url: "builder.api.import_template_group",
+	})
+		.submit({
+			template_group: activeGroup.value.name,
+			project_folder: builderStore.activeFolder || undefined,
+		})
+		.then((pageNames: string[]) => {
+			capture("builder_template_group_imported", {
+				template_group: activeGroup.value!.name,
+				page_count: pageNames.length,
+			});
+			showTemplatesDialog.value = false;
+			// land on the dashboard with the freshly imported pages so the user can
+			// pick which one to open (Import all creates several pages at once)
+			webPages.reload();
+			router.push({ name: "home" });
+		});
+	toast.promise(promise, {
+		loading: "Adding all pages...",
+		success: () => "All pages added",
+		error: () => "Could not add pages",
+	});
+	promise.finally(() => {
+		importingAll.value = false;
+	});
+};
+
+const editTemplate = (page: TemplatePageSummary) => {
+	showTemplatesDialog.value = false;
+	router.push({ name: "builder", params: { pageId: page.name } });
+};
+</script>

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -1,72 +1,71 @@
 <template>
 	<div class="flex h-full flex-col overflow-hidden">
-		<div class="mx-auto flex h-full w-full flex-col overflow-hidden" :class="contentClass">
-			<!-- header -->
-			<div class="px-8 pb-4 pr-5 pt-7">
-				<Button
-					v-if="activeGroup"
-					icon-left="lucide-arrow-left"
-					variant="ghost"
-					class="-ml-3 mb-5"
-					@click="selectedGroup = ''">
-					Back to all templates
-				</Button>
-				<div class="mb-2 flex flex-col gap-2">
-					<div class="flex items-center justify-between">
-						<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
-						<Button
-							v-if="activeGroup"
-							variant="outline"
-							:loading="importingAll"
-							icon-left="lucide-copy-plus"
-							@click="importAll">
-							Use all {{ activeGroup?.pages.length }} pages
-						</Button>
-					</div>
-					<p v-if="activeGroup?.description" class="max-w-2xl text-sm leading-relaxed text-ink-gray-5">
-						{{ activeGroup.description }}
-					</p>
-					<p v-else-if="!activeGroup" class="text-p-sm text-ink-gray-5">
-						{{ subtitle }}
-					</p>
+		<!-- header -->
+		<div class="px-8 pb-4 pr-5 pt-7">
+			<Button
+				v-if="activeGroup"
+				icon-left="lucide-arrow-left"
+				variant="ghost"
+				class="-ml-3 mb-5"
+				@click="selectedGroup = ''">
+				Back to all templates
+			</Button>
+			<div class="mb-2 flex flex-col gap-2">
+				<div class="flex items-center justify-between">
+					<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
+					<Button
+						v-if="activeGroup"
+						variant="outline"
+						:loading="importingAll"
+						icon-left="lucide-copy-plus"
+						@click="importAll">
+						Use all {{ activeGroup?.pages.length }} pages
+					</Button>
+				</div>
+				<p v-if="activeGroup?.description" class="max-w-2xl text-sm leading-relaxed text-ink-gray-5">
+					{{ activeGroup.description }}
+				</p>
+				<p v-else-if="!activeGroup" class="text-p-sm text-ink-gray-5">
+					{{ props.subtitle }}
+				</p>
+			</div>
+		</div>
+
+		<!-- pages within the selected group -->
+		<TemplatePageGrid
+			v-if="activeGroup"
+			:group="activeGroup"
+			:loading="Boolean(templateGroups.loading)"
+			@select="useTemplate"
+			@edit="editTemplate"></TemplatePageGrid>
+
+		<!-- gallery: blank page + a preview card per template group -->
+		<div v-else class="no-scrollbar flex-1 overflow-y-auto px-8 pb-8">
+			<div v-if="templateGroups.loading && !groups.length" class="grid gap-3 auto-fill-[190px]">
+				<div v-for="i in 6" :key="i" class="flex flex-col gap-2">
+					<div class="aspect-video w-full animate-pulse rounded-lg bg-surface-gray-2"></div>
+					<div class="h-3.5 w-2/3 animate-pulse rounded bg-surface-gray-2"></div>
 				</div>
 			</div>
-
-			<!-- pages within the selected group -->
-			<TemplatePageGrid
-				v-if="activeGroup"
-				:group="activeGroup"
-				:loading="Boolean(templateGroups.loading)"
-				@select="useTemplate"
-				@edit="editTemplate"></TemplatePageGrid>
-
-			<!-- gallery: blank page + a preview card per template group -->
-			<div v-else class="no-scrollbar flex-1 overflow-y-auto px-8 pb-8">
-				<div v-if="templateGroups.loading && !groups.length" class="grid gap-3 auto-fill-[190px]">
-					<div v-for="i in 6" :key="i" class="flex flex-col gap-2">
-						<div class="aspect-video w-full animate-pulse rounded-lg bg-surface-gray-2"></div>
-						<div class="h-3.5 w-2/3 animate-pulse rounded bg-surface-gray-2"></div>
-					</div>
-				</div>
-				<div v-else class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
-					<button
-						class="flex w-full flex-col self-start rounded-lg border border-dashed border-outline-gray-3 p-1.5 text-ink-gray-5 transition-colors duration-150 hover:border-outline-gray-4 hover:bg-surface-gray-1 hover:text-ink-gray-7"
-						@click="createBlankPage">
-						<span class="flex aspect-video w-full flex-col items-center justify-center gap-2">
-							<PlusIcon class="size-5" />
-							<span class="text-sm">{{ blankLabel }}</span>
-						</span>
-					</button>
-					<TemplateGroupCard
-						v-for="group in visibleGroups"
-						:key="group.name"
-						:group="group"
-						@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
-				</div>
+			<div v-else class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
+				<button
+					class="flex w-full flex-col self-start rounded-lg border border-dashed border-outline-gray-3 p-1.5 text-ink-gray-5 transition-colors duration-150 hover:border-outline-gray-4 hover:bg-surface-gray-1 hover:text-ink-gray-7"
+					@click="createBlankPage">
+					<span class="flex aspect-video w-full flex-col items-center justify-center gap-2">
+						<PlusIcon class="size-5" />
+						<span class="text-sm">{{ blankLabel }}</span>
+					</span>
+				</button>
+				<TemplateGroupCard
+					v-for="group in visibleGroups"
+					:key="group.name"
+					:group="group"
+					@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
 			</div>
 		</div>
 	</div>
 </template>
+
 <script setup lang="ts">
 import { useDashboardState } from "@/composables/useDashboardState";
 import router from "@/router";
@@ -86,8 +85,6 @@ const props = withDefaults(
 		heading?: string;
 		subtitle?: string;
 		blankLabel?: string;
-		// extra classes for the centered content column (e.g. a max-width for full-page use)
-		contentClass?: string;
 		// cap the number of template groups shown (0 = show all); the blank tile is extra
 		maxGroups?: number;
 	}>(),
@@ -95,7 +92,6 @@ const props = withDefaults(
 		heading: "New page",
 		subtitle: "Start from a blank page or pick a template.",
 		blankLabel: "Blank page",
-		contentClass: "",
 		maxGroups: 0,
 	},
 );
@@ -117,7 +113,6 @@ const activeGroup = computed<TemplateGroup | null>(
 	() => groups.value.find((group) => group.name === selectedGroup.value) || null,
 );
 const heading = computed(() => activeGroup.value?.title || props.heading);
-const subtitle = computed(() => props.subtitle);
 
 onMounted(() => {
 	// revalidate on mount — the cache (IndexedDB-backed) renders instantly

--- a/frontend/src/components/Templates/TemplatesDialog.vue
+++ b/frontend/src/components/Templates/TemplatesDialog.vue
@@ -5,73 +5,13 @@
 			<DialogDescription class="sr-only">
 				Start from a blank page or pick a page from a template.
 			</DialogDescription>
-			<div class="relative flex max-h-[85vh] min-h-[660px] flex-col overflow-hidden">
-				<!-- header -->
-				<div class="px-8 pb-4 pr-5 pt-7">
-					<Button
-						v-if="activeGroup"
-						icon-left="lucide-arrow-left"
-						variant="ghost"
-						class="-ml-3 mb-5"
-						@click="selectedGroup = ''">
-						Back to all templates
-					</Button>
-					<div class="mb-2 flex flex-col gap-2">
-						<div class="flex items-center justify-between">
-							<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
-							<Button
-								v-if="activeGroup"
-								variant="outline"
-								:loading="importingAll"
-								icon-left="lucide-copy-plus"
-								@click="importAll">
-								Use all {{ activeGroup?.pages.length }} pages
-							</Button>
-						</div>
-						<p class="max-w-2xl text-sm leading-relaxed text-ink-gray-5" v-if="activeGroup?.description">
-							{{ activeGroup.description }}
-						</p>
-						<p class="text-p-sm text-ink-gray-5" v-else-if="!activeGroup">
-							Start from a blank page or pick a template.
-						</p>
-					</div>
-				</div>
+			<div class="relative max-h-[85vh] min-h-[660px] overflow-hidden">
+				<TemplateGallery class="h-full" />
 				<Button
 					icon="lucide-x"
 					variant="subtle"
 					class="absolute right-5 top-5"
 					@click="showTemplatesDialog = false"></Button>
-
-				<!-- pages within the selected group -->
-				<TemplatePageGrid
-					v-if="activeGroup"
-					:group="activeGroup"
-					:loading="Boolean(templateGroups.loading)"
-					@select="useTemplate"
-					@edit="editTemplate"></TemplatePageGrid>
-
-				<!-- gallery: blank page + a preview card per template group -->
-				<div v-else class="no-scrollbar flex-1 overflow-y-auto px-8 pb-8">
-					<div v-if="templateGroups.loading && !groups.length" class="grid gap-3 auto-fill-[190px]">
-						<div v-for="i in 6" :key="i" class="flex flex-col gap-2">
-							<div class="aspect-video w-full animate-pulse rounded-lg bg-surface-gray-2"></div>
-							<div class="h-3.5 w-2/3 animate-pulse rounded bg-surface-gray-2"></div>
-						</div>
-					</div>
-					<div v-else class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
-						<button
-							class="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-outline-gray-3 text-ink-gray-5 transition-colors duration-150 hover:border-outline-gray-4 hover:bg-surface-gray-1 hover:text-ink-gray-7"
-							@click="createBlankPage">
-							<PlusIcon class="size-5" />
-							<span class="text-sm">Blank page</span>
-						</button>
-						<TemplateGroupCard
-							v-for="group in groups"
-							:key="group.name"
-							:group="group"
-							@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
-					</div>
-				</div>
 			</div>
 		</template>
 	</Dialog>
@@ -79,114 +19,17 @@
 <script setup lang="ts">
 import Dialog from "@/components/Controls/Dialog.vue";
 import { useDashboardState } from "@/composables/useDashboardState";
-import { templateGroups, webPages } from "@/data/webPage";
-import router from "@/router";
-import useBuilderStore from "@/stores/builderStore";
-import usePageStore from "@/stores/pageStore";
-import { TemplateGroup, TemplatePageSummary } from "@/types/doctypes";
-import { Button, createResource, toast } from "frappe-ui";
+import { Button } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
 import { DialogDescription, DialogTitle } from "reka-ui";
-import { computed, ref, watch } from "vue";
-import PlusIcon from "~icons/lucide/plus";
-import TemplateGroupCard from "./TemplateGroupCard.vue";
-import TemplatePageGrid from "./TemplatePageGrid.vue";
+import { watch } from "vue";
+import TemplateGallery from "./TemplateGallery.vue";
 
-const { showTemplatesDialog, lastTemplateGroup } = useDashboardState();
-const builderStore = useBuilderStore();
-const pageStore = usePageStore();
+const { showTemplatesDialog } = useDashboardState();
 const { capture } = useTelemetry();
-
-// "" = top-level gallery; a group name = drilled into that group's pages.
-// persisted so reopening the picker lands on the last template you viewed.
-const selectedGroup = lastTemplateGroup;
-
-const groups = computed<TemplateGroup[]>(() => templateGroups.data || []);
-const activeGroup = computed<TemplateGroup | null>(
-	() => groups.value.find((group) => group.name === selectedGroup.value) || null,
-);
-const heading = computed(() => activeGroup.value?.title || "New page");
 
 watch(showTemplatesDialog, (open) => {
 	if (!open) return;
 	capture("builder_template_dialog_opened");
-	// revalidate on open — the cache (IndexedDB-backed) renders instantly
-	// but goes stale when new template groups are synced on migrate
-	if (!templateGroups.loading) {
-		templateGroups.fetch();
-	}
 });
-
-const createBlankPage = () => {
-	showTemplatesDialog.value = false;
-	router.push({ name: "builder", params: { pageId: "new" } });
-};
-
-const creatingPage = ref(false);
-const useTemplate = (page: TemplatePageSummary) => {
-	if (creatingPage.value) return;
-	creatingPage.value = true;
-	const promise = createResource({
-		url: "builder.api.create_page_from_template",
-	})
-		.submit({
-			template_page: page.name,
-			project_folder: builderStore.activeFolder || undefined,
-		})
-		.then((newPageName: string) => {
-			capture("builder_page_template_used", {
-				template_page: page.name,
-				template_group: page.template_group,
-				source: page.live_url ? "hub" : "local",
-			});
-			showTemplatesDialog.value = false;
-			router.push({ name: "builder", params: { pageId: newPageName }, force: true });
-			pageStore.setPage(newPageName);
-		});
-	toast.promise(promise, {
-		loading: "Creating page from template...",
-		success: () => "Page created",
-		error: () => "Could not create page from template",
-	});
-	promise.finally(() => {
-		creatingPage.value = false;
-	});
-};
-
-const importingAll = ref(false);
-const importAll = () => {
-	if (importingAll.value || !activeGroup.value) return;
-	importingAll.value = true;
-	const promise = createResource({
-		url: "builder.api.import_template_group",
-	})
-		.submit({
-			template_group: activeGroup.value.name,
-			project_folder: builderStore.activeFolder || undefined,
-		})
-		.then((pageNames: string[]) => {
-			capture("builder_template_group_imported", {
-				template_group: activeGroup.value!.name,
-				page_count: pageNames.length,
-			});
-			showTemplatesDialog.value = false;
-			// land on the dashboard with the freshly imported pages so the user can
-			// pick which one to open (Import all creates several pages at once)
-			webPages.reload();
-			router.push({ name: "home" });
-		});
-	toast.promise(promise, {
-		loading: "Adding all pages...",
-		success: () => "All pages added",
-		error: () => "Could not add pages",
-	});
-	promise.finally(() => {
-		importingAll.value = false;
-	});
-};
-
-const editTemplate = (page: TemplatePageSummary) => {
-	showTemplatesDialog.value = false;
-	router.push({ name: "builder", params: { pageId: page.name } });
-};
 </script>

--- a/frontend/src/components/Templates/TemplatesDialog.vue
+++ b/frontend/src/components/Templates/TemplatesDialog.vue
@@ -5,8 +5,8 @@
 			<DialogDescription class="sr-only">
 				Start from a blank page or pick a page from a template.
 			</DialogDescription>
-			<div class="relative max-h-[85vh] min-h-[660px] overflow-hidden">
-				<TemplateGallery class="h-full" />
+			<div class="relative flex max-h-[85vh] min-h-[660px] flex-col overflow-hidden">
+				<TemplateGallery class="min-h-0 flex-1" />
 				<Button
 					icon="lucide-x"
 					variant="subtle"

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -40,11 +40,24 @@
 			</div>
 
 			<div class="flex items-center justify-between">
-				<!-- kept mounted (invisible on step 1) so the footer height stays fixed and the block doesn't shift -->
-				<Button variant="ghost" icon-left="lucide-arrow-left" :class="{ invisible: isFirst }" @click="goBack">
-					Back
-				</Button>
 				<span class="text-xs text-ink-gray-4">Step {{ stepIndex + 1 }} of {{ totalSteps }}</span>
+				<div class="flex items-center gap-2">
+					<!-- kept mounted (invisible on step 1) so the footer width/height stays fixed and nothing shifts -->
+					<Button
+						variant="ghost"
+						icon-left="lucide-arrow-left"
+						:class="{ invisible: isFirst }"
+						@click="goBack">
+						Back
+					</Button>
+					<Button
+						variant="solid"
+						icon-right="lucide-arrow-right"
+						:disabled="!answers[activeQuestion.key]"
+						@click="goNext">
+						Next
+					</Button>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -138,9 +151,9 @@ const templateHeading = computed(() =>
 );
 
 function select(value: string) {
-	// one click answers the question and moves on — no separate Continue step
+	// only highlight the choice; advancing is a deliberate Next click so a
+	// stray double-click can't skip past the following question
 	answers[activeQuestion.value.key] = value;
-	goNext();
 }
 
 function goBack() {

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -67,7 +67,7 @@ const telemetry = useTelemetry();
 // Dev benches have telemetry off; ?persona_survey=test logs the payload instead.
 const devForceShow = new URLSearchParams(window.location.search).get("persona_survey") === "test";
 
-type QuestionKey = "use_case" | "role";
+type QuestionKey = "use_case" | "role" | "source";
 
 const questions: {
 	key: QuestionKey;
@@ -98,11 +98,24 @@ const questions: {
 			{ value: "other", label: "Other" },
 		],
 	},
+	{
+		key: "source",
+		heading: "How did you hear about Builder?",
+		options: [
+			{ value: "search", label: "Search (Google)" },
+			{ value: "youtube", label: "YouTube" },
+			{ value: "friend", label: "Friend / colleague" },
+			{ value: "frappe_ecosystem", label: "Frappe / ERPNext" },
+			{ value: "social", label: "Social media" },
+			{ value: "other", label: "Other" },
+		],
+	},
 ];
 
 const answers = reactive<Record<QuestionKey, string | undefined>>({
 	use_case: undefined,
 	role: undefined,
+	source: undefined,
 });
 
 // question steps followed by the full-page template selector
@@ -154,7 +167,7 @@ function finishQuestions() {
 	const props = {
 		role: answers.role || null,
 		use_case: answers.use_case || null,
-		source: null,
+		source: answers.source || null,
 	};
 	if (devForceShow) console.log("[persona-survey] capture", props);
 	telemetry.capture("builder_persona_submitted", props);

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -1,35 +1,64 @@
 <template>
-	<div class="flex h-screen items-center justify-center p-5">
-		<div class="flex w-full max-w-lg flex-col gap-6 rounded-lg bg-surface-base p-8">
-			<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
-			<div class="flex flex-col gap-1">
-				<h1 class="text-xl font-semibold text-ink-gray-9">Before we start</h1>
-				<p class="text-p-sm text-ink-gray-6">
-					Answer a few quick questions so we can improve your Builder experience.
-				</p>
-			</div>
-			<div class="flex flex-col gap-5">
-				<div v-for="q in questions" :key="q.key" class="flex flex-col gap-2">
-					<Select
-						v-model="answers[q.key]"
-						:label="q.label"
-						:placeholder="q.placeholder"
-						:options="q.options" />
+	<!-- final step: full-page template selector -->
+	<div v-if="step === 'templates'" class="flex h-screen flex-col bg-surface-base">
+		<div class="mx-auto w-full max-w-3xl px-8 pt-16">
+			<img src="/builder_logo.png" alt="Builder" class="h-8" />
+		</div>
+		<div class="flex-1 overflow-hidden">
+			<TemplateGallery
+				class="h-full"
+				content-class="max-w-3xl"
+				blank-label="Start from scratch"
+				:max-groups="8"
+				:heading="templateHeading"
+				subtitle="Choose a template to get a head start, or start from scratch. You can always change direction later." />
+		</div>
+	</div>
+
+	<!-- question steps: one question per page -->
+	<div v-else class="flex h-screen items-center justify-center p-5">
+		<div class="flex w-full max-w-xl flex-col gap-8">
+			<div class="flex flex-col gap-6">
+				<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
+				<div class="flex flex-col gap-2">
+					<h1 class="text-2xl font-semibold text-ink-gray-9">{{ activeQuestion.heading }}</h1>
 				</div>
 			</div>
-			<div class="flex justify-end">
-				<Button variant="solid" :disabled="!hasAnyAnswer" @click="submit">Submit</Button>
+
+			<div class="grid grid-cols-2 gap-3">
+				<button
+					v-for="opt in activeQuestion.options"
+					:key="opt.value"
+					class="flex items-center rounded-lg border p-4 text-left text-base transition-colors duration-150"
+					:class="
+						answers[activeQuestion.key] === opt.value
+							? 'border-outline-gray-4 bg-surface-gray-2 text-ink-gray-9'
+							: 'border-outline-gray-2 text-ink-gray-7 hover:border-outline-gray-3 hover:bg-surface-gray-1'
+					"
+					@click="select(opt.value)">
+					{{ opt.label }}
+				</button>
+			</div>
+
+			<div class="flex items-center justify-between">
+				<!-- kept mounted (invisible on step 1) so the footer height stays fixed and the block doesn't shift -->
+				<Button variant="ghost" icon-left="lucide-arrow-left" :class="{ invisible: isFirst }" @click="goBack">
+					Back
+				</Button>
+				<span class="text-xs text-ink-gray-4">Step {{ stepIndex + 1 }} of {{ totalSteps }}</span>
 			</div>
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
+import TemplateGallery from "@/components/Templates/TemplateGallery.vue";
 import { builderSettings } from "@/data/builderSettings";
-import router from "@/router";
-import { Button, Select } from "frappe-ui";
+import { sessionUser } from "@/router";
+import { getUserInfo } from "@/usersInfo";
+import { Button } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
-import { computed, reactive } from "vue";
+import { computed, reactive, ref } from "vue";
 
 // Pulse is event-only (no person properties), but every event carries the
 // (anonymized, stable) user id, so this single event can be joined to the
@@ -38,18 +67,16 @@ const telemetry = useTelemetry();
 // Dev benches have telemetry off; ?persona_survey=test logs the payload instead.
 const devForceShow = new URLSearchParams(window.location.search).get("persona_survey") === "test";
 
-type QuestionKey = "role" | "use_case" | "source";
+type QuestionKey = "use_case" | "role";
 
 const questions: {
 	key: QuestionKey;
-	label: string;
-	placeholder: string;
+	heading: string;
 	options: { value: string; label: string }[];
 }[] = [
 	{
 		key: "use_case",
-		label: "What do you want to build first?",
-		placeholder: "Pick what you'll build",
+		heading: "What do you want to build first?",
 		options: [
 			{ value: "marketing_site", label: "Marketing / landing site" },
 			{ value: "web_app_ui", label: "Web app UI" },
@@ -61,8 +88,7 @@ const questions: {
 	},
 	{
 		key: "role",
-		label: "Which one best describes you?",
-		placeholder: "Pick what fits best",
+		heading: "Which one best describes you?",
 		options: [
 			{ value: "designer", label: "Designer" },
 			{ value: "developer", label: "Developer" },
@@ -72,30 +98,55 @@ const questions: {
 			{ value: "other", label: "Other" },
 		],
 	},
-	{
-		key: "source",
-		label: "How did you hear about Builder?",
-		placeholder: "Pick where you found us",
-		options: [
-			{ value: "search", label: "Search (Google)" },
-			{ value: "youtube", label: "YouTube" },
-			{ value: "friend", label: "Friend / colleague" },
-			{ value: "frappe_ecosystem", label: "Frappe / ERPNext" },
-			{ value: "social", label: "Social media" },
-			{ value: "other", label: "Other" },
-		],
-	},
 ];
 
 const answers = reactive<Record<QuestionKey, string | undefined>>({
-	role: undefined,
 	use_case: undefined,
-	source: undefined,
+	role: undefined,
 });
 
-const hasAnyAnswer = computed(() => Object.values(answers).some(Boolean));
+// question steps followed by the full-page template selector
+const stepOrder = [...questions.map((q) => q.key), "templates"] as const;
+const totalSteps = stepOrder.length;
+const stepIndex = ref(0);
+const step = computed(() => stepOrder[stepIndex.value]);
+const isFirst = computed(() => stepIndex.value === 0);
+const activeQuestion = computed(() => questions.find((q) => q.key === step.value)!);
 
-function submit() {
+// personal greeting; fullname is an email until the fetch lands (skip it then)
+const userInfo = getUserInfo(sessionUser.value);
+const greetingName = computed(() => {
+	const fullname = userInfo?.fullname;
+	// skip the name until it resolves, or when it's an email / the Guest fallback
+	if (!fullname || fullname.includes("@") || fullname === "Guest") return "";
+	return `, ${fullname.split(" ")[0]}`;
+});
+const templateHeading = computed(() =>
+	greetingName.value ? `You're all set${greetingName.value}. Pick a starting point` : "Pick a starting point",
+);
+
+function select(value: string) {
+	// one click answers the question and moves on — no separate Continue step
+	answers[activeQuestion.value.key] = value;
+	goNext();
+}
+
+function goBack() {
+	stepIndex.value = Math.max(0, stepIndex.value - 1);
+}
+
+function goNext() {
+	const next = stepIndex.value + 1;
+	// entering the template step means the questions are done — persist + capture now
+	// so any exit from the selector (template, blank, or skip) won't re-trigger the survey.
+	if (stepOrder[next] === "templates") finishQuestions();
+	stepIndex.value = next;
+}
+
+let submitted = false;
+function finishQuestions() {
+	if (submitted) return;
+	submitted = true;
 	// Optimistically flag done so the dashboard's redirect guard sees it before the async save lands.
 	if (builderSettings.doc) builderSettings.doc.persona_survey_done = 1;
 	builderSettings.setValue.submit({ persona_survey_done: 1 });
@@ -103,11 +154,9 @@ function submit() {
 	const props = {
 		role: answers.role || null,
 		use_case: answers.use_case || null,
-		source: answers.source || null,
+		source: null,
 	};
 	if (devForceShow) console.log("[persona-survey] capture", props);
 	telemetry.capture("builder_persona_submitted", props);
-
-	router.replace({ name: "home" });
 }
 </script>

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -6,8 +6,7 @@
 		</div>
 		<div class="flex-1 overflow-hidden">
 			<TemplateGallery
-				class="h-full"
-				content-class="max-w-3xl"
+				class="mx-auto h-full w-full max-w-3xl"
 				blank-label="Start from scratch"
 				:max-groups="8"
 				:heading="templateHeading"


### PR DESCRIPTION
Turns the first-run persona survey into a one-question-per-page wizard that ends in a full-page template picker — so new users leave onboarding with a starting point instead of an empty dashboard.

Each question is answered by picking a tile and clicking **Next** — selection only highlights the choice, so a stray double-click can't skip past the following question. Next stays disabled until the current question is answered.

The template gallery + create/import logic is extracted out of `TemplatesDialog` into a reusable `TemplateGallery`, shared by both the "New" modal and the onboarding step.

### New flow

| 1. What to build | 2. Your role | 3. How you heard |
|---|---|---|
| ![Q1](https://raw.githubusercontent.com/surajshetty3416/builder/59d679e77c23ea2a6e920f512c4010825475e2ce/.pr-assets/pr-1-question1.png) | ![Q2](https://raw.githubusercontent.com/surajshetty3416/builder/59d679e77c23ea2a6e920f512c4010825475e2ce/.pr-assets/pr-2-question2.png) | ![Q3](https://raw.githubusercontent.com/surajshetty3416/builder/59d679e77c23ea2a6e920f512c4010825475e2ce/.pr-assets/pr-3-question3.png) |

…then a full-page template picker:

![Template picker](https://raw.githubusercontent.com/surajshetty3416/builder/59d679e77c23ea2a6e920f512c4010825475e2ce/.pr-assets/pr-4-templates.png)
