### PR TITLE
fix: prevent arrow keys clobbering text InlineInput fields

### DIFF
--- a/frontend/src/components/Controls/InlineInput.vue
+++ b/frontend/src/components/Controls/InlineInput.vue
@@ -139,6 +139,8 @@ const handleMouseDown = (e: MouseEvent) => {
 };
 
 const handleKeyDown = (e: KeyboardEvent) => {
+	// Arrow-key stepping only for numeric inputs, not plain text fields.
+	if (!props.unitOptions.length && !props.enableSlider) return;
 	if (e.key === "ArrowUp" || e.key === "ArrowDown") {
 		const step = e.key === "ArrowUp" ? 1 : -1;
 		incrementOrDecrement(step);


### PR DESCRIPTION
`InlineInput.handleKeyDown` was applying ArrowUp/ArrowDown increment/decrement logic to every input, causing plain text fields (Video URL, Aria Label, Class, Placeholder, etc.) to be replaced with numeric values or `NaN`.

The stepping logic is now gated to numeric inputs only fields that expose `unitOptions` (e.g. `px`, `%`, grid sizing) or `enableSlider` (grid rows/columns). For all other inputs, ArrowUp/ArrowDown now fall back to the browser's default cursor navigation behavior.

Before fix when we do arrow key up and down:

https://github.com/user-attachments/assets/7ab4ce5b-a410-4c02-b76b-16b4fd17f4c7

After fix :

https://github.com/user-attachments/assets/9f3618fd-ae6e-401c-aaea-c178e7de0d0b

Fixes #660