### PR TITLE
feat: Re-arrange blocks right from canvas just by dragging

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -65,6 +65,7 @@ declare module 'vue' {
     Dialog: typeof import('./src/components/Controls/Dialog.vue')['default']
     DimensionInput: typeof import('./src/components/DimensionInput.vue')['default']
     DraggablePopup: typeof import('./src/components/Controls/DraggablePopup.vue')['default']
+    DropIndicator: typeof import('./src/components/DropIndicator.vue')['default']
     DynamicValueDropdown: typeof import('./src/components/DynamicValueDropdown.vue')['default']
     DynamicValueHandler: typeof import('./src/components/Controls/DynamicValueHandler.vue')['default']
     EditableSpan: typeof import('./src/components/EditableSpan.vue')['default']

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -274,7 +274,7 @@ const handleMove = (ev: MouseEvent) => {
 	// fall through to the free-move handler below.
 	if (reorderable.value) {
 		ev.stopPropagation();
-		startBlockReorder(ev, props.block);
+		startBlockReorder(ev, props.block, props.breakpoint);
 		return;
 	}
 

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -166,7 +166,7 @@ const isBlockSelected = computed(() => {
 
 const getStyleClasses = computed(() => {
 	const classes = [];
-	if ((movable.value || reorderable.value) && !props.block.isRoot()) {
+	if (movable.value && !props.block.isRoot()) {
 		classes.push("cursor-grab");
 	}
 	if (props.block.isExtendedFromComponent()) {

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -38,6 +38,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import blockController from "@/utils/blockController";
 import { addPxToNumber } from "@/utils/helpers";
+import { isReorderable, startBlockReorder } from "@/utils/useBlockReorder";
 import { Ref, computed, inject, nextTick, onMounted, ref, watch, watchEffect } from "vue";
 import setGuides from "../utils/guidesTracker";
 import trackTarget from "../utils/trackTarget";
@@ -165,7 +166,7 @@ const isBlockSelected = computed(() => {
 
 const getStyleClasses = computed(() => {
 	const classes = [];
-	if (movable.value && !props.block.isRoot()) {
+	if ((movable.value || reorderable.value) && !props.block.isRoot()) {
 		classes.push("cursor-grab");
 	}
 	if (props.block.isExtendedFromComponent()) {
@@ -199,6 +200,9 @@ watch(
 const movable = computed(() => {
 	return props.block.isMovable() && !props.readonly;
 });
+
+// In-flow blocks that can be reordered via the pointer-based reorder engine.
+const reorderable = computed(() => !props.readonly && isReorderable(props.block));
 
 onMounted(() => {
 	updateTracker.value = trackTarget(props.target, editor.value, canvasProps);
@@ -252,6 +256,16 @@ const handleMove = (ev: MouseEvent) => {
 	if (builderStore.mode === "text") {
 		canvasStore.editableBlock = props.block;
 	}
+
+	// In-flow blocks (not absolutely positioned) reorder within their flex/flow
+	// layout via the pointer-based engine — the canvas stays stable and only an
+	// overlay indicator moves until the block is dropped.
+	if (reorderable.value) {
+		ev.stopPropagation();
+		startBlockReorder(ev, props.block);
+		return;
+	}
+
 	if (!movable.value || props.block.isRoot()) return;
 	ev.stopPropagation();
 	const pauseId = canvasStore.activeCanvas?.history?.pause();

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -270,9 +270,8 @@ const handleMove = (ev: MouseEvent) => {
 	// draw inside this block instead of dragging it.
 	if (builderStore.mode !== "select") return;
 
-	// In-flow blocks (not absolutely positioned) reorder within their flex/flow
-	// layout via the pointer-based engine — the canvas stays stable and only an
-	// overlay indicator moves until the block is dropped.
+	// In-flow blocks reorder via the pointer engine; absolutely-positioned ones
+	// fall through to the free-move handler below.
 	if (reorderable.value) {
 		ev.stopPropagation();
 		startBlockReorder(ev, props.block);

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -53,6 +53,7 @@ const builderStore = useBuilderStore();
 
 const showResizer = computed(() => {
 	return (
+		builderStore.mode === "select" &&
 		!props.block.isRoot() &&
 		!props.editable &&
 		!props.readonly &&
@@ -90,6 +91,7 @@ const preventCLick = ref(false);
 
 const showPaddingHandler = computed(() => {
 	return (
+		builderStore.mode === "select" &&
 		isBlockSelected.value &&
 		!resizing.value &&
 		!canvasStore.isDragging &&
@@ -103,6 +105,7 @@ const showPaddingHandler = computed(() => {
 
 const showMarginHandler = computed(() => {
 	return (
+		builderStore.mode === "select" &&
 		isBlockSelected.value &&
 		!props.block.isRoot() &&
 		!canvasStore.isDragging &&
@@ -116,6 +119,7 @@ const showMarginHandler = computed(() => {
 
 const showBorderRadiusHandler = computed(() => {
 	return (
+		builderStore.mode === "select" &&
 		isBlockSelected.value &&
 		!props.block.isRoot() &&
 		!props.block.isText() &&
@@ -176,13 +180,17 @@ const getStyleClasses = computed(() => {
 	}
 	if (
 		isBlockSelected.value &&
+		builderStore.mode === "select" &&
 		!props.editable &&
 		!props.readonly &&
 		!props.block.isRoot() &&
 		!props.block.isRepeater() &&
 		!canvasStore.isDragging
 	) {
-		// make editor interactive
+		// make editor interactive — ONLY in select mode. In draw modes
+		// (container/text/image/repeater) or pan (move) the overlay must stay
+		// transparent so the press falls through to the canvas (e.g. to draw a
+		// container INSIDE this block instead of reordering it).
 		classes.push("pointer-events-auto");
 	}
 	return classes;
@@ -256,6 +264,11 @@ const handleMove = (ev: MouseEvent) => {
 	if (builderStore.mode === "text") {
 		canvasStore.editableBlock = props.block;
 	}
+
+	// Reorder / free-move are select-mode only. In draw modes (container, image,
+	// repeater) or pan (move) the press must fall through to the canvas so you can
+	// draw inside this block instead of dragging it.
+	if (builderStore.mode !== "select") return;
 
 	// In-flow blocks (not absolutely positioned) reorder within their flex/flow
 	// layout via the pointer-based engine — the canvas stays stable and only an

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -100,6 +100,7 @@
 			id="overlay"
 			ref="overlay" />
 		<div v-show="marquee.visible" class="pointer-events-none fixed z-[200]" :style="marqueeStyle" />
+		<DropIndicator />
 		<div class="absolute top-0 order-1 w-full">
 			<slot name="header"></slot>
 		</div>
@@ -143,6 +144,7 @@ import { Ref, computed, onMounted, onUnmounted, provide, reactive, ref, useId, w
 import setPanAndZoom from "../utils/panAndZoom";
 import BlockSnapGuides from "./BlockSnapGuides.vue";
 import BuilderBlock from "./BuilderBlock.vue";
+import DropIndicator from "./DropIndicator.vue";
 import FitScreenIcon from "./Icons/FitScreen.vue";
 
 const builderStore = useBuilderStore();

--- a/frontend/src/components/DropIndicator.vue
+++ b/frontend/src/components/DropIndicator.vue
@@ -1,0 +1,142 @@
+<template>
+	<div v-if="target.active" class="pointer-events-none fixed inset-0 z-[250]">
+		<!-- container highlight: shows which layout you're dropping into -->
+		<div
+			v-if="target.containerRect"
+			class="drop-container-highlight absolute rounded-[4px]"
+			:class="accentClass"
+			:style="containerStyle" />
+
+		<!-- SAME-container: exact in-flow slot box (measured from the placeholder) -->
+		<div
+			v-if="target.mode === 'slot' && target.slotRect"
+			class="drop-slot absolute rounded-[4px]"
+			:class="accentClass"
+			:style="slotStyle" />
+
+		<!-- CROSS-container: no-reflow line between the target's children -->
+		<div
+			v-if="target.mode === 'line' && target.line"
+			class="drop-line absolute rounded-full"
+			:class="[accentClass, `is-${target.line.orientation}`]"
+			:style="lineStyle">
+			<span class="drop-line-cap drop-line-cap--start" />
+			<span class="drop-line-cap drop-line-cap--end" />
+		</div>
+
+		<!-- spacing guide: the container's gap -->
+		<div v-if="target.spacing" class="drop-spacing-pill absolute" :class="accentClass" :style="pillStyle">
+			{{ target.spacing.value }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import useCanvasStore from "@/stores/canvasStore";
+import { computed } from "vue";
+
+const canvasStore = useCanvasStore();
+const target = computed(() => canvasStore.reorderTarget);
+
+const accentClass = computed(() => (target.value.isComponentParent ? "accent-purple" : "accent-blue"));
+
+const rectStyle = (r: { top: number; left: number; width: number; height: number } | null) =>
+	r ? { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` } : {};
+
+const containerStyle = computed(() => rectStyle(target.value.containerRect));
+const slotStyle = computed(() => rectStyle(target.value.slotRect));
+
+const LINE = 3;
+const lineStyle = computed(() => {
+	const l = target.value.line;
+	if (!l) return { display: "none" };
+	if (l.orientation === "vertical") {
+		return { left: `${l.left - LINE / 2}px`, top: `${l.top}px`, width: `${LINE}px`, height: `${l.length}px` };
+	}
+	return { left: `${l.left}px`, top: `${l.top - LINE / 2}px`, width: `${l.length}px`, height: `${LINE}px` };
+});
+
+const pillStyle = computed(() => {
+	const s = target.value.spacing;
+	if (!s) return { display: "none" };
+	return { left: `${s.left}px`, top: `${s.top}px` };
+});
+</script>
+
+<style scoped>
+.drop-slot.accent-blue {
+	box-shadow: inset 0 0 0 2px theme("colors.blue.500");
+	background-color: theme("colors.blue.500 / 12%");
+}
+.drop-slot.accent-purple {
+	box-shadow: inset 0 0 0 2px theme("colors.purple.500");
+	background-color: theme("colors.purple.500 / 12%");
+}
+
+.drop-line.accent-blue {
+	background-color: theme("colors.blue.500");
+	box-shadow:
+		0 0 0 1px theme("colors.blue.500 / 25%"),
+		0 0 6px theme("colors.blue.500 / 55%");
+}
+.drop-line.accent-purple {
+	background-color: theme("colors.purple.500");
+	box-shadow:
+		0 0 0 1px theme("colors.purple.500 / 25%"),
+		0 0 6px theme("colors.purple.500 / 55%");
+}
+.drop-line-cap {
+	position: absolute;
+	width: 7px;
+	height: 7px;
+	border-radius: 9999px;
+	background: inherit;
+	box-shadow: inherit;
+}
+.drop-line.is-vertical .drop-line-cap--start {
+	left: 50%;
+	top: 0;
+	transform: translate(-50%, -50%);
+}
+.drop-line.is-vertical .drop-line-cap--end {
+	left: 50%;
+	top: 100%;
+	transform: translate(-50%, -50%);
+}
+.drop-line.is-horizontal .drop-line-cap--start {
+	top: 50%;
+	left: 0;
+	transform: translate(-50%, -50%);
+}
+.drop-line.is-horizontal .drop-line-cap--end {
+	top: 50%;
+	left: 100%;
+	transform: translate(-50%, -50%);
+}
+
+.drop-spacing-pill {
+	transform: translate(-50%, -140%);
+	padding: 1px 6px;
+	border-radius: 9999px;
+	font-size: 10px;
+	line-height: 15px;
+	font-weight: 600;
+	color: #fff;
+	white-space: nowrap;
+}
+.drop-spacing-pill.accent-blue {
+	background-color: theme("colors.blue.500");
+}
+.drop-spacing-pill.accent-purple {
+	background-color: theme("colors.purple.500");
+}
+
+.drop-container-highlight.accent-blue {
+	box-shadow: inset 0 0 0 1.5px theme("colors.blue.400 / 70%");
+	background-color: theme("colors.blue.400 / 6%");
+}
+.drop-container-highlight.accent-purple {
+	box-shadow: inset 0 0 0 1.5px theme("colors.purple.400 / 70%");
+	background-color: theme("colors.purple.400 / 6%");
+}
+</style>

--- a/frontend/src/components/DropIndicator.vue
+++ b/frontend/src/components/DropIndicator.vue
@@ -1,50 +1,55 @@
 <template>
-	<div v-if="target.active" class="pointer-events-none fixed inset-0 z-[250]">
-		<!-- container highlight: shows which layout you're dropping into -->
+	<div v-if="target.active" ref="rootEl" class="pointer-events-none fixed inset-0 z-[250]" :style="clipStyle">
+		<!-- container outline: only when moving into a DIFFERENT container, so a
+		     plain in-place reorder stays quiet (no flicker) -->
 		<div
-			v-if="target.containerRect"
+			v-if="target.containerRect && !target.isSameContainer"
 			class="drop-container-highlight absolute rounded-[4px]"
 			:class="accentClass"
 			:style="containerStyle" />
 
-		<!-- SAME-container: exact in-flow slot box (measured from the placeholder) -->
+		<!-- insertion line — layout-aware (flex row/column, wrapped flex, grid) -->
 		<div
-			v-if="target.mode === 'slot' && target.slotRect"
-			class="drop-slot absolute rounded-[4px]"
-			:class="accentClass"
-			:style="slotStyle" />
-
-		<!-- CROSS-container: no-reflow line between the target's children -->
-		<div
-			v-if="target.mode === 'line' && target.line"
+			v-if="target.line"
 			class="drop-line absolute rounded-full"
 			:class="[accentClass, `is-${target.line.orientation}`]"
 			:style="lineStyle">
 			<span class="drop-line-cap drop-line-cap--start" />
 			<span class="drop-line-cap drop-line-cap--end" />
 		</div>
-
-		<!-- spacing guide: the container's gap -->
-		<div v-if="target.spacing" class="drop-spacing-pill absolute" :class="accentClass" :style="pillStyle">
-			{{ target.spacing.value }}
-		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
 import useCanvasStore from "@/stores/canvasStore";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 const canvasStore = useCanvasStore();
 const target = computed(() => canvasStore.reorderTarget);
 
+const rootEl = ref<HTMLElement>();
+
+// Clip the (full-viewport) overlay to the canvas region so indicators never
+// paint over the side panels. Recomputes each drag update (target changes) —
+// getBoundingClientRect is a cheap read and the panels don't move mid-drag.
+const clipStyle = computed(() => {
+	if (!target.value.active) return {};
+	const host = rootEl.value?.closest("[data-builder-canvas]") as HTMLElement | null;
+	if (!host) return {};
+	const r = host.getBoundingClientRect();
+	const top = Math.max(0, r.top);
+	const left = Math.max(0, r.left);
+	const right = Math.max(0, window.innerWidth - r.right);
+	const bottom = Math.max(0, window.innerHeight - r.bottom);
+	return { clipPath: `inset(${top}px ${right}px ${bottom}px ${left}px)` };
+});
+
 const accentClass = computed(() => (target.value.isComponentParent ? "accent-purple" : "accent-blue"));
 
-const rectStyle = (r: { top: number; left: number; width: number; height: number } | null) =>
-	r ? { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` } : {};
-
-const containerStyle = computed(() => rectStyle(target.value.containerRect));
-const slotStyle = computed(() => rectStyle(target.value.slotRect));
+const containerStyle = computed(() => {
+	const r = target.value.containerRect;
+	return r ? { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` } : {};
+});
 
 const LINE = 3;
 const lineStyle = computed(() => {
@@ -55,24 +60,9 @@ const lineStyle = computed(() => {
 	}
 	return { left: `${l.left}px`, top: `${l.top - LINE / 2}px`, width: `${l.length}px`, height: `${LINE}px` };
 });
-
-const pillStyle = computed(() => {
-	const s = target.value.spacing;
-	if (!s) return { display: "none" };
-	return { left: `${s.left}px`, top: `${s.top}px` };
-});
 </script>
 
 <style scoped>
-.drop-slot.accent-blue {
-	box-shadow: inset 0 0 0 2px theme("colors.blue.500");
-	background-color: theme("colors.blue.500 / 12%");
-}
-.drop-slot.accent-purple {
-	box-shadow: inset 0 0 0 2px theme("colors.purple.500");
-	background-color: theme("colors.purple.500 / 12%");
-}
-
 .drop-line.accent-blue {
 	background-color: theme("colors.blue.500");
 	box-shadow:
@@ -112,23 +102,6 @@ const pillStyle = computed(() => {
 	top: 50%;
 	left: 100%;
 	transform: translate(-50%, -50%);
-}
-
-.drop-spacing-pill {
-	transform: translate(-50%, -140%);
-	padding: 1px 6px;
-	border-radius: 9999px;
-	font-size: 10px;
-	line-height: 15px;
-	font-weight: 600;
-	color: #fff;
-	white-space: nowrap;
-}
-.drop-spacing-pill.accent-blue {
-	background-color: theme("colors.blue.500");
-}
-.drop-spacing-pill.accent-purple {
-	background-color: theme("colors.purple.500");
 }
 
 .drop-container-highlight.accent-blue {

--- a/frontend/src/components/DropIndicator.vue
+++ b/frontend/src/components/DropIndicator.vue
@@ -65,15 +65,9 @@ const lineStyle = computed(() => {
 <style scoped>
 .drop-line.accent-blue {
 	background-color: theme("colors.blue.500");
-	box-shadow:
-		0 0 0 1px theme("colors.blue.500 / 25%"),
-		0 0 6px theme("colors.blue.500 / 55%");
 }
 .drop-line.accent-purple {
 	background-color: theme("colors.purple.500");
-	box-shadow:
-		0 0 0 1px theme("colors.purple.500 / 25%"),
-		0 0 6px theme("colors.purple.500 / 55%");
 }
 .drop-line-cap {
 	position: absolute;
@@ -81,7 +75,6 @@ const lineStyle = computed(() => {
 	height: 7px;
 	border-radius: 9999px;
 	background: inherit;
-	box-shadow: inherit;
 }
 .drop-line.is-vertical .drop-line-cap--start {
 	left: 50%;

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1,5 +1,6 @@
 import type Block from "@/block";
 import type BuilderCanvas from "@/components/BuilderCanvas.vue";
+import type { IndicatorGeometry } from "@/utils/dropGeometry";
 import { getVersionedDoc } from "@/data/snapshot";
 import { confirm, getBlockCopy, getBlockInstance } from "@/utils/helpers";
 import { toast } from "frappe-ui";
@@ -30,6 +31,25 @@ const useCanvasStore = defineStore("canvasStore", {
 			placeholder: <HTMLElement | null>null,
 			parentBlock: <Block | null>null,
 			index: <number | null>null,
+		},
+		// On-canvas block reordering (pointer-based). Kept separate from dropTarget
+		// (panel → canvas drops) so the two systems don't interfere. The overlay
+		// DropIndicator reads this; nothing here mutates the canvas DOM, so the
+		// layout stays stable during the drag.
+		reorderTarget: {
+			active: <boolean>false,
+			// "slot": exact in-flow placeholder (same-container reorder, shifts siblings)
+			// "line": no-reflow line between children (cross-container drop)
+			mode: <"slot" | "line">"slot",
+			// exact drop slot (screen px) — measured from the in-flow placeholder,
+			// so it reflects the container's real flex/grid layout
+			slotRect: <{ top: number; left: number; width: number; height: number } | null>null,
+			// cross-container line indicator geometry (screen px)
+			line: <IndicatorGeometry | null>null,
+			containerRect: <{ top: number; left: number; width: number; height: number } | null>null,
+			isComponentParent: <boolean>false,
+			// spacing guide: the container's main-axis gap (px), positioned for a label
+			spacing: <{ value: number; left: number; top: number } | null>null,
 		},
 		editableBlock: <Block | null>null,
 		editingContentType: <"html" | "css" | "js">"html", // TODO: Remove js and css
@@ -270,6 +290,18 @@ const useCanvasStore = defineStore("canvasStore", {
 			if (placeholder) {
 				placeholder.remove();
 			}
+		},
+
+		clearReorderTarget() {
+			this.reorderTarget = {
+				active: false,
+				mode: "slot",
+				slotRect: null,
+				line: null,
+				containerRect: null,
+				isComponentParent: false,
+				spacing: null,
+			};
 		},
 	},
 });

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -37,14 +37,11 @@ const useCanvasStore = defineStore("canvasStore", {
 		// touches the canvas DOM, so the layout stays frozen during a drag.
 		reorderTarget: {
 			active: <boolean>false,
-			// insertion line geometry (screen px), placed to reflect the target
-			// container's real flex/grid layout
+			// insertion line geometry, screen px
 			line: <IndicatorGeometry | null>null,
 			containerRect: <{ top: number; left: number; width: number; height: number } | null>null,
 			isComponentParent: <boolean>false,
-			// true while hovering the block's own container (reorder) vs a different
-			// one (move) — used to keep the container outline out of the way when the
-			// drop wouldn't change the parent
+			// dropping into the block's own container (reorder) vs a different one
 			isSameContainer: <boolean>false,
 		},
 		editableBlock: <Block | null>null,

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -32,13 +32,9 @@ const useCanvasStore = defineStore("canvasStore", {
 			parentBlock: <Block | null>null,
 			index: <number | null>null,
 		},
-		// On-canvas block reordering (pointer-based). Kept separate from dropTarget
-		// (panel → canvas drops) so the two systems don't interfere. The overlay
-		// DropIndicator reads this; NOTHING here mutates the canvas DOM during a
-		// drag — the layout is frozen after the source is lifted, so there are zero
-		// per-move reflows and no jitter. The indicator is a pure overlay computed
-		// from the (static) children, and is layout-aware (flex row/column, wrapped
-		// flex, and grid).
+		// On-canvas block reordering (pointer-based). Separate from dropTarget
+		// (panel → canvas drops). The overlay DropIndicator reads this; nothing here
+		// touches the canvas DOM, so the layout stays frozen during a drag.
 		reorderTarget: {
 			active: <boolean>false,
 			// insertion line geometry (screen px), placed to reflect the target

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -34,22 +34,22 @@ const useCanvasStore = defineStore("canvasStore", {
 		},
 		// On-canvas block reordering (pointer-based). Kept separate from dropTarget
 		// (panel → canvas drops) so the two systems don't interfere. The overlay
-		// DropIndicator reads this; nothing here mutates the canvas DOM, so the
-		// layout stays stable during the drag.
+		// DropIndicator reads this; NOTHING here mutates the canvas DOM during a
+		// drag — the layout is frozen after the source is lifted, so there are zero
+		// per-move reflows and no jitter. The indicator is a pure overlay computed
+		// from the (static) children, and is layout-aware (flex row/column, wrapped
+		// flex, and grid).
 		reorderTarget: {
 			active: <boolean>false,
-			// "slot": exact in-flow placeholder (same-container reorder, shifts siblings)
-			// "line": no-reflow line between children (cross-container drop)
-			mode: <"slot" | "line">"slot",
-			// exact drop slot (screen px) — measured from the in-flow placeholder,
-			// so it reflects the container's real flex/grid layout
-			slotRect: <{ top: number; left: number; width: number; height: number } | null>null,
-			// cross-container line indicator geometry (screen px)
+			// insertion line geometry (screen px), placed to reflect the target
+			// container's real flex/grid layout
 			line: <IndicatorGeometry | null>null,
 			containerRect: <{ top: number; left: number; width: number; height: number } | null>null,
 			isComponentParent: <boolean>false,
-			// spacing guide: the container's main-axis gap (px), positioned for a label
-			spacing: <{ value: number; left: number; top: number } | null>null,
+			// true while hovering the block's own container (reorder) vs a different
+			// one (move) — used to keep the container outline out of the way when the
+			// drop wouldn't change the parent
+			isSameContainer: <boolean>false,
 		},
 		editableBlock: <Block | null>null,
 		editingContentType: <"html" | "css" | "js">"html", // TODO: Remove js and css
@@ -295,12 +295,10 @@ const useCanvasStore = defineStore("canvasStore", {
 		clearReorderTarget() {
 			this.reorderTarget = {
 				active: false,
-				mode: "slot",
-				slotRect: null,
 				line: null,
 				containerRect: null,
 				isComponentParent: false,
-				spacing: null,
+				isSameContainer: false,
 			};
 		},
 	},

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -2,6 +2,12 @@
 // panel drop zone. All coordinates are in client (screen) space so callers can
 // position fixed overlays directly and mix live getBoundingClientRect values
 // with cursor clientX/clientY without worrying about canvas scale/translate.
+//
+// The reorder engine never mutates the canvas DOM while dragging — it measures
+// the (static) children once per pointer move and draws an overlay indicator.
+// So everything here is pure geometry: it takes rects + a pointer and returns
+// an insertion index / an indicator line, and is fully layout-aware (flex row,
+// flex column, wrapped flex, and CSS grid all fall out of the same 2D model).
 
 export type LayoutDirection = "row" | "column";
 export type IndicatorOrientation = "vertical" | "horizontal";
@@ -11,7 +17,7 @@ export interface ChildRect {
 	start: number;
 	end: number;
 	mid: number;
-	// cross-axis extents (used to size the insertion line)
+	// cross-axis extents (used to cluster into rows and to size the line)
 	crossStart: number;
 	crossEnd: number;
 }
@@ -31,7 +37,7 @@ export function getLayoutDirection(style: CSSStyleDeclaration): LayoutDirection 
 	if (display === "flex" || display === "inline-flex") {
 		return style.flexDirection.includes("row") ? "row" : "column";
 	} else if (display === "grid" || display === "inline-grid") {
-		return style.gridAutoFlow.includes("row") ? "row" : "column";
+		return style.gridAutoFlow.includes("column") ? "column" : "row";
 	}
 	// block-level and inline children stack vertically
 	return "column";
@@ -39,15 +45,14 @@ export function getLayoutDirection(style: CSSStyleDeclaration): LayoutDirection 
 
 // Snapshot the direct block children of a container along the given axis.
 // `excludeEl` (the block currently being dragged) is skipped so its own slot
-// doesn't influence the computed index.
+// doesn't influence the computed index. Returned in DOM order, which — for
+// every layout the builder produces — matches visual reading order.
 export function collectChildRects(
 	parentEl: HTMLElement,
 	direction: LayoutDirection,
 	excludeEl?: HTMLElement | null,
 ): ChildRect[] {
-	const children = Array.from(
-		parentEl.querySelectorAll(`:scope > ${BUILDER_SELECTOR}`),
-	) as HTMLElement[];
+	const children = Array.from(parentEl.querySelectorAll(`:scope > ${BUILDER_SELECTOR}`)) as HTMLElement[];
 
 	const rects: ChildRect[] = [];
 	for (const el of children) {
@@ -73,79 +78,128 @@ export function collectChildRects(
 			});
 		}
 	}
-	// keep DOM order == visual order for the monotonic index scan below
 	return rects;
 }
 
-// Monotonic insertion index: number of children whose midpoint sits before the
-// pointer along the main axis. Monotonic (vs. nearest-child + before/after)
-// means the index only ever changes when the pointer actually crosses a
-// midpoint, so there's no oscillation at boundaries.
-export function computeDropIndex(rects: ChildRect[], pointerMain: number): number {
+// Two rects share a visual line when they overlap on the cross axis by more than
+// half of the smaller one — robust to ragged item heights in a grid row.
+function sameLine(a: ChildRect, b: ChildRect): boolean {
+	const overlap = Math.min(a.crossEnd, b.crossEnd) - Math.max(a.crossStart, b.crossStart);
+	const minSize = Math.min(a.crossEnd - a.crossStart, b.crossEnd - b.crossStart) || 1;
+	return overlap > minSize * 0.5;
+}
+
+// Group children into visual lines (grid rows for a row layout, the single
+// stacked column for a column/flex layout) in reading order. A one-line result
+// means a plain flex row/column; multiple lines means a wrapped flex or a grid.
+// Because DOM order is reading order, a new line simply starts whenever the next
+// child no longer overlaps the current line's cross band.
+export function clusterLines(rects: ChildRect[]): ChildRect[][] {
+	const lines: ChildRect[][] = [];
+	let current: ChildRect[] = [];
+	for (const r of rects) {
+		const onCurrent = current.length > 0 && current.some((c) => sameLine(c, r));
+		if (!onCurrent && current.length) {
+			lines.push(current);
+			current = [];
+		}
+		current.push(r);
+	}
+	if (current.length) lines.push(current);
+	// order items within each line by their main-axis start (usually already so)
+	for (const line of lines) line.sort((a, b) => a.start - b.start);
+	return lines;
+}
+
+function lineBand(line: ChildRect[]): { start: number; end: number } {
+	return {
+		start: Math.min(...line.map((r) => r.crossStart)),
+		end: Math.max(...line.map((r) => r.crossEnd)),
+	};
+}
+
+// 2D reading-order insertion index: how many children come before the pointer,
+// scanning line-by-line down the cross axis and item-by-item along the main
+// axis. Reduces to a simple midpoint scan for a single flex line, and handles
+// wrapped flex / grid without any special-casing. Monotonic within a line (the
+// index only changes when the pointer crosses an item midpoint or a line
+// boundary), so there's no oscillation at the edges.
+export function computeReadingOrderIndex(
+	lines: ChildRect[][],
+	pointerMain: number,
+	pointerCross: number,
+): number {
 	let index = 0;
-	for (const child of rects) {
-		if (pointerMain > child.mid) {
-			index++;
-		} else {
+	for (const line of lines) {
+		const band = lineBand(line);
+		if (pointerCross > band.end) {
+			// the whole line sits above the pointer → it's entirely before it
+			index += line.length;
+			continue;
+		}
+		if (pointerCross < band.start) {
+			// this line (and every later one) is below the pointer → stop
 			break;
 		}
+		// pointer is within this line's band → count items to its left
+		for (const item of line) {
+			if (pointerMain > item.mid) index++;
+			else break;
+		}
+		return index;
 	}
 	return index;
 }
 
-// Where to draw the insertion line, given the resolved index. Falls in the gap
-// between child[index-1] and child[index]; clamps to the container's content
-// box when dropping at the very start/end or into an empty container. The
-// caller passes the container's already-measured rect and computed style so the
-// drag hot path doesn't re-measure them.
-export function computeIndicator(
-	rects: ChildRect[],
+// Where to draw the insertion line for a resolved index. Uses the two children
+// bracketing the insertion point:
+//   - both present and on the same line → centre the line in the gap between
+//     them, spanning their shared cross band (the clean flex-row/column look)
+//   - only a following child (line start, or the very first slot) → a caret at
+//     its leading edge, spanning that cell — reads as "insert before this cell",
+//     which is what makes grid drops legible
+//   - only a preceding child (very last slot) → a caret at its trailing edge
+//   - no children (empty container) → span the container's content box
+// The caller passes the container's measured rect + computed style so the drag
+// hot path doesn't re-measure them.
+export function computeDropIndicator(
+	lines: ChildRect[][],
 	index: number,
 	parentRect: DOMRect,
 	style: CSSStyleDeclaration,
 	direction: LayoutDirection,
 ): IndicatorGeometry {
-	const padTop = parseFloat(style.paddingTop) || 0;
-	const padBottom = parseFloat(style.paddingBottom) || 0;
-	const padLeft = parseFloat(style.paddingLeft) || 0;
-	const padRight = parseFloat(style.paddingRight) || 0;
-
 	const orientation: IndicatorOrientation = direction === "row" ? "vertical" : "horizontal";
+	const flat = lines.flat();
 
-	// main-axis position of the line
-	let mainPos: number;
-	if (rects.length === 0) {
-		mainPos =
-			direction === "row" ? parentRect.left + padLeft : parentRect.top + padTop;
-	} else if (index <= 0) {
-		mainPos = rects[0].start;
-	} else if (index >= rects.length) {
-		mainPos = rects[rects.length - 1].end;
-	} else {
-		// centre of the gap between the two neighbours
-		mainPos = (rects[index - 1].end + rects[index].start) / 2;
-	}
+	const build = (mainPos: number, crossStart: number, crossEnd: number): IndicatorGeometry => {
+		const length = Math.max(crossEnd - crossStart, 4);
+		return orientation === "vertical"
+			? { orientation, left: mainPos, top: crossStart, length }
+			: { orientation, left: crossStart, top: mainPos, length };
+	};
 
-	// cross-axis span of the line — hug the children's extent when present,
-	// otherwise span the container's content box
-	let crossStart: number;
-	let crossEnd: number;
-	if (rects.length === 0) {
+	if (flat.length === 0) {
+		const padTop = parseFloat(style.paddingTop) || 0;
+		const padBottom = parseFloat(style.paddingBottom) || 0;
+		const padLeft = parseFloat(style.paddingLeft) || 0;
+		const padRight = parseFloat(style.paddingRight) || 0;
 		if (direction === "row") {
-			crossStart = parentRect.top + padTop;
-			crossEnd = parentRect.bottom - padBottom;
-		} else {
-			crossStart = parentRect.left + padLeft;
-			crossEnd = parentRect.right - padRight;
+			return build(parentRect.left + padLeft, parentRect.top + padTop, parentRect.bottom - padBottom);
 		}
-	} else {
-		crossStart = Math.min(...rects.map((r) => r.crossStart));
-		crossEnd = Math.max(...rects.map((r) => r.crossEnd));
+		return build(parentRect.top + padTop, parentRect.left + padLeft, parentRect.right - padRight);
 	}
-	const length = Math.max(crossEnd - crossStart, 4);
 
-	if (orientation === "vertical") {
-		return { orientation, left: mainPos, top: crossStart, length };
+	const prev = index > 0 ? flat[index - 1] : null;
+	const next = index < flat.length ? flat[index] : null;
+
+	if (prev && next && sameLine(prev, next)) {
+		const mid = (prev.end + next.start) / 2;
+		return build(mid, Math.min(prev.crossStart, next.crossStart), Math.max(prev.crossEnd, next.crossEnd));
 	}
-	return { orientation, left: crossStart, top: mainPos, length };
+	if (next) {
+		return build(next.start, next.crossStart, next.crossEnd);
+	}
+	// prev is guaranteed here (flat.length > 0 and next is null)
+	return build((prev as ChildRect).end, (prev as ChildRect).crossStart, (prev as ChildRect).crossEnd);
 }

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -1,0 +1,151 @@
+// Layout-aware drop geometry shared by the on-canvas reorder engine and the
+// panel drop zone. All coordinates are in client (screen) space so callers can
+// position fixed overlays directly and mix live getBoundingClientRect values
+// with cursor clientX/clientY without worrying about canvas scale/translate.
+
+export type LayoutDirection = "row" | "column";
+export type IndicatorOrientation = "vertical" | "horizontal";
+
+export interface ChildRect {
+	// main-axis extents (left/right for row, top/bottom for column)
+	start: number;
+	end: number;
+	mid: number;
+	// cross-axis extents (used to size the insertion line)
+	crossStart: number;
+	crossEnd: number;
+}
+
+export interface IndicatorGeometry {
+	orientation: IndicatorOrientation;
+	// top-left of the line in client coords + its length
+	left: number;
+	top: number;
+	length: number;
+}
+
+const BUILDER_SELECTOR = ".__builder_component__";
+
+export function getLayoutDirection(style: CSSStyleDeclaration): LayoutDirection {
+	const display = style.display;
+	if (display === "flex" || display === "inline-flex") {
+		return style.flexDirection.includes("row") ? "row" : "column";
+	} else if (display === "grid" || display === "inline-grid") {
+		return style.gridAutoFlow.includes("row") ? "row" : "column";
+	}
+	// block-level and inline children stack vertically
+	return "column";
+}
+
+// Snapshot the direct block children of a container along the given axis.
+// `excludeEl` (the block currently being dragged) is skipped so its own slot
+// doesn't influence the computed index.
+export function collectChildRects(
+	parentEl: HTMLElement,
+	direction: LayoutDirection,
+	excludeEl?: HTMLElement | null,
+): ChildRect[] {
+	const children = Array.from(
+		parentEl.querySelectorAll(`:scope > ${BUILDER_SELECTOR}`),
+	) as HTMLElement[];
+
+	const rects: ChildRect[] = [];
+	for (const el of children) {
+		if (excludeEl && (el === excludeEl || el.contains(excludeEl))) continue;
+		const rect = el.getBoundingClientRect();
+		// ignore zero-size / detached nodes
+		if (rect.width === 0 && rect.height === 0) continue;
+		if (direction === "row") {
+			rects.push({
+				start: rect.left,
+				end: rect.right,
+				mid: rect.left + rect.width / 2,
+				crossStart: rect.top,
+				crossEnd: rect.bottom,
+			});
+		} else {
+			rects.push({
+				start: rect.top,
+				end: rect.bottom,
+				mid: rect.top + rect.height / 2,
+				crossStart: rect.left,
+				crossEnd: rect.right,
+			});
+		}
+	}
+	// keep DOM order == visual order for the monotonic index scan below
+	return rects;
+}
+
+// Monotonic insertion index: number of children whose midpoint sits before the
+// pointer along the main axis. Monotonic (vs. nearest-child + before/after)
+// means the index only ever changes when the pointer actually crosses a
+// midpoint, so there's no oscillation at boundaries.
+export function computeDropIndex(rects: ChildRect[], pointerMain: number): number {
+	let index = 0;
+	for (const child of rects) {
+		if (pointerMain > child.mid) {
+			index++;
+		} else {
+			break;
+		}
+	}
+	return index;
+}
+
+// Where to draw the insertion line, given the resolved index. Falls in the gap
+// between child[index-1] and child[index]; clamps to the container's content
+// box when dropping at the very start/end or into an empty container. The
+// caller passes the container's already-measured rect and computed style so the
+// drag hot path doesn't re-measure them.
+export function computeIndicator(
+	rects: ChildRect[],
+	index: number,
+	parentRect: DOMRect,
+	style: CSSStyleDeclaration,
+	direction: LayoutDirection,
+): IndicatorGeometry {
+	const padTop = parseFloat(style.paddingTop) || 0;
+	const padBottom = parseFloat(style.paddingBottom) || 0;
+	const padLeft = parseFloat(style.paddingLeft) || 0;
+	const padRight = parseFloat(style.paddingRight) || 0;
+
+	const orientation: IndicatorOrientation = direction === "row" ? "vertical" : "horizontal";
+
+	// main-axis position of the line
+	let mainPos: number;
+	if (rects.length === 0) {
+		mainPos =
+			direction === "row" ? parentRect.left + padLeft : parentRect.top + padTop;
+	} else if (index <= 0) {
+		mainPos = rects[0].start;
+	} else if (index >= rects.length) {
+		mainPos = rects[rects.length - 1].end;
+	} else {
+		// centre of the gap between the two neighbours
+		mainPos = (rects[index - 1].end + rects[index].start) / 2;
+	}
+
+	// cross-axis span of the line — hug the children's extent when present,
+	// otherwise span the container's content box
+	let crossStart: number;
+	let crossEnd: number;
+	if (rects.length === 0) {
+		if (direction === "row") {
+			crossStart = parentRect.top + padTop;
+			crossEnd = parentRect.bottom - padBottom;
+		} else {
+			crossStart = parentRect.left + padLeft;
+			crossEnd = parentRect.right - padRight;
+		}
+	} else {
+		crossStart = Math.min(...rects.map((r) => r.crossStart));
+		crossEnd = Math.max(...rects.map((r) => r.crossEnd));
+	}
+	const length = Math.max(crossEnd - crossStart, 4);
+
+	if (orientation === "vertical") {
+		return { orientation, left: mainPos, top: crossStart, length };
+	}
+	return { orientation, left: crossStart, top: mainPos, length };
+}

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -159,15 +159,19 @@ export function computeReadingOrderIndex(
 //     its leading edge, spanning that cell — reads as "insert before this cell",
 //     which is what makes grid drops legible
 //   - only a preceding child (very last slot) → a caret at its trailing edge
-//   - no children (empty container) → span the container's content box
+//   - no children (empty container) → place it where the first child will land,
+//     honouring the container's justify-content (main axis) and align-items
+//     (cross axis), sized to the dragged block when known
 // The caller passes the container's measured rect + computed style so the drag
-// hot path doesn't re-measure them.
+// hot path doesn't re-measure them. `sourceSize` (the dragged block's screen-px
+// box) lets the empty-container indicator match the incoming block's extent.
 export function computeDropIndicator(
 	lines: ChildRect[][],
 	index: number,
 	parentRect: DOMRect,
 	style: CSSStyleDeclaration,
 	direction: LayoutDirection,
+	sourceSize?: { width: number; height: number },
 ): IndicatorGeometry {
 	const orientation: IndicatorOrientation = direction === "row" ? "vertical" : "horizontal";
 	const flat = lines.flat();
@@ -184,10 +188,44 @@ export function computeDropIndicator(
 		const padBottom = parseFloat(style.paddingBottom) || 0;
 		const padLeft = parseFloat(style.paddingLeft) || 0;
 		const padRight = parseFloat(style.paddingRight) || 0;
-		if (direction === "row") {
-			return build(parentRect.left + padLeft, parentRect.top + padTop, parentRect.bottom - padBottom);
+		// content-box extents along the main + cross axes
+		const mainLo = direction === "row" ? parentRect.left + padLeft : parentRect.top + padTop;
+		const mainHi = direction === "row" ? parentRect.right - padRight : parentRect.bottom - padBottom;
+		const crossLo = direction === "row" ? parentRect.top + padTop : parentRect.left + padLeft;
+		const crossHi = direction === "row" ? parentRect.bottom - padBottom : parentRect.right - padRight;
+
+		// main-axis position of the line ← justify-content
+		const justify = style.justifyContent;
+		let mainPos: number;
+		if (justify === "center" || justify === "space-around" || justify === "space-evenly") {
+			mainPos = (mainLo + mainHi) / 2;
+		} else if (justify === "flex-end" || justify === "end" || justify === "right") {
+			mainPos = mainHi;
+		} else {
+			mainPos = mainLo;
 		}
-		return build(parentRect.top + padTop, parentRect.left + padLeft, parentRect.right - padRight);
+
+		// cross-axis span of the line ← align-items (sized to the dragged block)
+		const align = style.alignItems;
+		const sourceCross = sourceSize ? (direction === "row" ? sourceSize.height : sourceSize.width) : 0;
+		let cs = crossLo;
+		let ce = crossHi;
+		if (sourceCross > 0 && align !== "stretch" && align !== "normal" && align !== "") {
+			if (align === "center") {
+				const c = (crossLo + crossHi) / 2;
+				cs = c - sourceCross / 2;
+				ce = c + sourceCross / 2;
+			} else if (align === "flex-end" || align === "end") {
+				cs = crossHi - sourceCross;
+				ce = crossHi;
+			} else {
+				cs = crossLo;
+				ce = crossLo + sourceCross;
+			}
+			cs = Math.max(cs, crossLo);
+			ce = Math.min(ce, crossHi);
+		}
+		return build(mainPos, cs, ce);
 	}
 
 	const prev = index > 0 ? flat[index - 1] : null;

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -56,10 +56,9 @@ export function collectChildRects(
 
 	const rects: ChildRect[] = [];
 	for (const el of children) {
-		// Skip only the dragged element itself — NOT an ancestor-path child that
-		// merely contains it. When you drag a deeply-nested block out to one of its
-		// ancestors, the child on the path to the source is a real sibling target
-		// (you want to drop before/after it), so it must stay counted.
+		// Skip only the dragged element itself — not an ancestor that merely
+		// contains it, so dragging a nested block out counts the path-child as a
+		// sibling drop target.
 		if (excludeEl && el === excludeEl) continue;
 		const rect = el.getBoundingClientRect();
 		// ignore zero-size / detached nodes

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -61,7 +61,6 @@ export function collectChildRects(
 		// sibling drop target.
 		if (excludeEl && el === excludeEl) continue;
 		const rect = el.getBoundingClientRect();
-		// ignore zero-size / detached nodes
 		if (rect.width === 0 && rect.height === 0) continue;
 		if (direction === "row") {
 			rects.push({

--- a/frontend/src/utils/dropGeometry.ts
+++ b/frontend/src/utils/dropGeometry.ts
@@ -56,7 +56,11 @@ export function collectChildRects(
 
 	const rects: ChildRect[] = [];
 	for (const el of children) {
-		if (excludeEl && (el === excludeEl || el.contains(excludeEl))) continue;
+		// Skip only the dragged element itself — NOT an ancestor-path child that
+		// merely contains it. When you drag a deeply-nested block out to one of its
+		// ancestors, the child on the path to the source is a real sibling target
+		// (you want to drop before/after it), so it must stay counted.
+		if (excludeEl && el === excludeEl) continue;
 		const rect = el.getBoundingClientRect();
 		// ignore zero-size / detached nodes
 		if (rect.width === 0 && rect.height === 0) continue;

--- a/frontend/src/utils/useBlockEventHandlers.ts
+++ b/frontend/src/utils/useBlockEventHandlers.ts
@@ -24,7 +24,7 @@ export function useBlockEventHandlers(target: HTMLElement) {
 		if (builderStore.mode !== "select" || builderStore.readOnlyMode) return;
 		const block = getBlock(e);
 		if (!block || !isReorderable(block)) return;
-		startBlockReorder(e, block);
+		startBlockReorder(e, block, getBlockInfo(e).breakpoint);
 	}
 
 	function handleClick(e: MouseEvent) {

--- a/frontend/src/utils/useBlockEventHandlers.ts
+++ b/frontend/src/utils/useBlockEventHandlers.ts
@@ -2,6 +2,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { getBlock, getBlockInfo, isBlock } from "@/utils/helpers";
+import { isReorderable, startBlockReorder } from "@/utils/useBlockReorder";
 import { useEventListener } from "@vueuse/core";
 import { nextTick } from "vue";
 
@@ -9,9 +10,22 @@ const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 
 export function useBlockEventHandlers(target: HTMLElement) {
+	useEventListener(target, "mousedown", handleMouseDown);
 	useEventListener(target, "click", handleClick);
 	useEventListener(target, "dblclick", handleDoubleClick);
 	useEventListener(target, "contextmenu", triggerContextMenu);
+
+	// Press-and-drag any block to reorder it in one gesture (no need to select
+	// first). The threshold inside startBlockReorder means a plain click still
+	// falls through to handleClick for selection.
+	function handleMouseDown(e: MouseEvent) {
+		if (e.button !== 0) return;
+		if (!isBlock(e) || isEditable(e)) return;
+		if (builderStore.mode !== "select" || builderStore.readOnlyMode) return;
+		const block = getBlock(e);
+		if (!block || !isReorderable(block)) return;
+		startBlockReorder(e, block);
+	}
 
 	function handleClick(e: MouseEvent) {
 		if (!isBlock(e) || isEditable(e)) return;

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -136,18 +136,28 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 	// siblings — impossible when they're flush. 0.3 → the outer 30% on each side
 	// reorders (so ~60% of a flush row is reorderable), the inner 40% nests.
 	const EDGE_REORDER_BAND = 0.3;
+	// EMPTY child containers default to before/after (you usually want to add a
+	// sibling next to an existing child, not drop inside it) — nesting is reserved
+	// for a small dead-centre core. Populated containers keep the normal band.
+	const EDGE_REORDER_BAND_EMPTY = 0.42;
 
 	// Is the pointer in `childEl`'s outer edge band (NOT its inner core), measured
 	// along its parent's layout axis? In the edge band = "reorder beside this
 	// container"; in the core = "nest into it".
-	const inEdgeBand = (childEl: HTMLElement, parentBlock: Block, clientX: number, clientY: number): boolean => {
+	const inEdgeBand = (
+		childEl: HTMLElement,
+		parentBlock: Block,
+		clientX: number,
+		clientY: number,
+		bandFraction: number,
+	): boolean => {
 		const parentEl = getContainerEl(parentBlock);
 		const dir = parentEl ? getLayoutDirection(getComputedStyle(parentEl)) : "column";
 		const r = childEl.getBoundingClientRect();
 		const lo = dir === "row" ? r.left : r.top;
 		const hi = dir === "row" ? r.right : r.bottom;
 		const pointer = dir === "row" ? clientX : clientY;
-		const band = (hi - lo) * EDGE_REORDER_BAND;
+		const band = (hi - lo) * bandFraction;
 		return pointer < lo + band || pointer > hi - band;
 	};
 
@@ -171,13 +181,24 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 
 		const rawEl = getContainerEl(raw);
 		const nonDragged = raw.getChildren().filter((c) => c.blockId !== block.blockId);
-		let canNest = raw.canHaveChildren() && !!rawEl && (nonDragged.length > 0 || isSpaciousContainer(rawEl));
+		// Dropping back into the source's OWN parent when the source is its only
+		// child is a no-op — so never nest there; fall through to before/after it.
+		// This is what lets you drag a deeply-nested block OUT: hovering the (now
+		// apparently empty) parent it came from resolves to its grandparent.
+		const isEmptySourceParent = raw.blockId === originalParentId && nonDragged.length === 0;
+		let canNest =
+			!isEmptySourceParent &&
+			raw.canHaveChildren() &&
+			!!rawEl &&
+			(nonDragged.length > 0 || isSpaciousContainer(rawEl));
 
 		// Over a nestable container's outer edge band → reorder BESIDE it in its
-		// parent instead of nesting.
+		// parent instead of nesting. Empty containers get a wider band so they
+		// default to before/after (add a sibling) rather than nest-inside.
 		const parent = raw.getParentBlock();
-		if (canNest && rawEl && parent && inEdgeBand(rawEl, parent, clientX, clientY)) {
-			canNest = false;
+		if (canNest && rawEl && parent) {
+			const band = nonDragged.length === 0 ? EDGE_REORDER_BAND_EMPTY : EDGE_REORDER_BAND;
+			if (inEdgeBand(rawEl, parent, clientX, clientY, band)) canNest = false;
 		}
 
 		let container: Block | null = canNest ? raw : parent || raw;

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -23,16 +23,12 @@ export function isReorderable(block: Block): boolean {
 	);
 }
 
-// Pointer-based on-canvas reorder, designed for zero layout jitter.
-//
-// The whole point: the canvas DOM is NEVER mutated while dragging. On pickup the
-// source is lifted out of the flow exactly once (a single, clean reflow — the
-// siblings close the gap) and a floating ghost follows the cursor. From then on
-// every pointer move only MEASURES the target container's children (read-only)
-// and repositions a fixed overlay line — no insertions, no per-move reflow, so
-// there's nothing to jitter. The insertion index is computed in 2D reading
-// order, so flex rows, flex columns, wrapped flex and CSS grid are all handled
-// by the same code. The block tree is mutated once, on release, in one history
+// Pointer-based on-canvas reorder with zero layout jitter: the canvas DOM is
+// never mutated during the drag. On pickup the source is hidden in place and a
+// floating ghost follows the cursor; each move only measures the target's
+// children (read-only) and repositions a fixed overlay line. The insertion index
+// is computed in 2D reading order, so flex rows/columns, wrapped flex and grid
+// all share one path. The tree is mutated once, on release, as a single history
 // entry.
 export function startBlockReorder(event: MouseEvent, block: Block) {
 	const canvasStore = useCanvasStore();
@@ -79,7 +75,7 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		pauseId = canvasStore.activeCanvas?.history?.pause();
 
 		const scale = getScale();
-		// floating ghost — clone BEFORE dimming the source
+		// floating ghost — clone before hiding the source
 		ghost = document.createElement("div");
 		ghost.id = "reorder-ghost";
 		const clone = sourceEl.cloneNode(true) as HTMLElement;

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -1,9 +1,10 @@
 import type Block from "@/block";
 import useCanvasStore from "@/stores/canvasStore";
 import {
+	clusterLines,
 	collectChildRects,
-	computeDropIndex,
-	computeIndicator,
+	computeDropIndicator,
+	computeReadingOrderIndex,
 	getLayoutDirection,
 } from "@/utils/dropGeometry";
 
@@ -22,12 +23,17 @@ export function isReorderable(block: Block): boolean {
 	);
 }
 
-// Pointer-based on-canvas reorder. The dragged block is lifted out of the flow
-// (a floating ghost follows the cursor) and a real, same-sized placeholder is
-// inserted into the target container — so the browser's own flex/grid engine
-// positions the drop slot EXACTLY where the block will land (respecting
-// display / justify-content / align-items / gap), and siblings open up to make
-// room. The tree is only mutated on release, in one history entry.
+// Pointer-based on-canvas reorder, designed for zero layout jitter.
+//
+// The whole point: the canvas DOM is NEVER mutated while dragging. On pickup the
+// source is lifted out of the flow exactly once (a single, clean reflow — the
+// siblings close the gap) and a floating ghost follows the cursor. From then on
+// every pointer move only MEASURES the target container's children (read-only)
+// and repositions a fixed overlay line — no insertions, no per-move reflow, so
+// there's nothing to jitter. The insertion index is computed in 2D reading
+// order, so flex rows, flex columns, wrapped flex and CSS grid are all handled
+// by the same code. The block tree is mutated once, on release, in one history
+// entry.
 export function startBlockReorder(event: MouseEvent, block: Block) {
 	const canvasStore = useCanvasStore();
 	const findBlock = (id: string): Block | null => canvasStore.activeCanvas?.findBlock(id) ?? null;
@@ -49,56 +55,31 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 	const sourceRect = sourceEl.getBoundingClientRect();
 	const grabOffsetX = startX - sourceRect.left;
 	const grabOffsetY = startY - sourceRect.top;
-	// the block's own container — reordering here shifts siblings (a real slot),
-	// dropping into any OTHER container just shows a no-reflow line indicator
+	// the block's own container — dropping here reorders (same parent); dropping
+	// into any other container moves the block across
 	const originalParentId = block.getParentBlock()?.blockId ?? null;
 
 	let started = false;
 	let ghost: HTMLElement | null = null;
-	let placeholder: HTMLElement | null = null;
 	let pauseId: unknown = null;
-	let prevBodyCursor = "";
-	let prevSourceDisplay = "";
+	let prevSourceVisibility = "";
 
 	// resolved drop target at release time
 	let dropParent: Block | null = null;
 	let dropIndex: number | null = null;
 
-	// A transparent spacer that occupies the dragged block's box (size + margins +
-	// cross-axis alignment) so the flex layout reserves the real slot. The visible
-	// indicator is drawn crisply as an overlay on top of this (see DropIndicator).
-	const buildPlaceholder = (): HTMLElement => {
-		const el = document.createElement("div");
-		el.className = "reorder-placeholder";
-		const cs = getComputedStyle(sourceEl);
-		Object.assign(el.style, {
-			boxSizing: "border-box",
-			// offsetWidth/Height are unscaled border-box px (the placeholder lives
-			// inside the scaled canvas, so it must use design-space sizes)
-			width: `${sourceEl.offsetWidth}px`,
-			height: `${sourceEl.offsetHeight}px`,
-			marginTop: cs.marginTop,
-			marginRight: cs.marginRight,
-			marginBottom: cs.marginBottom,
-			marginLeft: cs.marginLeft,
-			alignSelf: cs.alignSelf,
-			flex: "0 0 auto",
-			pointerEvents: "none",
-			background: "transparent",
-		});
-		return el;
-	};
-
 	const beginDrag = () => {
 		started = true;
 		canvasStore.isDragging = true;
-		// suppress the click that fires after the drag so the block isn't
-		// re-selected/toggled by useBlockEventHandlers
+		// selecting on grab means point-drag doubles as selection — no need to
+		// click-to-select first. preventClick stops the trailing click from
+		// toggling the selection back off.
+		canvasStore.selectBlock(block, null);
 		canvasStore.preventClick = true;
 		pauseId = canvasStore.activeCanvas?.history?.pause();
 
 		const scale = getScale();
-		// floating ghost — clone BEFORE hiding the source
+		// floating ghost — clone BEFORE dimming the source
 		ghost = document.createElement("div");
 		ghost.id = "reorder-ghost";
 		const clone = sourceEl.cloneNode(true) as HTMLElement;
@@ -122,14 +103,13 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		});
 		document.body.appendChild(ghost);
 
-		placeholder = buildPlaceholder();
-
-		// lift the source out of the flow so its own slot closes up
-		prevSourceDisplay = sourceEl.style.display;
-		sourceEl.style.display = "none";
-
-		prevBodyCursor = document.body.style.cursor;
-		document.body.style.cursor = "grabbing";
+		// Hide the source WITHOUT removing it from the flow (visibility, not
+		// display) so it keeps its slot. Nothing shifts on pickup — critical for
+		// grids, where display:none would renumber every following cell — and since
+		// visibility:hidden elements are skipped by elementFromPoint and excluded
+		// from measurement, the layout is completely frozen for the whole drag.
+		prevSourceVisibility = sourceEl.style.visibility;
+		sourceEl.style.visibility = "hidden";
 	};
 
 	// Is `candidate` the dragged block itself, or somewhere inside its subtree?
@@ -150,12 +130,36 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		return r.width >= sourceRect.width * NEST_SIZE_FACTOR && r.height >= sourceRect.height * NEST_SIZE_FACTOR;
 	};
 
-	// Decide the container to drop into, from whatever is under the cursor:
-	//  - cursor over a container's body (populated, or an empty drop-zone) → nest inside
-	//  - cursor over a childless leaf box → reorder as its sibling
-	//  - cursor in the gap between items → elementFromPoint returns the parent, so
-	//    you reorder at that level. No edge bands: the live layout (placeholder in
-	//    place) drives everything, which is what keeps the drop stable.
+	// Fraction of a container-child's main-axis extent, at EACH end, reserved for
+	// "reorder beside me" instead of "nest inside me". Without this you could only
+	// reorder past a child container by hitting the hairline gap/edge between
+	// siblings — impossible when they're flush. 0.3 → the outer 30% on each side
+	// reorders (so ~60% of a flush row is reorderable), the inner 40% nests.
+	const EDGE_REORDER_BAND = 0.3;
+
+	// Is the pointer in `childEl`'s outer edge band (NOT its inner core), measured
+	// along its parent's layout axis? In the edge band = "reorder beside this
+	// container"; in the core = "nest into it".
+	const inEdgeBand = (childEl: HTMLElement, parentBlock: Block, clientX: number, clientY: number): boolean => {
+		const parentEl = getContainerEl(parentBlock);
+		const dir = parentEl ? getLayoutDirection(getComputedStyle(parentEl)) : "column";
+		const r = childEl.getBoundingClientRect();
+		const lo = dir === "row" ? r.left : r.top;
+		const hi = dir === "row" ? r.right : r.bottom;
+		const pointer = dir === "row" ? clientX : clientY;
+		const band = (hi - lo) * EDGE_REORDER_BAND;
+		return pointer < lo + band || pointer > hi - band;
+	};
+
+	// Auto-detect intent from whatever is under the cursor, no modifier keys.
+	// Decided from the DEEPEST hovered block only (single level — deeper climbing
+	// wrongly pops out of tall containers like a grid's lower row):
+	//  - a childless leaf → reorder among its siblings (in its parent)
+	//  - a container hovered on its INNER CORE → nest inside it
+	//  - a container hovered on its outer EDGE BAND → reorder beside it in its parent
+	//    (this is what makes a flush row/column of containers reorderable without a
+	//    gap to aim at)
+	//  - a gap between items → elementFromPoint already returns the parent
 	// Returns the resolved block AND its element so the caller doesn't re-query.
 	const resolveTargetContainer = (clientX: number, clientY: number) => {
 		const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
@@ -166,44 +170,35 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		if (!raw) return null;
 
 		const rawEl = getContainerEl(raw);
-		const nonDraggedChildren = raw.getChildren().filter((c) => c.blockId !== block.blockId);
-		const canNest =
-			raw.canHaveChildren() && !!rawEl && (nonDraggedChildren.length > 0 || isSpaciousContainer(rawEl));
+		const nonDragged = raw.getChildren().filter((c) => c.blockId !== block.blockId);
+		let canNest = raw.canHaveChildren() && !!rawEl && (nonDragged.length > 0 || isSpaciousContainer(rawEl));
 
-		let container: Block | null = canNest ? raw : raw.getParentBlock() || raw;
+		// Over a nestable container's outer edge band → reorder BESIDE it in its
+		// parent instead of nesting.
+		const parent = raw.getParentBlock();
+		if (canNest && rawEl && parent && inEdgeBand(rawEl, parent, clientX, clientY)) {
+			canNest = false;
+		}
+
+		let container: Block | null = canNest ? raw : parent || raw;
 
 		while (container && (!container.canHaveChildren() || isSelfOrInsideDragged(container))) {
 			container = container.getParentBlock();
 		}
 		if (!container) return null;
-		// reuse rawEl when we settled on `raw` itself, otherwise resolve the element
 		const parentEl = container === raw ? rawEl : getContainerEl(container);
 		if (!parentEl) return null;
 		return { parent: container, parentEl };
 	};
 
-	// Direct block children of a container, excluding the placeholder and the
-	// (hidden) source — i.e. the real siblings, in DOM order.
-	const realChildren = (containerEl: HTMLElement): HTMLElement[] =>
-		Array.from(containerEl.children).filter(
-			(c) => c !== placeholder && c !== sourceEl,
-		) as HTMLElement[];
-
-	const positionPlaceholder = (containerEl: HTMLElement, index: number) => {
-		if (!placeholder) return;
-		const ref = realChildren(containerEl)[index] || null;
-		if (placeholder.parentElement !== containerEl || placeholder.nextElementSibling !== ref) {
-			containerEl.insertBefore(placeholder, ref);
-		}
-	};
-
 	const clearTarget = () => {
 		dropParent = null;
 		dropIndex = null;
-		if (placeholder?.parentElement) placeholder.remove();
 		canvasStore.clearReorderTarget();
 	};
 
+	// Read-only: measure the resolved container's children and update the overlay.
+	// No DOM writes → no reflow → no jitter.
 	const updateTarget = (clientX: number, clientY: number) => {
 		const resolved = resolveTargetContainer(clientX, clientY);
 		if (!resolved) {
@@ -215,43 +210,22 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		const style = getComputedStyle(parentEl);
 		const direction = getLayoutDirection(style);
 		const pointerMain = direction === "row" ? clientX : clientY;
+		const pointerCross = direction === "row" ? clientY : clientX;
+
+		const rects = collectChildRects(parentEl, direction, sourceEl);
+		const lines = clusterLines(rects);
+		const index = computeReadingOrderIndex(lines, pointerMain, pointerCross);
+
 		const cr = parentEl.getBoundingClientRect();
+		dropParent = parent;
+		dropIndex = index;
+
 		const t = canvasStore.reorderTarget;
 		t.active = true;
 		t.isComponentParent = parent.isExtendedFromComponent();
+		t.isSameContainer = parent.blockId === originalParentId;
 		t.containerRect = { top: cr.top, left: cr.left, width: cr.width, height: cr.height };
-		dropParent = parent;
-
-		if (parent.blockId === originalParentId) {
-			// SAME container → real in-flow slot: the placeholder shifts siblings so
-			// the drop position is exact. Index from the live layout (placeholder
-			// excluded by class, hidden source by zero rect).
-			const rects = collectChildRects(parentEl, direction, sourceEl);
-			const index = computeDropIndex(rects, pointerMain);
-			positionPlaceholder(parentEl, index);
-			dropIndex = index;
-
-			const pr = (placeholder as HTMLElement).getBoundingClientRect();
-			t.mode = "slot";
-			t.slotRect = { top: pr.top, left: pr.left, width: pr.width, height: pr.height };
-			t.line = null;
-
-			const gap = parseFloat(direction === "row" ? style.columnGap : style.rowGap) || 0;
-			t.spacing = gap > 0 ? { value: Math.round(gap), left: pr.left + pr.width / 2, top: pr.top } : null;
-		} else {
-			// CROSS container → no layout shift: keep the placeholder out and show a
-			// line indicator between the target's existing children. Computed from
-			// the untouched layout, so there's no reflow feedback / jitter.
-			if (placeholder?.parentElement) placeholder.remove();
-			const rects = collectChildRects(parentEl, direction);
-			const index = computeDropIndex(rects, pointerMain);
-			dropIndex = index;
-
-			t.mode = "line";
-			t.slotRect = null;
-			t.line = computeIndicator(rects, index, cr, style, direction);
-			t.spacing = null;
-		}
+		t.line = computeDropIndicator(lines, index, cr, style, direction);
 	};
 
 	const positionGhost = (clientX: number, clientY: number) => {
@@ -265,7 +239,7 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		if (!oldParent) return;
 
 		if (dropParent.blockId === oldParent.blockId) {
-			// moveChild removes then inserts, so dropIndex (position among the
+			// moveChild removes then re-inserts, so dropIndex (position among the
 			// non-dragged siblings) maps directly.
 			oldParent.moveChild(block, dropIndex);
 		} else {
@@ -282,12 +256,9 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 
 		if (ghost) ghost.remove();
 		ghost = null;
-		if (placeholder?.parentElement) placeholder.remove();
-		placeholder = null;
 
 		if (started) {
-			sourceEl.style.display = prevSourceDisplay;
-			document.body.style.cursor = prevBodyCursor;
+			sourceEl.style.visibility = prevSourceVisibility;
 			canvasStore.isDragging = false;
 		}
 		canvasStore.clearReorderTarget();
@@ -317,9 +288,6 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 
 	const onUp = () => {
 		if (started && dropParent !== null && dropIndex !== null) {
-			// remove the placeholder before mutating the tree so Vue's re-render of
-			// the container children isn't fighting a stray DOM node
-			if (placeholder?.parentElement) placeholder.remove();
 			commit();
 		}
 		cleanup();

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -30,17 +30,26 @@ export function isReorderable(block: Block): boolean {
 // is computed in 2D reading order, so flex rows/columns, wrapped flex and grid
 // all share one path. The tree is mutated once, on release, as a single history
 // entry.
-export function startBlockReorder(event: MouseEvent, block: Block) {
+export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: string) {
 	const canvasStore = useCanvasStore();
 	const findBlock = (id: string): Block | null => canvasStore.activeCanvas?.findBlock(id) ?? null;
 	const getScale = () => canvasStore.activeCanvas?.canvasProps?.scale || 1;
 
-	const activeBreakpoint =
-		canvasStore.activeCanvas?.activeBreakpoint || canvasStore.activeCanvas?.hoveredBreakpoint || "desktop";
+	// Measure the elements of the breakpoint the drag actually happens in — the
+	// same block renders one element per visible breakpoint (each a separate
+	// canvas with different layout), so a hard-coded active breakpoint would
+	// measure the wrong layout when dragging on, e.g., the mobile canvas.
+	const dragBreakpoint =
+		breakpoint ||
+		((event.target as HTMLElement)?.closest?.(".__builder_component__") as HTMLElement | null)?.dataset
+			.breakpoint ||
+		canvasStore.activeCanvas?.activeBreakpoint ||
+		canvasStore.activeCanvas?.hoveredBreakpoint ||
+		"desktop";
 
 	const getContainerEl = (target: Block): HTMLElement | null =>
 		document.querySelector(
-			`.__builder_component__[data-block-id="${target.blockId}"][data-breakpoint="${activeBreakpoint}"]`,
+			`.__builder_component__[data-block-id="${target.blockId}"][data-breakpoint="${dragBreakpoint}"]`,
 		) as HTMLElement | null;
 
 	const sourceEl = getContainerEl(block);

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -225,7 +225,10 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		t.isComponentParent = parent.isExtendedFromComponent();
 		t.isSameContainer = parent.blockId === originalParentId;
 		t.containerRect = { top: cr.top, left: cr.left, width: cr.width, height: cr.height };
-		t.line = computeDropIndicator(lines, index, cr, style, direction);
+		t.line = computeDropIndicator(lines, index, cr, style, direction, {
+			width: sourceRect.width,
+			height: sourceRect.height,
+		});
 	};
 
 	const positionGhost = (clientX: number, clientY: number) => {

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -122,14 +122,6 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		return false;
 	};
 
-	// An empty container is worth nesting into when it's clearly bigger than the
-	// dragged block (a drop zone), not a same-sized leaf box you'd reorder past.
-	const NEST_SIZE_FACTOR = 1.6;
-	const isSpaciousContainer = (rawEl: HTMLElement): boolean => {
-		const r = rawEl.getBoundingClientRect();
-		return r.width >= sourceRect.width * NEST_SIZE_FACTOR && r.height >= sourceRect.height * NEST_SIZE_FACTOR;
-	};
-
 	// Fraction of a container-child's main-axis extent, at EACH end, reserved for
 	// "reorder beside me" instead of "nest inside me". Without this you could only
 	// reorder past a child container by hitting the hairline gap/edge between
@@ -186,11 +178,12 @@ export function startBlockReorder(event: MouseEvent, block: Block) {
 		// This is what lets you drag a deeply-nested block OUT: hovering the (now
 		// apparently empty) parent it came from resolves to its grandparent.
 		const isEmptySourceParent = raw.blockId === originalParentId && nonDragged.length === 0;
-		let canNest =
-			!isEmptySourceParent &&
-			raw.canHaveChildren() &&
-			!!rawEl &&
-			(nonDragged.length > 0 || isSpaciousContainer(rawEl));
+		// Any container that can hold children is a nest target — including one the
+		// same size as (or smaller than) the dragged block. The edge band below is
+		// what separates nest (dead-centre) from reorder-beside (edges), so no size
+		// heuristic is needed; empty containers just get a wider band (mostly
+		// before/after, centre nests).
+		let canNest = !isEmptySourceParent && raw.canHaveChildren() && !!rawEl;
 
 		// Over a nestable container's outer edge band → reorder BESIDE it in its
 		// parent instead of nesting. Empty containers get a wider band so they

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -11,9 +11,7 @@ import {
 const DRAG_THRESHOLD = 4; // px before a mousedown becomes a drag
 const GHOST_OPACITY = 0.9;
 
-// Can this block be reordered by dragging it on the canvas? (in-flow, not root,
-// not an absolutely-positioned block — those free-move — and not owned by a
-// component instance).
+// Absolutely-positioned blocks free-move; component-owned blocks are locked.
 export function isReorderable(block: Block): boolean {
 	return (
 		!block.isRoot() &&
@@ -60,16 +58,12 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 	const sourceRect = sourceEl.getBoundingClientRect();
 	const grabOffsetX = startX - sourceRect.left;
 	const grabOffsetY = startY - sourceRect.top;
-	// the block's own container — dropping here reorders (same parent); dropping
-	// into any other container moves the block across
 	const originalParentId = block.getParentBlock()?.blockId ?? null;
 
 	let started = false;
 	let ghost: HTMLElement | null = null;
 	let pauseId: unknown = null;
 	let prevSourceVisibility = "";
-
-	// resolved drop target at release time
 	let dropParent: Block | null = null;
 	let dropIndex: number | null = null;
 
@@ -84,7 +78,7 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 		pauseId = canvasStore.activeCanvas?.history?.pause();
 
 		const scale = getScale();
-		// floating ghost — clone before hiding the source
+		// clone before hiding the source below
 		ghost = document.createElement("div");
 		ghost.id = "reorder-ghost";
 		const clone = sourceEl.cloneNode(true) as HTMLElement;
@@ -190,9 +184,7 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 		// before/after, centre nests).
 		let canNest = !isEmptySourceParent && raw.canHaveChildren() && !!rawEl;
 
-		// Over a nestable container's outer edge band → reorder BESIDE it in its
-		// parent instead of nesting. Empty containers get a wider band so they
-		// default to before/after (add a sibling) rather than nest-inside.
+		// Empty containers use a wider band so they default to before/after.
 		const parent = raw.getParentBlock();
 		if (canNest && rawEl && parent) {
 			const band = nonDragged.length === 0 ? EDGE_REORDER_BAND_EMPTY : EDGE_REORDER_BAND;
@@ -216,8 +208,6 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 		canvasStore.clearReorderTarget();
 	};
 
-	// Read-only: measure the resolved container's children and update the overlay.
-	// No DOM writes → no reflow → no jitter.
 	const updateTarget = (clientX: number, clientY: number) => {
 		const resolved = resolveTargetContainer(clientX, clientY);
 		if (!resolved) {

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -1,0 +1,339 @@
+import type Block from "@/block";
+import useCanvasStore from "@/stores/canvasStore";
+import {
+	collectChildRects,
+	computeDropIndex,
+	computeIndicator,
+	getLayoutDirection,
+} from "@/utils/dropGeometry";
+
+const DRAG_THRESHOLD = 4; // px before a mousedown becomes a drag
+const GHOST_OPACITY = 0.9;
+
+// Can this block be reordered by dragging it on the canvas? (in-flow, not root,
+// not an absolutely-positioned block — those free-move — and not owned by a
+// component instance).
+export function isReorderable(block: Block): boolean {
+	return (
+		!block.isRoot() &&
+		!block.isMovable() &&
+		!block.isChildOfComponent &&
+		Boolean(block.getParentBlock())
+	);
+}
+
+// Pointer-based on-canvas reorder. The dragged block is lifted out of the flow
+// (a floating ghost follows the cursor) and a real, same-sized placeholder is
+// inserted into the target container — so the browser's own flex/grid engine
+// positions the drop slot EXACTLY where the block will land (respecting
+// display / justify-content / align-items / gap), and siblings open up to make
+// room. The tree is only mutated on release, in one history entry.
+export function startBlockReorder(event: MouseEvent, block: Block) {
+	const canvasStore = useCanvasStore();
+	const findBlock = (id: string): Block | null => canvasStore.activeCanvas?.findBlock(id) ?? null;
+	const getScale = () => canvasStore.activeCanvas?.canvasProps?.scale || 1;
+
+	const activeBreakpoint =
+		canvasStore.activeCanvas?.activeBreakpoint || canvasStore.activeCanvas?.hoveredBreakpoint || "desktop";
+
+	const getContainerEl = (target: Block): HTMLElement | null =>
+		document.querySelector(
+			`.__builder_component__[data-block-id="${target.blockId}"][data-breakpoint="${activeBreakpoint}"]`,
+		) as HTMLElement | null;
+
+	const sourceEl = getContainerEl(block);
+	if (!sourceEl) return;
+
+	const startX = event.clientX;
+	const startY = event.clientY;
+	const sourceRect = sourceEl.getBoundingClientRect();
+	const grabOffsetX = startX - sourceRect.left;
+	const grabOffsetY = startY - sourceRect.top;
+	// the block's own container — reordering here shifts siblings (a real slot),
+	// dropping into any OTHER container just shows a no-reflow line indicator
+	const originalParentId = block.getParentBlock()?.blockId ?? null;
+
+	let started = false;
+	let ghost: HTMLElement | null = null;
+	let placeholder: HTMLElement | null = null;
+	let pauseId: unknown = null;
+	let prevBodyCursor = "";
+	let prevSourceDisplay = "";
+
+	// resolved drop target at release time
+	let dropParent: Block | null = null;
+	let dropIndex: number | null = null;
+
+	// A transparent spacer that occupies the dragged block's box (size + margins +
+	// cross-axis alignment) so the flex layout reserves the real slot. The visible
+	// indicator is drawn crisply as an overlay on top of this (see DropIndicator).
+	const buildPlaceholder = (): HTMLElement => {
+		const el = document.createElement("div");
+		el.className = "reorder-placeholder";
+		const cs = getComputedStyle(sourceEl);
+		Object.assign(el.style, {
+			boxSizing: "border-box",
+			// offsetWidth/Height are unscaled border-box px (the placeholder lives
+			// inside the scaled canvas, so it must use design-space sizes)
+			width: `${sourceEl.offsetWidth}px`,
+			height: `${sourceEl.offsetHeight}px`,
+			marginTop: cs.marginTop,
+			marginRight: cs.marginRight,
+			marginBottom: cs.marginBottom,
+			marginLeft: cs.marginLeft,
+			alignSelf: cs.alignSelf,
+			flex: "0 0 auto",
+			pointerEvents: "none",
+			background: "transparent",
+		});
+		return el;
+	};
+
+	const beginDrag = () => {
+		started = true;
+		canvasStore.isDragging = true;
+		// suppress the click that fires after the drag so the block isn't
+		// re-selected/toggled by useBlockEventHandlers
+		canvasStore.preventClick = true;
+		pauseId = canvasStore.activeCanvas?.history?.pause();
+
+		const scale = getScale();
+		// floating ghost — clone BEFORE hiding the source
+		ghost = document.createElement("div");
+		ghost.id = "reorder-ghost";
+		const clone = sourceEl.cloneNode(true) as HTMLElement;
+		clone.style.margin = "0";
+		ghost.appendChild(clone);
+		Object.assign(ghost.style, {
+			position: "fixed",
+			left: "0",
+			top: "0",
+			width: `${sourceRect.width / scale}px`,
+			height: `${sourceRect.height / scale}px`,
+			transformOrigin: "top left",
+			transform: `translate(${sourceRect.left}px, ${sourceRect.top}px) scale(${scale})`,
+			opacity: String(GHOST_OPACITY),
+			pointerEvents: "none",
+			zIndex: "999999",
+			boxShadow: "0 12px 32px rgba(0,0,0,0.24), 0 2px 6px rgba(0,0,0,0.12)",
+			borderRadius: "6px",
+			overflow: "hidden",
+			willChange: "transform",
+		});
+		document.body.appendChild(ghost);
+
+		placeholder = buildPlaceholder();
+
+		// lift the source out of the flow so its own slot closes up
+		prevSourceDisplay = sourceEl.style.display;
+		sourceEl.style.display = "none";
+
+		prevBodyCursor = document.body.style.cursor;
+		document.body.style.cursor = "grabbing";
+	};
+
+	// Is `candidate` the dragged block itself, or somewhere inside its subtree?
+	const isSelfOrInsideDragged = (candidate: Block): boolean => {
+		let node: Block | null = candidate;
+		while (node) {
+			if (node.blockId === block.blockId) return true;
+			node = node.getParentBlock();
+		}
+		return false;
+	};
+
+	// An empty container is worth nesting into when it's clearly bigger than the
+	// dragged block (a drop zone), not a same-sized leaf box you'd reorder past.
+	const NEST_SIZE_FACTOR = 1.6;
+	const isSpaciousContainer = (rawEl: HTMLElement): boolean => {
+		const r = rawEl.getBoundingClientRect();
+		return r.width >= sourceRect.width * NEST_SIZE_FACTOR && r.height >= sourceRect.height * NEST_SIZE_FACTOR;
+	};
+
+	// Decide the container to drop into, from whatever is under the cursor:
+	//  - cursor over a container's body (populated, or an empty drop-zone) → nest inside
+	//  - cursor over a childless leaf box → reorder as its sibling
+	//  - cursor in the gap between items → elementFromPoint returns the parent, so
+	//    you reorder at that level. No edge bands: the live layout (placeholder in
+	//    place) drives everything, which is what keeps the drop stable.
+	// Returns the resolved block AND its element so the caller doesn't re-query.
+	const resolveTargetContainer = (clientX: number, clientY: number) => {
+		const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+		const hovered = el?.closest(".__builder_component__") as HTMLElement | null;
+		let raw: Block | null = (hovered?.dataset.blockId && findBlock(hovered.dataset.blockId)) || null;
+
+		while (raw && isSelfOrInsideDragged(raw)) raw = raw.getParentBlock();
+		if (!raw) return null;
+
+		const rawEl = getContainerEl(raw);
+		const nonDraggedChildren = raw.getChildren().filter((c) => c.blockId !== block.blockId);
+		const canNest =
+			raw.canHaveChildren() && !!rawEl && (nonDraggedChildren.length > 0 || isSpaciousContainer(rawEl));
+
+		let container: Block | null = canNest ? raw : raw.getParentBlock() || raw;
+
+		while (container && (!container.canHaveChildren() || isSelfOrInsideDragged(container))) {
+			container = container.getParentBlock();
+		}
+		if (!container) return null;
+		// reuse rawEl when we settled on `raw` itself, otherwise resolve the element
+		const parentEl = container === raw ? rawEl : getContainerEl(container);
+		if (!parentEl) return null;
+		return { parent: container, parentEl };
+	};
+
+	// Direct block children of a container, excluding the placeholder and the
+	// (hidden) source — i.e. the real siblings, in DOM order.
+	const realChildren = (containerEl: HTMLElement): HTMLElement[] =>
+		Array.from(containerEl.children).filter(
+			(c) => c !== placeholder && c !== sourceEl,
+		) as HTMLElement[];
+
+	const positionPlaceholder = (containerEl: HTMLElement, index: number) => {
+		if (!placeholder) return;
+		const ref = realChildren(containerEl)[index] || null;
+		if (placeholder.parentElement !== containerEl || placeholder.nextElementSibling !== ref) {
+			containerEl.insertBefore(placeholder, ref);
+		}
+	};
+
+	const clearTarget = () => {
+		dropParent = null;
+		dropIndex = null;
+		if (placeholder?.parentElement) placeholder.remove();
+		canvasStore.clearReorderTarget();
+	};
+
+	const updateTarget = (clientX: number, clientY: number) => {
+		const resolved = resolveTargetContainer(clientX, clientY);
+		if (!resolved) {
+			clearTarget();
+			return;
+		}
+		const { parent, parentEl } = resolved;
+
+		const style = getComputedStyle(parentEl);
+		const direction = getLayoutDirection(style);
+		const pointerMain = direction === "row" ? clientX : clientY;
+		const cr = parentEl.getBoundingClientRect();
+		const t = canvasStore.reorderTarget;
+		t.active = true;
+		t.isComponentParent = parent.isExtendedFromComponent();
+		t.containerRect = { top: cr.top, left: cr.left, width: cr.width, height: cr.height };
+		dropParent = parent;
+
+		if (parent.blockId === originalParentId) {
+			// SAME container → real in-flow slot: the placeholder shifts siblings so
+			// the drop position is exact. Index from the live layout (placeholder
+			// excluded by class, hidden source by zero rect).
+			const rects = collectChildRects(parentEl, direction, sourceEl);
+			const index = computeDropIndex(rects, pointerMain);
+			positionPlaceholder(parentEl, index);
+			dropIndex = index;
+
+			const pr = (placeholder as HTMLElement).getBoundingClientRect();
+			t.mode = "slot";
+			t.slotRect = { top: pr.top, left: pr.left, width: pr.width, height: pr.height };
+			t.line = null;
+
+			const gap = parseFloat(direction === "row" ? style.columnGap : style.rowGap) || 0;
+			t.spacing = gap > 0 ? { value: Math.round(gap), left: pr.left + pr.width / 2, top: pr.top } : null;
+		} else {
+			// CROSS container → no layout shift: keep the placeholder out and show a
+			// line indicator between the target's existing children. Computed from
+			// the untouched layout, so there's no reflow feedback / jitter.
+			if (placeholder?.parentElement) placeholder.remove();
+			const rects = collectChildRects(parentEl, direction);
+			const index = computeDropIndex(rects, pointerMain);
+			dropIndex = index;
+
+			t.mode = "line";
+			t.slotRect = null;
+			t.line = computeIndicator(rects, index, cr, style, direction);
+			t.spacing = null;
+		}
+	};
+
+	const positionGhost = (clientX: number, clientY: number) => {
+		if (!ghost) return;
+		ghost.style.transform = `translate(${clientX - grabOffsetX}px, ${clientY - grabOffsetY}px) scale(${getScale()})`;
+	};
+
+	const commit = () => {
+		if (dropParent === null || dropIndex === null) return;
+		const oldParent = block.getParentBlock();
+		if (!oldParent) return;
+
+		if (dropParent.blockId === oldParent.blockId) {
+			// moveChild removes then inserts, so dropIndex (position among the
+			// non-dragged siblings) maps directly.
+			oldParent.moveChild(block, dropIndex);
+		} else {
+			oldParent.removeChild(block);
+			dropParent.addChild(block, dropIndex, false);
+		}
+		canvasStore.selectBlock(block, null);
+	};
+
+	const cleanup = () => {
+		document.removeEventListener("mousemove", onMove);
+		document.removeEventListener("mouseup", onUp);
+		document.removeEventListener("keydown", onKey);
+
+		if (ghost) ghost.remove();
+		ghost = null;
+		if (placeholder?.parentElement) placeholder.remove();
+		placeholder = null;
+
+		if (started) {
+			sourceEl.style.display = prevSourceDisplay;
+			document.body.style.cursor = prevBodyCursor;
+			canvasStore.isDragging = false;
+		}
+		canvasStore.clearReorderTarget();
+
+		if (pauseId) {
+			// Resume WITHOUT committing: the tree mutation in commit() runs in this
+			// same mouseup tick, so its deep-watch flush is still pending and the
+			// natural (debounced) watcher records exactly one history entry once
+			// unpaused. Passing commitNow here would double it. A no-op drag leaves
+			// the tree unchanged, so the watcher records nothing.
+			canvasStore.activeCanvas?.history?.resume(pauseId as never, false);
+			pauseId = null;
+		}
+	};
+
+	const onMove = (e: MouseEvent) => {
+		if (!started) {
+			if (Math.abs(e.clientX - startX) < DRAG_THRESHOLD && Math.abs(e.clientY - startY) < DRAG_THRESHOLD) {
+				return;
+			}
+			beginDrag();
+		}
+		e.preventDefault();
+		positionGhost(e.clientX, e.clientY);
+		updateTarget(e.clientX, e.clientY);
+	};
+
+	const onUp = () => {
+		if (started && dropParent !== null && dropIndex !== null) {
+			// remove the placeholder before mutating the tree so Vue's re-render of
+			// the container children isn't fighting a stray DOM node
+			if (placeholder?.parentElement) placeholder.remove();
+			commit();
+		}
+		cleanup();
+	};
+
+	const onKey = (e: KeyboardEvent) => {
+		if (e.key === "Escape") {
+			dropParent = null;
+			dropIndex = null;
+			cleanup();
+		}
+	};
+
+	document.addEventListener("mousemove", onMove);
+	document.addEventListener("mouseup", onUp);
+	document.addEventListener("keydown", onKey);
+}

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -3,6 +3,7 @@ import useBlockTemplateStore from "@/stores/blockTemplateStore";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
+import { getLayoutDirection, type LayoutDirection } from "@/utils/dropGeometry";
 import {
 	getBlockCopy,
 	getBlockInstance,
@@ -21,8 +22,6 @@ const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 const componentStore = useComponentStore();
 const blockTemplateStore = useBlockTemplateStore();
-
-type LayoutDirection = "row" | "column";
 
 export function useCanvasDropZone(
 	canvasContainer: Ref<HTMLElement>,
@@ -114,7 +113,7 @@ export function useCanvasDropZone(
 
 		if (parentBlock) {
 			const parentElement = getBlockElement(parentBlock);
-			layoutDirection = getLayoutDirection(parentElement);
+			layoutDirection = getLayoutDirection(window.getComputedStyle(parentElement));
 			index = findDropIndex(ev, parentElement, layoutDirection);
 		}
 
@@ -155,17 +154,6 @@ export function useCanvasDropZone(
 		// Determine if we should insert before or after the closest child
 		// if mouse is closer to left/top side of the child, insert before, else after
 		return mousePos <= childPositions[closestIndex].midPoint ? closestIndex : closestIndex + 1;
-	};
-
-	const getLayoutDirection = (element: HTMLElement): LayoutDirection => {
-		const style = window.getComputedStyle(element);
-		const display = style.display;
-		if (display === "flex" || display === "inline-flex") {
-			return style.flexDirection.includes("row") ? "row" : "column";
-		} else if (display === "grid" || display == "inline-grid") {
-			return style.gridAutoFlow.includes("row") ? "row" : "column";
-		}
-		return "column";
 	};
 
 	const updateDropTarget = (

--- a/frontend/src/utils/useCanvasMarqueeSelection.ts
+++ b/frontend/src/utils/useCanvasMarqueeSelection.ts
@@ -238,6 +238,14 @@ export function useCanvasMarqueeSelection(options: UseCanvasMarqueeSelectionOpti
 			return false;
 		}
 
+		// Pressing on an actual block starts a block drag/selection (see
+		// useBlockEventHandlers), not a marquee. The root block (page background)
+		// and truly empty canvas still start a marquee.
+		const blockEl = target.closest(".__builder_component__") as HTMLElement | null;
+		if (blockEl && blockEl.dataset.blockId && blockEl.dataset.blockId !== "root") {
+			return false;
+		}
+
 		return true;
 	};
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/3e88e40f-3d82-41b2-83f6-268e4c334fe0

This will help users easily adjust/reorder/move blocks around the canvas. Everything works well without much jitter or layout shifts.


Following cases are handled

https://github.com/user-attachments/assets/13b8693d-9e59-440e-be6c-fa4e959bfae1

