### PR TITLE
fix: canvas rendering of inline text blocks (span/a pills) + text-edit corruption

### DIFF
--- a/frontend/src/components/BlockProperties.vue
+++ b/frontend/src/components/BlockProperties.vue
@@ -84,8 +84,7 @@ const showSection = (section: PropertySection) => {
 	if (section.condition) {
 		showSection = section.condition();
 	}
-	// a section whose properties are all condition-hidden renders as a blank header
-	// (e.g. Layout on text blocks) — hide it entirely
+	// hide sections whose properties are all condition-hidden (blank header otherwise)
 	if (showSection) {
 		showSection = getFilteredProperties(section).length > 0;
 	}

--- a/frontend/src/components/BlockProperties.vue
+++ b/frontend/src/components/BlockProperties.vue
@@ -84,7 +84,9 @@ const showSection = (section: PropertySection) => {
 	if (section.condition) {
 		showSection = section.condition();
 	}
-	if (showSection && builderStore.propertyFilter) {
+	// a section whose properties are all condition-hidden renders as a blank header
+	// (e.g. Layout on text blocks) — hide it entirely
+	if (showSection) {
 		showSection = getFilteredProperties(section).length > 0;
 	}
 	return showSection;

--- a/frontend/src/components/BlockPropertySections/LayoutSection.ts
+++ b/frontend/src/components/BlockPropertySections/LayoutSection.ts
@@ -48,12 +48,15 @@ const layoutSectionProperties = [
 	},
 	{
 		component: BlockGridLayoutHandler,
+		// mirrors the component's own v-ifs so an all-hidden section can be detected
+		condition: () => blockController.isGrid(),
 		getProps: () => {},
 		searchKeyWords:
 			"Layout, Grid, GridTemplate, Grid Template, GridGap, Grid Gap, GridRow, Grid Row, GridColumn, Grid Column",
 	},
 	{
 		component: BlockFlexLayoutHandler,
+		condition: () => blockController.isFlex() || Boolean(blockController.getParentBlock()?.isFlex()),
 		getProps: () => {},
 		searchKeyWords:
 			"Layout, Flex, Flexbox, Flex Box, FlexBox, Justify, Space Between, Flex Grow, Flex Shrink, Flex Basis, Align Items, Align Content, Align Self, Flex Direction, Flex Wrap, Flex Flow, Flex Grow, Flex Shrink, Flex Basis, Gap, Order",

--- a/frontend/src/components/BlockPropertySections/LayoutSection.ts
+++ b/frontend/src/components/BlockPropertySections/LayoutSection.ts
@@ -48,8 +48,7 @@ const layoutSectionProperties = [
 	},
 	{
 		component: BlockGridLayoutHandler,
-		// mirrors the component's own v-ifs so an all-hidden section can be detected
-		condition: () => blockController.isGrid(),
+		condition: () => blockController.isGrid() || Boolean(blockController.getParentBlock()?.isGrid()),
 		getProps: () => {},
 		searchKeyWords:
 			"Layout, Grid, GridTemplate, Grid Template, GridGap, Grid Gap, GridRow, Grid Row, GridColumn, Grid Column",

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -257,6 +257,15 @@ const getInnerHTML = (editor: Editor | null) => {
 	) {
 		innerHTML = editor?.getText();
 	}
+	// tiptap wraps content in a paragraph node, so getHTML() returns <p>…</p>. Storing
+	// that wrapper as the block's innerHTML nests a block box inside the block's own
+	// text element — a <p> inside a <span> fragments the inline box (background/radius
+	// shatter into pieces), and <p> inside <p> is invalid HTML that the parser splits
+	// on publish. When the whole doc is that one paragraph, the wrapper is redundant.
+	const doc = editor.state.doc;
+	if (doc.childCount === 1 && doc.firstChild?.type.name === "paragraph" && innerHTML.startsWith("<p>")) {
+		innerHTML = innerHTML.slice(3).replace(/<\/p>$/, "");
+	}
 	return innerHTML;
 };
 

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -1,10 +1,10 @@
 <template>
 	<component :is="block.getTag()" ref="component" :key="editor" class="__text_block__">
 		<div
+			class="__text_content__ bg-clip-[inherit] bg-inherit [-webkit-background-clip:inherit] [background-image:inherit]"
 			v-html="textContent"
 			v-show="!editor && textContent"
-			@click="handleClick"
-			class="bg-clip-[inherit] bg-inherit [-webkit-background-clip:inherit] [background-image:inherit]"></div>
+			@click="handleClick"></div>
 		<TextBlockBubbleMenu
 			v-if="editor"
 			:block="block"
@@ -376,6 +376,14 @@ defineExpose({
 });
 </script>
 <style scoped>
+/* The published page renders text directly inside the block's own tag; this wrapper
+   div exists only for v-html. Without display:contents it adds a block box, which
+   shatters inline blocks (span/a pills): the background/radius paint on empty inline
+   fragments while the text renders full-width with no background behind it. */
+.__text_content__ {
+	display: contents;
+}
+
 .__text_block__ :deep([contenteditable="true"]) {
 	caret-color: currentcolor;
 	/* blocks inherit `select-none`; re-enable native text selection while editing */

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -257,14 +257,12 @@ const getInnerHTML = (editor: Editor | null) => {
 	) {
 		innerHTML = editor?.getText();
 	}
-	// tiptap wraps content in a paragraph node, so getHTML() returns <p>…</p>. Storing
-	// that wrapper as the block's innerHTML nests a block box inside the block's own
-	// text element — a <p> inside a <span> fragments the inline box (background/radius
-	// shatter into pieces), and <p> inside <p> is invalid HTML that the parser splits
-	// on publish. When the whole doc is that one paragraph, the wrapper is redundant.
+	// a lone attribute-less <p> wrapper is redundant inside the block's own tag
+	// (and a block box inside inline elements like span/a breaks their layout)
 	const doc = editor.state.doc;
-	if (doc.childCount === 1 && doc.firstChild?.type.name === "paragraph" && innerHTML.startsWith("<p>")) {
-		innerHTML = innerHTML.slice(3).replace(/<\/p>$/, "");
+	const wrapped = innerHTML.match(/^<p>([\s\S]*)<\/p>$/);
+	if (doc.childCount === 1 && doc.firstChild?.type.name === "paragraph" && wrapped) {
+		innerHTML = wrapped[1];
 	}
 	return innerHTML;
 };
@@ -376,18 +374,12 @@ defineExpose({
 });
 </script>
 <style scoped>
-/* The published page renders text directly inside the block's own tag; this wrapper
-   div exists only for v-html. Without display:contents it adds a block box, which
-   shatters inline blocks (span/a pills): the background/radius paint on empty inline
-   fragments while the text renders full-width with no background behind it. */
+/* no box — a block box inside inline tags (span/a) fragments their background/radius */
 .__text_content__ {
 	display: contents;
 }
 
-/* Same problem on the editing path: selecting a text block swaps the static div for
-   the tiptap editor root, another block box. Keep it inline-level inside inline tags
-   so the host element's background/radius still paint as one box. (display:contents
-   is not an option here — the contenteditable ProseMirror element needs a box.) */
+/* the contenteditable editor root needs a box, so keep it inline-level inside inline tags */
 :is(span, a, b, i, em, strong, cite, label).__text_block__ > .__text_editor__ {
 	display: inline-block;
 }

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -22,7 +22,7 @@
 			v-on-click-outside="handleClickOutside"
 			@mouseup="selectionTriggered = false"
 			v-if="editor && showEditor"
-			class="bg-clip-[inherit] relative bg-inherit [-webkit-background-clip:inherit] [background-image:inherit]"
+			class="__text_editor__ bg-clip-[inherit] relative bg-inherit [-webkit-background-clip:inherit] [background-image:inherit]"
 			:style="block.getRawStyles()"
 			@keydown="(e: KeyboardEvent) => bubbleMenu?.handleKeydown(e)" />
 		<slot />
@@ -382,6 +382,17 @@ defineExpose({
    fragments while the text renders full-width with no background behind it. */
 .__text_content__ {
 	display: contents;
+}
+
+/* Same problem on the editing path: selecting a text block swaps the static div for
+   the tiptap editor root, another block box. Keep it inline-level inside inline tags
+   so the host element's background/radius still paint as one box. (display:contents
+   is not an option here — the contenteditable ProseMirror element needs a box.) */
+:is(span, a, b, i, em, strong, cite, label).__text_block__ > .__text_editor__ {
+	display: inline-block;
+}
+:is(span, a, b, i, em, strong, cite, label).__text_block__ :deep(.ProseMirror p) {
+	display: inline;
 }
 
 .__text_block__ :deep([contenteditable="true"]) {


### PR DESCRIPTION
## Problem

Inline text blocks (`span`/`a` styled as pills or chips) render broken in the editor canvas while looking perfect on the published page.

The canvas renders text through wrapper elements the published page doesn't have: a static `<div v-html>` (and, once the block is selected, the tiptap editor root). Both are **block boxes inside the block's own tag**. For inline elements this fragments the inline box: the background and border-radius paint on the empty fragments around the wrapper (detached rounded "caps"), while the text lays out full-width with no background behind it — invisible when the text color matches the section behind it.

| Editor canvas (before) | Published page (same block) |
|---|---|
| two detached half-moon caps, invisible text | correct pill |

On top of that, editing text in the canvas corrupts data: tiptap's `getHTML()` wraps content in a paragraph node, and the save path stored `<p>…</p>` verbatim as the block's `innerHTML` — a block-in-inline for spans and invalid nested `<p>` for paragraphs (which the HTML parser splits on the published page).

## Fixes (one commit each)

1. **`getInnerHTML` strips tiptap's paragraph wrapper** when the whole document is that single paragraph (marks like bold/color survive; multi-paragraph content keeps its wrappers, headers keep their existing special case).
2. **Static content wrapper gets `display: contents`** so it generates no box and the text participates in the block's own layout — canvas now matches publish. (This also supersedes the `bg-inherit`/background-clip inheritance workaround for knockout text, which is kept.)
3. **Editing path + panel**: inside inline tags the tiptap editor root is kept `inline-block` (its paragraph inline) so selecting/editing a pill doesn't re-shatter it — `display: contents` isn't usable there because the contenteditable ProseMirror element needs a box. Also: the Layout section rendered as a blank header for text blocks (its Type toggle is condition-hidden for text, and the grid/flex handlers render nothing unless the block or parent is grid/flex) — those render conditions are now mirrored as property conditions, and sections whose properties are all hidden are hidden entirely.