### PR TITLE
fix: Update frappe-ui to v1.0.0-beta.21

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "@vueuse/core": "^10.2.1",
     "autoprefixer": "^10.4.2",
     "codemirror": "^6.0.2",
-    "frappe-ui": "1.0.0-beta.8",
+    "frappe-ui": "1.0.0-beta.21",
     "js-yaml": "^4.1.1",
     "opentype.js": "^1.3.4",
     "pinia": "^2.0.28",

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -43,7 +43,7 @@ const typographySectionProperties = [
 				propertyKey: "fontFamily",
 				getOptions: (filterString: string) => {
 					const fontOptions = [] as { label: string; value: string }[];
-					userFonts.data.forEach((font: UserFont) => {
+					userFonts.data?.forEach((font: UserFont) => {
 						if (fontOptions.length >= 20) {
 							return;
 						}

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -543,7 +543,7 @@ watch(
 		const waitsForComponentData = Boolean(props.block.extendedFromComponent);
 		const cleanup = emulateBlockClientScript({
 			key: uidToUse,
-			element,
+			element: element as HTMLElement,
 			breakpoint: props.breakpoint,
 			css: clientScript.css ?? "",
 			javascript:

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -66,7 +66,7 @@
 				v-show="breakpoint.visible"
 				:key="breakpoint.device">
 				<div
-					class="absolute left-0 cursor-pointer select-none text-5xl text-ink-gray-7"
+					class="absolute left-0 cursor-pointer select-none text-4xl text-ink-gray-7"
 					:style="{
 						fontSize: `calc(${12}px * 1/${canvasProps.scale})`,
 						top: `calc(${-20}px * 1/${canvasProps.scale})`,

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex h-[88vh] max-h-[800px] overflow-hidden">
 		<div class="flex w-48 shrink-0 flex-col gap-5 bg-surface-gray-1 p-4 px-2">
-			<span class="text-xl-semibold px-2 text-ink-gray-9">Settings</span>
+			<span class="text-lg-semibold px-2 text-ink-gray-9">Settings</span>
 			<div class="flex flex-col gap-0.5" v-for="(item, index) in settingsSidebarItems" :key="index">
 				<span class="text-base-medium mb-2 px-2 text-ink-gray-5">
 					{{ item.title }}
@@ -21,7 +21,7 @@
 			</div>
 		</div>
 		<div class="flex flex-1 flex-col gap-5 overflow-hidden bg-surface-base p-14 px-16 pb-0">
-			<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ selectedItemDoc?.title }}</h2>
+			<h2 class="text-2xl-semibold leading-none text-ink-gray-9">{{ selectedItemDoc?.title }}</h2>
 			<Button
 				icon="lucide-x"
 				variant="subtle"

--- a/frontend/src/components/BuilderToolbar.vue
+++ b/frontend/src/components/BuilderToolbar.vue
@@ -26,7 +26,7 @@
 			</div>
 		</div>
 		<div>
-			<Popover placement="bottom" popoverClass="!mt-[20px]">
+			<Popover placement="bottom" :offset="20">
 				<template #target="{ togglePopover, isOpen }">
 					<div class="flex cursor-pointer items-center gap-2 p-2 text-ink-gray-8">
 						<div class="flex h-6 items-center text-base text-ink-gray-6" v-if="!pageStore.activePage">

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -4,8 +4,7 @@
 		v-if="renderMode === 'popover'"
 		:placement="placement"
 		:offset="offset"
-		class="!block w-full"
-		popoverClass="!min-w-fit">
+		class="!block w-full">
 		<template #target="{ togglePopover, isOpen }">
 			<slot
 				name="target"

--- a/frontend/src/components/DashboardHead.vue
+++ b/frontend/src/components/DashboardHead.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="m-auto flex w-3/4 max-w-6xl items-center justify-between bg-surface-base px-3.5 py-5 pt-8">
-		<h1 class="text-3xl-semibold text-ink-gray-9">
+		<h1 class="text-2xl-semibold text-ink-gray-9">
 			{{ builderStore.activeFolder || "All Pages" }}
 		</h1>
 		<div class="flex gap-2">

--- a/frontend/src/components/DashboardSidebar.vue
+++ b/frontend/src/components/DashboardSidebar.vue
@@ -63,7 +63,7 @@
 								}">
 								<div class="flex w-full cursor-pointer items-center gap-2">
 									<img src="/builder_logo.png" alt="logo" class="h-7" />
-									<h1 class="text-md mt-[2px] font-semibold leading-5 text-gray-800 dark:text-gray-200">
+									<h1 class="mt-[2px] text-md font-semibold leading-5 text-gray-800 dark:text-gray-200">
 										Builder
 									</h1>
 								</div>
@@ -233,7 +233,7 @@ const renameFolder = async (newFolderName: string, targetFolder: BuilderProjectF
 			new_name: newFolderName,
 		})
 		.then(() => {
-			builderProjectFolder.data = builderProjectFolder.data.map((folder: BuilderProjectFolder) => {
+			builderProjectFolder.data = (builderProjectFolder.data ?? []).map((folder: BuilderProjectFolder) => {
 				if (folder.folder_name === builderStore.activeFolder) {
 					folder.folder_name = newFolderName;
 				}
@@ -256,7 +256,7 @@ const deleteFolder = async (folderName: string) => {
 		},
 		auto: true,
 	});
-	builderProjectFolder.data = builderProjectFolder.data.filter(
+	builderProjectFolder.data = (builderProjectFolder.data ?? []).filter(
 		(folder: BuilderProjectFolder) => folder.folder_name !== folderName,
 	);
 	setFolderActive("");

--- a/frontend/src/components/Modals/VariableManager.vue
+++ b/frontend/src/components/Modals/VariableManager.vue
@@ -15,7 +15,7 @@
 		action-label="Add Variable"
 		:action-handler="addNewVariable"
 		placement="top-left">
-		<template #header><h2 class="text-xl-semibold py-2">Manage Variables</h2></template>
+		<template #header><h2 class="text-lg-semibold py-2">Manage Variables</h2></template>
 		<template #content>
 			<div @keydown.esc="clearSelection">
 				<div class="mb-3">

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -4,7 +4,7 @@
 			<div class="flex h-full w-48 flex-col justify-between gap-1">
 				<div class="flex flex-col gap-1">
 					<draggable
-						v-model="attachedScriptResource.data"
+						v-model="attachedScripts"
 						:item-key="(script: attachedScript) => script.name"
 						handle=".drag-handle"
 						@end="onScriptReorder"
@@ -182,6 +182,13 @@ const attachedScriptResource = createListResource({
 	},
 });
 
+const attachedScripts = computed({
+	get: () => attachedScriptResource.data ?? [],
+	set: (scripts: attachedScript[]) => {
+		attachedScriptResource.data = scripts;
+	},
+});
+
 const clientScriptResource = createListResource({
 	doctype: "Builder Client Script",
 	fields: ["script_type", "name"],
@@ -303,7 +310,7 @@ const updateScriptName = async (newName: string, script: attachedScript) => {
 			script.name = newName;
 		}
 		return script;
-	});
+	}) as unknown as BuilderClientScript[];
 	return createResource({
 		url: "frappe.client.rename_doc",
 	})
@@ -313,7 +320,7 @@ const updateScriptName = async (newName: string, script: attachedScript) => {
 			new_name: newName,
 		})
 		.then(async () => {
-			attachedScriptResource.data = attachedScriptResource.data.map(
+			attachedScriptResource.data = (attachedScriptResource.data ?? []).map(
 				(s: { script_name: string; script: string }) => {
 					if (s.script_name === script.script_name) {
 						s.script_name = newName;

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -40,7 +40,7 @@
 		<Dialog class="overscroll-none" :title="dialogTitle" size="7xl" :isDirty="isDirty" v-model="showDialog">
 			<template #title>
 				<div class="flex w-full items-center justify-between gap-3 pr-2">
-					<span class="text-xl font-semibold text-ink-gray-9">{{ dialogTitle }}</span>
+					<span class="text-lg font-semibold text-ink-gray-9">{{ dialogTitle }}</span>
 					<TabButtons
 						v-if="showBlockClientScriptToggle"
 						v-model="activeBlockClientScript"

--- a/frontend/src/components/Settings/AnalyticsFilters.vue
+++ b/frontend/src/components/Settings/AnalyticsFilters.vue
@@ -103,9 +103,9 @@ const getRouteOptions = async (query: string) => {
 
 	const queryLower = query?.toLowerCase() || "";
 
-	return webPages.data
+	return (webPages.data ?? [])
 		.filter((page: BuilderPage) => page.route && !page.dynamic_route)
-		.map((page: BuilderPage) => ({ value: page.route, label: page.route }))
+		.map((page: BuilderPage) => ({ value: page.route as string, label: page.route as string }))
 		.filter(
 			(option: { value: string; label: string }) =>
 				!queryLower || option.label.toLowerCase().includes(queryLower),

--- a/frontend/src/components/Settings/AnalyticsOverview.vue
+++ b/frontend/src/components/Settings/AnalyticsOverview.vue
@@ -1,22 +1,22 @@
 <template>
 	<div class="my-5 flex flex-col gap-4 text-ink-gray-9">
 		<div class="flex items-center justify-between gap-4">
-			<span class="text-xl-medium">Overview</span>
+			<span class="text-lg-medium">Overview</span>
 			<div class="flex gap-2">
 				<slot name="filters"></slot>
 			</div>
 		</div>
 		<div class="flex gap-8">
 			<div class="flex flex-col gap-2">
-				<span class="text-5xl">{{ loading ? "-" : shortenNumber(data.total_unique_views) }}</span>
+				<span class="text-4xl">{{ loading ? "-" : shortenNumber(data.total_unique_views) }}</span>
 				<span class="text-sm text-ink-gray-7">Unique Visitors</span>
 			</div>
 			<div class="flex flex-col gap-2">
-				<span class="text-5xl">{{ loading ? "-" : shortenNumber(data.total_views) }}</span>
+				<span class="text-4xl">{{ loading ? "-" : shortenNumber(data.total_views) }}</span>
 				<span class="text-sm text-ink-gray-7">Total Pageviews</span>
 			</div>
 			<div v-if="ctr !== undefined" class="flex flex-col gap-2">
-				<span class="text-5xl">{{ loading ? "-" : `${ctr}%` }}</span>
+				<span class="text-4xl">{{ loading ? "-" : `${ctr}%` }}</span>
 				<span class="text-sm text-ink-gray-7">Click-through Rate</span>
 			</div>
 		</div>

--- a/frontend/src/components/Settings/GlobalAnalytics.vue
+++ b/frontend/src/components/Settings/GlobalAnalytics.vue
@@ -17,7 +17,7 @@
 				</template>
 			</AnalyticsOverview>
 			<div class="mt-8">
-				<h3 class="text-xl-medium mb-4 text-ink-gray-7">Top Pages</h3>
+				<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Pages</h3>
 				<div
 					v-if="analytics.loading"
 					class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -186,11 +186,13 @@ function brokenReason(d: any): string {
 }
 
 function statusTheme(status: string) {
-	return (
-		({ Active: "green", Broken: "red", Pending: "orange", "In Progress": "blue" } as Record<string, string>)[
-			status
-		] ?? "gray"
-	);
+	const themes: Record<string, "green" | "red" | "orange" | "blue"> = {
+		Active: "green",
+		Broken: "red",
+		Pending: "orange",
+		"In Progress": "blue",
+	};
+	return themes[status] ?? "gray";
 }
 
 async function copyToClipboard(text: string) {

--- a/frontend/src/components/Settings/GlobalGeneral.vue
+++ b/frontend/src/components/Settings/GlobalGeneral.vue
@@ -28,7 +28,7 @@
 		</div>
 		<hr class="w-full border-outline-gray-2" />
 		<div class="flex flex-col justify-between gap-5">
-			<span class="text-xl-semibold text-ink-gray-9">Favicon</span>
+			<span class="text-lg-semibold text-ink-gray-9">Favicon</span>
 			<div class="flex flex-1 gap-5">
 				<div
 					class="flex items-center justify-center rounded border border-outline-gray-1 bg-surface-gray-2 px-20 py-5">

--- a/frontend/src/components/Settings/GlobalRedirects.vue
+++ b/frontend/src/components/Settings/GlobalRedirects.vue
@@ -166,7 +166,7 @@ const focusInput = (el: any) => el?.$el?.querySelector?.("input")?.focus();
 
 onMounted(() => routeRedirects.fetch());
 
-const findIndex = (id: string) => routeRedirects.data.findIndex((r: any) => r.name === id);
+const findIndex = (id: string) => (routeRedirects.data ?? []).findIndex((r: any) => r.name === id);
 
 const rows = computed<RedirectRow[]>(() => {
 	const query = searchQuery.value.toLowerCase().trim();
@@ -247,7 +247,7 @@ const insertNew = (d: Draft) => {
 		},
 		() => {
 			const i = findIndex(tempId);
-			if (i !== -1) routeRedirects.data.splice(i, 1);
+			if (i !== -1) routeRedirects.data?.splice(i, 1);
 		},
 		{ loading: "Adding redirect...", success: "Redirect added", error: "Error adding redirect" },
 	);
@@ -255,11 +255,11 @@ const insertNew = (d: Draft) => {
 
 const saveExisting = (id: string, d: Draft) => {
 	const index = findIndex(id);
-	const backup = index !== -1 ? { ...routeRedirects.data[index] } : null;
+	const backup = index !== -1 ? { ...routeRedirects.data![index] } : null;
 	performOptimisticUpdate(
 		() => routeRedirects.setValue.submit({ name: id, ...docFields(d) }),
-		() => index !== -1 && Object.assign(routeRedirects.data[index], docFields(d)),
-		() => backup && Object.assign(routeRedirects.data[index], backup),
+		() => index !== -1 && Object.assign(routeRedirects.data![index], docFields(d)),
+		() => backup && Object.assign(routeRedirects.data![index], backup),
 		{ loading: "Updating redirect...", success: "Redirect updated", error: "Error updating redirect" },
 	);
 };
@@ -272,11 +272,11 @@ const deleteRedirect = async (id: string) => {
 	if (!(await confirm(message))) return;
 
 	const index = findIndex(id);
-	const backup = index !== -1 ? { ...routeRedirects.data[index] } : null;
+	const backup = index !== -1 ? { ...routeRedirects.data![index] } : null;
 	performOptimisticUpdate(
 		() => routeRedirects.delete.submit(id),
-		() => index !== -1 && routeRedirects.data.splice(index, 1),
-		() => backup && routeRedirects.data.splice(index, 0, backup),
+		() => index !== -1 && routeRedirects.data!.splice(index, 1),
+		() => backup && routeRedirects.data!.splice(index, 0, backup),
 		{ loading: "Deleting redirect...", success: "Redirect deleted", error: "Error deleting redirect" },
 	);
 };

--- a/frontend/src/components/Settings/PageGeneral.vue
+++ b/frontend/src/components/Settings/PageGeneral.vue
@@ -62,7 +62,7 @@
 				<hr class="w-full border-outline-gray-2" />
 
 				<div class="flex flex-col justify-between gap-5">
-					<span class="text-xl-semibold text-ink-gray-9">Favicon</span>
+					<span class="text-lg-semibold text-ink-gray-9">Favicon</span>
 					<div class="flex flex-1 gap-5">
 						<div
 							class="flex items-center justify-center rounded border border-outline-gray-1 bg-surface-gray-2 px-20 py-5">

--- a/frontend/src/components/Settings/TopClicksList.vue
+++ b/frontend/src/components/Settings/TopClicksList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<h3 class="text-xl-medium mb-4 text-ink-gray-7">Top Clicks</h3>
+		<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Clicks</h3>
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			Loading...
 		</div>

--- a/frontend/src/components/Settings/TopReferrersList.vue
+++ b/frontend/src/components/Settings/TopReferrersList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<h3 class="text-xl-medium mb-4 text-ink-gray-7">Top Referrers</h3>
+		<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Referrers</h3>
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			Loading...
 		</div>

--- a/frontend/src/components/Settings/TrackingDisabledNotice.vue
+++ b/frontend/src/components/Settings/TrackingDisabledNotice.vue
@@ -4,7 +4,7 @@
 			<FeatherIcon name="bar-chart-2" class="h-6 w-6 text-ink-gray-5" />
 		</div>
 		<div class="flex flex-col gap-1">
-			<h3 class="text-lg-medium text-ink-gray-9">View tracking is off</h3>
+			<h3 class="text-md-medium text-ink-gray-9">View tracking is off</h3>
 			<p class="max-w-sm text-p-sm text-ink-gray-6">
 				Turn on view tracking to start collecting page views, clicks and click-through rates for your
 				published pages.

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -12,7 +12,7 @@
 			</Button>
 			<div class="mb-2 flex flex-col gap-2">
 				<div class="flex items-center justify-between">
-					<h2 class="text-3xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
+					<h2 class="text-2xl-semibold leading-none text-ink-gray-9">{{ heading }}</h2>
 					<Button
 						v-if="activeGroup"
 						variant="outline"

--- a/frontend/src/components/TextBlockBubbleMenu.vue
+++ b/frontend/src/components/TextBlockBubbleMenu.vue
@@ -7,7 +7,7 @@
 		:plugin-key="bubbleMenuPluginKey"
 		v-show="!canvasProps?.panning && !canvasProps?.scaling"
 		v-if="editor"
-		class="rounded-md border border-outline-gray-3 bg-surface-base p-1 text-xl text-ink-gray-9 shadow-2xl">
+		class="rounded-md border border-outline-gray-3 bg-surface-base p-1 text-lg text-ink-gray-9 shadow-2xl">
 		<div
 			v-if="settingLink"
 			class="flex flex-col gap-2 p-1"
@@ -106,9 +106,7 @@
 					:modelValue="selectedColor"
 					@update:modelValue="setTextColor"
 					:show-input="true"
-					placement="top"
-					:appendTo="overlayElement"
-					popoverClass="!min-w-fit">
+					placement="top">
 					<template #target="{ togglePopover, isOpen }">
 						<button v-show="!block.isHeader()" class="rounded px-2 py-1 hover:bg-surface-gray-2">
 							<div class="p-1">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -83,3 +83,9 @@ p:empty::before {
 .PopoverContent {
 	z-index: 30;
 }
+
+/* frappe-ui v1.0.0-beta.21 dimmed Switch labels to the shared InputLabel default
+   (ink-gray-5); restore the old emphasis since the label acts as the row title */
+div:has(> [role='switch']) label[data-slot='label'] {
+	@apply font-medium text-ink-gray-8;
+}

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -2,7 +2,7 @@
 	<div v-show="isSmallScreen" class="grid h-screen w-screen place-content-center gap-4 text-ink-gray-9">
 		<img src="/builder_logo.png" alt="logo" class="h-10" />
 		<div class="flex flex-col">
-			<h1 class="text-p-4xl-semibold">Screen too small</h1>
+			<h1 class="text-p-3xl-semibold">Screen too small</h1>
 			<p class="text-p-base">Please switch to a larger screen to edit</p>
 		</div>
 	</div>
@@ -505,7 +505,7 @@ watch(
 				},
 				auto: true,
 			});
-			usageCountResource.promise.then((res: { count: number; pages: BuilderPage[] }) => {
+			usageCountResource.promise?.then((res: { count: number; pages: BuilderPage[] }) => {
 				usageCount.value = res.count;
 				componentUsedInPages.value = res.pages;
 			});

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -19,7 +19,7 @@
 			<div class="flex flex-col gap-6">
 				<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
 				<div class="flex flex-col gap-2">
-					<h1 class="text-2xl font-semibold text-ink-gray-9">{{ activeQuestion.heading }}</h1>
+					<h1 class="text-xl font-semibold text-ink-gray-9">{{ activeQuestion.heading }}</h1>
 				</div>
 			</div>
 

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -120,7 +120,7 @@ const useComponentStore = defineStore("componentStore", {
 									},
 									auto: true,
 								});
-								await toast.promise(componentResource.promise, {
+								await toast.promise(componentResource.promise!, {
 									loading: "Syncing component in all the pages...",
 									success: () => {
 										pageStore.fetchActivePage().then(() => {

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -120,7 +120,7 @@ const usePageStore = defineStore("pageStore", {
 		async fetchActivePage(pageName?: string) {
 			const webPageResource = await createDocumentResource({
 				doctype: "Builder Page",
-				name: pageName,
+				name: pageName as string,
 				auto: true,
 			});
 			try {

--- a/frontend/src/utils/dialogs.ts
+++ b/frontend/src/utils/dialogs.ts
@@ -71,8 +71,8 @@ export function promptSelectFolder() {
 	const options = [
 		{ label: "Home", value: "" },
 		...(builderProjectFolder.data || []).map((p: BuilderProjectFolder) => ({
-			label: p.folder_name,
-			value: p.folder_name,
+			label: p.folder_name as string,
+			value: p.folder_name as string,
 		})),
 	];
 	dialog.prompt({

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -532,8 +532,8 @@ export function useBuilderEvents(
 			if (route.params.pageId && route.params.pageId !== "new") {
 				const currentModified = pageStore.activePage?.modified;
 				webComponent.reload();
-				webPages.fetchOne.submit(pageStore.activePage?.name).then((doc: BuilderPage[]) => {
-					if (currentModified !== doc[0]?.modified) {
+				webPages.fetchOne.submit(pageStore.activePage?.name).then((doc: BuilderPage[] | null) => {
+					if (currentModified !== doc?.[0]?.modified) {
 						pageStore.setPage(route.params.pageId as string, false, route.query);
 					}
 				});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,7 +21,8 @@
       "@/*": [
         "src/*"
       ],
-      "tslib" : ["/node_modules/tslib/tslib.d.ts"]
+      "tslib" : ["/node_modules/tslib/tslib.d.ts"],
+      "vue": ["../node_modules/vue"]
     },
     "lib": [
       "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,16 @@
     "@codemirror/view" "^6.17.0"
     "@lezer/common" "^1.0.0"
 
+"@codemirror/autocomplete@^6.7.1":
+  version "6.20.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz#696b740312c6a962e14567b49a3661b5924bc5ae"
+  integrity sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
 "@codemirror/commands@^6.0.0", "@codemirror/commands@^6.8.1":
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.8.1.tgz#639f5559d2f33f2582a2429c58cb0c1b925c7a30"
@@ -342,7 +352,7 @@
     "@codemirror/view" "^6.27.0"
     "@lezer/common" "^1.1.0"
 
-"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.3.1":
+"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.2.0", "@codemirror/lang-css@^6.3.0", "@codemirror/lang-css@^6.3.1":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
   integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
@@ -352,6 +362,21 @@
     "@codemirror/state" "^6.0.0"
     "@lezer/common" "^1.0.2"
     "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-html@^6.0.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
 
 "@codemirror/lang-html@^6.4.9":
   version "6.4.10"
@@ -381,7 +406,20 @@
     "@lezer/common" "^1.0.0"
     "@lezer/javascript" "^1.0.0"
 
-"@codemirror/lang-json@^6.0.2":
+"@codemirror/lang-javascript@^6.2.2":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz#b9ea6b2f0383ed6895fae7888c0322541538f10a"
+  integrity sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/lang-json@^6.0.1", "@codemirror/lang-json@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.2.tgz#054b160671306667e25d80385286049841836179"
   integrity sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==
@@ -389,7 +427,20 @@
     "@codemirror/language" "^6.0.0"
     "@lezer/json" "^1.0.0"
 
-"@codemirror/lang-python@^6.2.1":
+"@codemirror/lang-markdown@^6.3.1":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz#29df87310a555b007beba8e12893363956a26e8e"
+  integrity sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.7.1"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.3.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.2.1"
+    "@lezer/markdown" "^1.0.0"
+
+"@codemirror/lang-python@^6.1.6", "@codemirror/lang-python@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-python/-/lang-python-6.2.1.tgz#37c9930716110156865a95c548aa0eef5552863a"
   integrity sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==
@@ -400,6 +451,54 @@
     "@lezer/common" "^1.2.1"
     "@lezer/python" "^1.1.4"
 
+"@codemirror/lang-sass@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz#38c1b0a1326cc9f5cb2741d2cd51cfbcd7abc0b2"
+  integrity sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==
+  dependencies:
+    "@codemirror/lang-css" "^6.2.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/sass" "^1.0.0"
+
+"@codemirror/lang-sql@^6.8.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz#49bfbf6cf31516a99e674da9a399f4426101a95a"
+  integrity sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@codemirror/lang-xml@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz#e3e786e1a89fdc9520efe75c1d6d3de1c40eb91c"
+  integrity sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/xml" "^1.0.0"
+
+"@codemirror/lang-yaml@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz#4d4127e8339984639715d1e3f8edca1ea5bfabfb"
+  integrity sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.2.0"
+    "@lezer/lr" "^1.0.0"
+    "@lezer/yaml" "^1.0.0"
+
 "@codemirror/language@^6.0.0", "@codemirror/language@^6.11.3", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0", "@codemirror/language@^6.8.0":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.11.3.tgz#8e6632df566a7ed13a1bd307f9837765bb1abfdd"
@@ -408,6 +507,18 @@
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.23.0"
     "@lezer/common" "^1.1.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/language@^6.3.0":
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.4.tgz#01e70fd5aa3a8a067ff1dfec75d5b6394cdfa058"
+  integrity sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
     style-mod "^4.0.0"
@@ -1110,6 +1221,11 @@
   resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.2.3.tgz#138fcddab157d83da557554851017c6c1e5667fd"
   integrity sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==
 
+"@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
 "@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.0.tgz#296f298814782c2fad42a936f3510042cdcd2034"
@@ -1126,10 +1242,26 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@lezer/highlight@^1.2.0":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
 "@lezer/html@^1.3.0":
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.12.tgz#a438e2d04f4c863d49cad27efe714cde8cf3ff1b"
   integrity sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.13.tgz#6a1305ae3bd2c9c01f877f8a8dc1e15ec652d01c"
+  integrity sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==
   dependencies:
     "@lezer/common" "^1.2.0"
     "@lezer/highlight" "^1.0.0"
@@ -1160,6 +1292,21 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@lezer/lr@^1.4.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.6.4.tgz#250d54e1c4e59e89be9329884141f76165d66327"
+  integrity sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==
+  dependencies:
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+
 "@lezer/python@^1.1.4":
   version "1.1.18"
   resolved "https://registry.yarnpkg.com/@lezer/python/-/python-1.1.18.tgz#fa02fbf492741c82dc2dc98a0a042bd0d4d7f1d3"
@@ -1168,6 +1315,33 @@
     "@lezer/common" "^1.2.0"
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
+
+"@lezer/sass@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lezer/sass/-/sass-1.1.0.tgz#c82e660aa5b39303d1de763923aef979fef1d3a4"
+  integrity sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/xml@^1.0.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@lezer/xml/-/xml-1.0.6.tgz#908c203923288f854eb8e2f4d9b06c437e8610b9"
+  integrity sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/yaml@^1.0.0":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@lezer/yaml/-/yaml-1.0.4.tgz#66a622188f1984a71d34506759b5807699043589"
+  integrity sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.4.0"
 
 "@marijn/find-cluster-break@^1.0.0":
   version "1.0.2"
@@ -3405,7 +3579,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-codemirror@^6.0.2:
+codemirror@^6.0.1, codemirror@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.2.tgz#4d3fea1ad60b6753f97ca835f2f48c6936a8946e"
   integrity sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==
@@ -7980,7 +8154,16 @@ string-argv@^0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8076,7 +8259,14 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9225,7 +9415,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9238,6 +9428,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Updates the frappe-ui submodule from v1.0.0-beta.8 to v1.0.0-beta.21 (keeping the exact version pin in `frontend/package.json` in sync so yarn resolves the workspace copy), plus the adaptations the new version needs:

## Adaptations

- **Typography tokens**: ran frappe-ui's `migrate-tokens-v2` codemod — 20 renames across 16 files (`text-5xl` → `text-4xl`, `text-xl-semibold` → `text-lg-semibold`, etc.).
- **Popover**: `popoverClass` is a no-op in the new Popover. Replaced the `!mt-[20px]` spacing hack in `BuilderToolbar` with the `:offset` prop, and dropped the already-inert `!min-w-fit` / `appendTo` props from `ColorPicker` and `TextBlockBubbleMenu`. (The deprecated-but-supported `placement` prop and `#target`/`#body` slots are left as-is.)
- **Types**: the stricter resource typings (`data`/`promise` now nullable, Badge `theme` a union, Combobox options) surfaced 24 new `vue-tsc` errors — fixed with null guards and narrow casts. Also mapped `vue` in `tsconfig.json` paths to the hoisted copy so vue-tsc stops resolving frappe-ui's types against its nested vue and creating type-identity mismatches. Net result: 55 errors vs 58 on develop (no new errors, 3 pre-existing ones fixed incidentally).
