### PR TITLE
fix: open get_page_ctr DuckDB connection read-only

### DIFF
--- a/builder/builder_analytics.py
+++ b/builder/builder_analytics.py
@@ -410,7 +410,9 @@ def get_page_ctr(
 
 		where_clause, params = build_where_clause(route, from_date, to_date, route_filter_type)
 
-		with DuckDBConnection() as db:
+		# read-only so this SELECT-only query doesn't take the exclusive write lock and
+		# starve the concurrent get_page_analytics read on the same dashboard load
+		with DuckDBConnection(read_only=True) as db:
 			total_views = (
 				db.execute(f"SELECT COUNT(*) FROM {DUCKDB_TABLE} WHERE {where_clause}", params).fetchone()[0]
 				or 0


### PR DESCRIPTION
## Problem

`get_page_ctr` runs only `SELECT`s but opened a **read-write** DuckDB connection (`DuckDBConnection()`), which takes the exclusive file lock. Every other dashboard read passes `read_only=True` precisely so reads can coexist — see the class comment at the top of `builder_analytics.py`.

On a per-page analytics load, `get_page_analytics` (read-only) and `get_page_ctr` fire together. They race for the lock, so one call intermittently fails and returns its empty payload. The result: on real pages the stat tiles show `0` / `0%` **or** the Top Clicks / Top Referrers panels flicker to "No … yet", depending on which request loses the race.

## Fix

Open the connection `read_only=True`, matching the other read paths, so both dashboard reads coexist without contention.

```python
with DuckDBConnection(read_only=True) as db:
```

One line, SELECT-only path, no behavior change beyond removing the lock contention.