### PR TITLE
refactor: redesign persona survey and categorise template picker

### DIFF
--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -49,7 +49,6 @@
 				</div>
 			</div>
 			<div v-else class="flex flex-col gap-5">
-				<!-- category filter, only when the catalog has categories -->
 				<div v-if="categories.length" class="flex flex-wrap gap-2">
 					<Button
 						v-for="category in ['', ...categories]"
@@ -113,7 +112,6 @@ const groups = computed<TemplateGroup[]>(() => templateGroups.data || []);
 const visibleGroups = computed<TemplateGroup[]>(() =>
 	props.maxGroups > 0 ? groups.value.slice(0, props.maxGroups) : groups.value,
 );
-// distinct hub manifest categories in catalog order; drives the filter pills
 const categories = computed<string[]>(() => {
 	const seen = new Set<string>();
 	for (const group of visibleGroups.value) {
@@ -122,13 +120,11 @@ const categories = computed<string[]>(() => {
 	return [...seen];
 });
 
-// "" = All; persisted, and seeded by the persona survey's use-case answer.
-// Reset to All if the stored category disappears from the catalog.
+// "" = All; reset if the stored category disappears from a loaded catalog
 const selectedCategory = templateCategoryFilter;
 watch(
 	categories,
 	() => {
-		// only once the catalog is in; an empty list just means it hasn't loaded yet
 		if (
 			categories.value.length &&
 			selectedCategory.value &&

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -48,13 +48,25 @@
 					<div class="h-3.5 w-2/3 animate-pulse rounded bg-surface-gray-2"></div>
 				</div>
 			</div>
-			<div v-else class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
-				<BlankPageCard label="Start from scratch" @click="createBlankPage('gallery')" />
-				<TemplateGroupCard
-					v-for="group in visibleGroups"
-					:key="group.name"
-					:group="group"
-					@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
+			<div v-else class="flex flex-col gap-5">
+				<!-- category filter, only when the catalog has categories -->
+				<div v-if="categories.length" class="flex flex-wrap gap-2">
+					<Button
+						v-for="category in ['', ...categories]"
+						:key="category"
+						:variant="selectedCategory === category ? 'subtle' : 'outline'"
+						:label="category || 'All'"
+						:class="{ 'border border-transparent': selectedCategory === category }"
+						@click="selectedCategory = category" />
+				</div>
+				<div class="grid gap-x-4 gap-y-5 auto-fill-[190px]">
+					<BlankPageCard label="Start from scratch" @click="createBlankPage('gallery')" />
+					<TemplateGroupCard
+						v-for="group in filteredGroups"
+						:key="group.name"
+						:group="group"
+						@select="(group: TemplateGroup) => (selectedGroup = group.name)"></TemplateGroupCard>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -69,7 +81,7 @@ import usePageStore from "@/stores/pageStore";
 import { TemplateGroup, TemplatePageSummary } from "@/types/template";
 import { Button, createResource, toast } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import BlankPageCard from "./BlankPageCard.vue";
 import TemplateGroupCard from "./TemplateGroupCard.vue";
 import TemplatePageGrid from "./TemplatePageGrid.vue";
@@ -88,7 +100,7 @@ const props = withDefaults(
 	},
 );
 
-const { showTemplatesDialog, lastTemplateGroup } = useDashboardState();
+const { showTemplatesDialog, lastTemplateGroup, templateCategoryFilter } = useDashboardState();
 const builderStore = useBuilderStore();
 const pageStore = usePageStore();
 const { capture } = useTelemetry();
@@ -101,6 +113,39 @@ const groups = computed<TemplateGroup[]>(() => templateGroups.data || []);
 const visibleGroups = computed<TemplateGroup[]>(() =>
 	props.maxGroups > 0 ? groups.value.slice(0, props.maxGroups) : groups.value,
 );
+// distinct hub manifest categories in catalog order; drives the filter pills
+const categories = computed<string[]>(() => {
+	const seen = new Set<string>();
+	for (const group of visibleGroups.value) {
+		for (const category of group.categories || []) seen.add(category);
+	}
+	return [...seen];
+});
+
+// "" = All; persisted, and seeded by the persona survey's use-case answer.
+// Reset to All if the stored category disappears from the catalog.
+const selectedCategory = templateCategoryFilter;
+watch(
+	categories,
+	() => {
+		// only once the catalog is in; an empty list just means it hasn't loaded yet
+		if (
+			categories.value.length &&
+			selectedCategory.value &&
+			!categories.value.includes(selectedCategory.value)
+		) {
+			selectedCategory.value = "";
+		}
+	},
+	{ immediate: true },
+);
+
+const filteredGroups = computed<TemplateGroup[]>(() =>
+	selectedCategory.value
+		? visibleGroups.value.filter((group) => group.categories?.includes(selectedCategory.value))
+		: visibleGroups.value,
+);
+
 const activeGroup = computed<TemplateGroup | null>(
 	() => groups.value.find((group) => group.name === selectedGroup.value) || null,
 );

--- a/frontend/src/composables/useDashboardState.ts
+++ b/frontend/src/composables/useDashboardState.ts
@@ -10,6 +10,10 @@ const showTemplatesDialog = ref(false);
 // remembers the template group the picker was last drilled into ("" = gallery)
 const lastTemplateGroup = useStorage("lastTemplateGroup", "") as Ref<string>;
 
+// active category filter in the template gallery ("" = All); seeded by the
+// persona survey's use-case answer so the picker opens on relevant templates
+const templateCategoryFilter = useStorage("templateCategoryFilter", "") as Ref<string>;
+
 const displayType = useStorage("displayType", "grid") as Ref<"grid" | "list" | "tree">;
 const typeFilter = useStorage("typeFilter", "") as Ref<"" | "draft" | "published" | "unpublished" | "all">;
 const orderBy = useStorage("orderBy", "creation") as Ref<
@@ -27,6 +31,7 @@ export function useDashboardState() {
 		treeExpanded,
 		showTemplatesDialog,
 		lastTemplateGroup,
+		templateCategoryFilter,
 		displayType,
 		typeFilter,
 		orderBy,

--- a/frontend/src/composables/useDashboardState.ts
+++ b/frontend/src/composables/useDashboardState.ts
@@ -10,8 +10,7 @@ const showTemplatesDialog = ref(false);
 // remembers the template group the picker was last drilled into ("" = gallery)
 const lastTemplateGroup = useStorage("lastTemplateGroup", "") as Ref<string>;
 
-// active category filter in the template gallery ("" = All); seeded by the
-// persona survey's use-case answer so the picker opens on relevant templates
+// active category filter in the template gallery ("" = All)
 const templateCategoryFilter = useStorage("templateCategoryFilter", "") as Ref<string>;
 
 const displayType = useStorage("displayType", "grid") as Ref<"grid" | "list" | "tree">;

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -15,8 +15,7 @@
 
 	<!-- question steps: one question per page -->
 	<div v-else class="flex h-screen flex-col items-center overflow-y-auto p-5">
-		<!-- top-anchored (not centered) so the logo/heading never move between steps
-		     or when the "Other" textarea expands -->
+		<!-- top-anchored so the logo/heading never move between steps -->
 		<div class="mt-[28vh] flex w-full max-w-sm flex-col gap-5">
 			<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
 			<div class="relative flex flex-col gap-1.5">
@@ -45,11 +44,7 @@
 					@click="select(opt.value)" />
 			</div>
 
-			<!-- free-text detail, revealed when "Other" is picked. -mt-5 cancels the
-			     column gap while collapsed (the inner mt-5 restores it when open) so
-			     the closed state doesn't leave a double gap before Next. The inner
-			     translate makes the whole textarea slide down from under the pills
-			     (drawer-style) instead of being clipped mid-reveal. -->
+			<!-- "Other" free text; -mt-5 + inner mt-5 avoid a double column gap while collapsed -->
 			<div
 				class="-mt-5 grid transition-[grid-template-rows,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
 				:class="isOtherSelected ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'">
@@ -188,7 +183,6 @@ const templateHeading = computed(() =>
 	greetingName.value ? `You're all set${greetingName.value}. Pick a starting point` : "Pick a starting point",
 );
 
-// surface the templates that match what the user said they want to build:
 // seeds the gallery's persisted category filter (used by the templates dialog too)
 const useCaseToCategory: Record<string, string> = {
 	marketing_site: "Marketing",
@@ -200,8 +194,7 @@ function select(value: string) {
 	// only highlight the choice; advancing is a deliberate Next click so a
 	// stray double-click can't skip past the following question
 	answers[activeQuestion.value.key] = value;
-	// preventScroll: focusing the still-clipped textarea mid-animation would
-	// otherwise scroll-jump the page
+	// preventScroll: focusing the still-clipped textarea would scroll-jump the page
 	if (value === "other") nextTick(() => otherInput.value?.el?.focus({ preventScroll: true }));
 }
 
@@ -229,10 +222,12 @@ function finishQuestions(skipped = false) {
 	const category = answers.use_case && useCaseToCategory[answers.use_case];
 	if (category) templateCategoryFilter.value = category;
 	// Optimistically flag done so the dashboard's redirect guard sees it before the async save lands.
-	// Never let a failed save/capture block the user from moving on.
+	// A failed save/capture must never block the user from moving on.
 	try {
 		if (builderSettings.doc) builderSettings.doc.persona_survey_done = 1;
-		builderSettings.setValue.submit({ persona_survey_done: 1 });
+		Promise.resolve(builderSettings.setValue.submit({ persona_survey_done: 1 })).catch((e: unknown) => {
+			console.error("[persona-survey] failed to persist", e);
+		});
 	} catch (e) {
 		console.error("[persona-survey] failed to persist", e);
 	}

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -9,72 +9,95 @@
 				class="mx-auto h-full w-full max-w-3xl"
 				:max-groups="8"
 				:heading="templateHeading"
-				subtitle="Choose a template to get a head start, or start from scratch. You can always change direction later." />
+				subtitle="Choose a template to get a head start, or start from scratch." />
 		</div>
 	</div>
 
 	<!-- question steps: one question per page -->
-	<div v-else class="flex h-screen items-center justify-center p-5">
-		<div class="flex w-full max-w-xl flex-col gap-8">
-			<div class="flex flex-col gap-6">
-				<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
-				<div class="flex flex-col gap-2">
-					<h1 class="text-xl font-semibold text-ink-gray-9">{{ activeQuestion.heading }}</h1>
-				</div>
+	<div v-else class="flex h-screen flex-col items-center overflow-y-auto p-5">
+		<!-- top-anchored (not centered) so the logo/heading never move between steps
+		     or when the "Other" textarea expands -->
+		<div class="mt-[28vh] flex w-full max-w-sm flex-col gap-5">
+			<img src="/builder_logo.png" alt="Builder" class="h-8 self-start" />
+			<div class="relative flex flex-col gap-1.5">
+				<!-- kept mounted (invisible on step 1) so nothing shifts when it appears -->
+				<Button
+					variant="ghost"
+					class="absolute -left-11 top-0"
+					:class="{ invisible: isFirst }"
+					label="Back"
+					@click="goBack">
+					<template #icon>
+						<LucideChevronLeft class="size-4" />
+					</template>
+				</Button>
+				<h1 class="text-2xl font-bold text-ink-gray-9">{{ activeQuestion.heading }}</h1>
+				<p class="text-base text-ink-gray-6">{{ activeQuestion.subtitle }}</p>
 			</div>
 
-			<div class="grid grid-cols-2 gap-3">
-				<button
+			<div class="flex flex-wrap gap-3.5">
+				<Button
 					v-for="opt in activeQuestion.options"
 					:key="opt.value"
-					class="flex items-center rounded-lg border p-4 text-left text-base transition-colors duration-150"
-					:class="
-						answers[activeQuestion.key] === opt.value
-							? 'border-outline-gray-4 bg-surface-gray-2 text-ink-gray-9'
-							: 'border-outline-gray-2 text-ink-gray-7 hover:border-outline-gray-3 hover:bg-surface-gray-1'
-					"
-					@click="select(opt.value)">
-					{{ opt.label }}
-				</button>
+					:variant="answers[activeQuestion.key] === opt.value ? 'subtle' : 'outline'"
+					:label="opt.label"
+					:class="{ 'border border-transparent': answers[activeQuestion.key] === opt.value }"
+					@click="select(opt.value)" />
 			</div>
 
-			<div class="flex items-center justify-between">
-				<span class="text-xs text-ink-gray-4">Step {{ stepIndex + 1 }} of {{ totalSteps }}</span>
-				<div class="flex items-center gap-2">
-					<!-- kept mounted (invisible on step 1) so the footer width/height stays fixed and nothing shifts -->
-					<Button
-						variant="ghost"
-						icon-left="lucide-arrow-left"
-						:class="{ invisible: isFirst }"
-						@click="goBack">
-						Back
-					</Button>
-					<Button
-						variant="solid"
-						icon-right="lucide-arrow-right"
-						:disabled="!answers[activeQuestion.key]"
-						@click="goNext">
-						Next
-					</Button>
+			<!-- free-text detail, revealed when "Other" is picked. -mt-5 cancels the
+			     column gap while collapsed (the inner mt-5 restores it when open) so
+			     the closed state doesn't leave a double gap before Next. The inner
+			     translate makes the whole textarea slide down from under the pills
+			     (drawer-style) instead of being clipped mid-reveal. -->
+			<div
+				class="-mt-5 grid transition-[grid-template-rows,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
+				:class="isOtherSelected ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'">
+				<div class="overflow-hidden">
+					<div
+						class="transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
+						:class="isOtherSelected ? 'translate-y-0' : '-translate-y-full'">
+						<Textarea
+							ref="otherInput"
+							v-model="otherText[activeQuestion.key]"
+							class="mt-5"
+							variant="subtle"
+							:rows="3"
+							:placeholder="activeQuestion.otherPlaceholder"
+							:tabindex="isOtherSelected ? 0 : -1" />
+					</div>
 				</div>
 			</div>
+
+			<Button
+				variant="solid"
+				size="md"
+				class="w-full"
+				label="Next"
+				:disabled="!answers[activeQuestion.key]"
+				@click="goNext" />
 		</div>
+
+		<Button variant="ghost" label="Skip for now" class="fixed bottom-8" @click="skip" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import TemplateGallery from "@/components/Templates/TemplateGallery.vue";
+import { useDashboardState } from "@/composables/useDashboardState";
 import { builderSettings } from "@/data/builderSettings";
 import { sessionUser } from "@/router";
 import { getUserInfo } from "@/usersInfo";
-import { Button } from "frappe-ui";
+import { Button, Textarea } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
-import { computed, reactive, ref } from "vue";
+import { computed, nextTick, reactive, ref } from "vue";
+import LucideChevronLeft from "~icons/lucide/chevron-left";
 
 // Pulse is event-only (no person properties), but every event carries the
 // (anonymized, stable) user id, so this single event can be joined to the
 // rest of the user's funnel for persona-wise segmentation.
 const telemetry = useTelemetry();
+const { templateCategoryFilter } = useDashboardState();
 // Dev benches have telemetry off; ?persona_survey=test logs the payload instead.
 const devForceShow = new URLSearchParams(window.location.search).get("persona_survey") === "test";
 
@@ -83,23 +106,29 @@ type QuestionKey = "use_case" | "role" | "source";
 const questions: {
 	key: QuestionKey;
 	heading: string;
+	subtitle: string;
+	otherPlaceholder: string;
 	options: { value: string; label: string }[];
 }[] = [
 	{
-		key: "use_case",
-		heading: "What do you want to build first?",
+		key: "source",
+		heading: "How did you hear about Builder?",
+		subtitle: "Just curious, it helps us know what's working.",
+		otherPlaceholder: "I heard from the community",
 		options: [
-			{ value: "marketing_site", label: "Marketing / landing site" },
-			{ value: "web_app_ui", label: "Web app UI" },
-			{ value: "internal_tool", label: "Internal tool" },
-			{ value: "dashboard", label: "Dashboard / admin panel" },
-			{ value: "portfolio", label: "Portfolio / personal site" },
-			{ value: "exploring", label: "Just exploring" },
+			{ value: "search", label: "Search (Google)" },
+			{ value: "youtube", label: "YouTube" },
+			{ value: "friend", label: "Friend / colleague" },
+			{ value: "frappe_ecosystem", label: "Frappe / ERPNext" },
+			{ value: "social", label: "Social media" },
+			{ value: "other", label: "Other" },
 		],
 	},
 	{
 		key: "role",
 		heading: "Which one best describes you?",
+		subtitle: "This helps us personalise your Builder experience",
+		otherPlaceholder: "I'm a student building my first site",
 		options: [
 			{ value: "designer", label: "Designer" },
 			{ value: "developer", label: "Developer" },
@@ -110,14 +139,17 @@ const questions: {
 		],
 	},
 	{
-		key: "source",
-		heading: "How did you hear about Builder?",
+		key: "use_case",
+		heading: "What do you want to build first?",
+		subtitle: "We'll point you to the right starting templates",
+		otherPlaceholder: "A booking site for my clinic",
 		options: [
-			{ value: "search", label: "Search (Google)" },
-			{ value: "youtube", label: "YouTube" },
-			{ value: "friend", label: "Friend / colleague" },
-			{ value: "frappe_ecosystem", label: "Frappe / ERPNext" },
-			{ value: "social", label: "Social media" },
+			{ value: "marketing_site", label: "Marketing / landing site" },
+			{ value: "ecommerce", label: "Online store / E-commerce" },
+			{ value: "portfolio", label: "Portfolio / personal site" },
+			{ value: "web_app_ui", label: "Web app UI" },
+			{ value: "internal_tool", label: "Internal tool / dashboard" },
+			{ value: "exploring", label: "Just exploring" },
 			{ value: "other", label: "Other" },
 		],
 	},
@@ -128,14 +160,21 @@ const answers = reactive<Record<QuestionKey, string | undefined>>({
 	role: undefined,
 	source: undefined,
 });
+const otherText = reactive<Record<QuestionKey, string>>({
+	use_case: "",
+	role: "",
+	source: "",
+});
 
 // question steps followed by the full-page template selector
 const stepOrder = [...questions.map((q) => q.key), "templates"] as const;
-const totalSteps = stepOrder.length;
 const stepIndex = ref(0);
 const step = computed(() => stepOrder[stepIndex.value]);
 const isFirst = computed(() => stepIndex.value === 0);
 const activeQuestion = computed(() => questions.find((q) => q.key === step.value)!);
+const isOtherSelected = computed(() => answers[activeQuestion.value.key] === "other");
+
+const otherInput = ref<InstanceType<typeof Textarea>>();
 
 // personal greeting; fullname is an email until the fetch lands (skip it then)
 const userInfo = getUserInfo(sessionUser.value);
@@ -149,10 +188,21 @@ const templateHeading = computed(() =>
 	greetingName.value ? `You're all set${greetingName.value}. Pick a starting point` : "Pick a starting point",
 );
 
+// surface the templates that match what the user said they want to build:
+// seeds the gallery's persisted category filter (used by the templates dialog too)
+const useCaseToCategory: Record<string, string> = {
+	marketing_site: "Marketing",
+	ecommerce: "E-commerce",
+	portfolio: "Portfolio",
+};
+
 function select(value: string) {
 	// only highlight the choice; advancing is a deliberate Next click so a
 	// stray double-click can't skip past the following question
 	answers[activeQuestion.value.key] = value;
+	// preventScroll: focusing the still-clipped textarea mid-animation would
+	// otherwise scroll-jump the page
+	if (value === "other") nextTick(() => otherInput.value?.el?.focus({ preventScroll: true }));
 }
 
 function goBack() {
@@ -161,26 +211,46 @@ function goBack() {
 
 function goNext() {
 	const next = stepIndex.value + 1;
-	// entering the template step means the questions are done — persist + capture now
+	// entering the template step means the questions are done, persist + capture now
 	// so any exit from the selector (template, blank, or skip) won't re-trigger the survey.
 	if (stepOrder[next] === "templates") finishQuestions();
 	stepIndex.value = next;
 }
 
+function skip() {
+	finishQuestions(true);
+	stepIndex.value = stepOrder.indexOf("templates");
+}
+
 let submitted = false;
-function finishQuestions() {
+function finishQuestions(skipped = false) {
 	if (submitted) return;
 	submitted = true;
+	const category = answers.use_case && useCaseToCategory[answers.use_case];
+	if (category) templateCategoryFilter.value = category;
 	// Optimistically flag done so the dashboard's redirect guard sees it before the async save lands.
-	if (builderSettings.doc) builderSettings.doc.persona_survey_done = 1;
-	builderSettings.setValue.submit({ persona_survey_done: 1 });
+	// Never let a failed save/capture block the user from moving on.
+	try {
+		if (builderSettings.doc) builderSettings.doc.persona_survey_done = 1;
+		builderSettings.setValue.submit({ persona_survey_done: 1 });
+	} catch (e) {
+		console.error("[persona-survey] failed to persist", e);
+	}
 
 	const props = {
 		role: answers.role || null,
 		use_case: answers.use_case || null,
 		source: answers.source || null,
+		role_other: (answers.role === "other" && otherText.role.trim()) || null,
+		use_case_other: (answers.use_case === "other" && otherText.use_case.trim()) || null,
+		source_other: (answers.source === "other" && otherText.source.trim()) || null,
+		skipped,
 	};
 	if (devForceShow) console.log("[persona-survey] capture", props);
-	telemetry.capture("builder_persona_submitted", props);
+	try {
+		telemetry.capture("builder_persona_submitted", props);
+	} catch (e) {
+		console.error("[persona-survey] failed to capture", e);
+	}
 }
 </script>

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -15,5 +15,8 @@ export interface TemplateGroup {
 	title: string;
 	description?: string;
 	preview?: string;
+	// hub manifest categories used to section the gallery (e.g. ["Marketing", "Portfolio"]);
+	// a group is shown under each of its categories
+	categories?: string[];
 	pages: TemplatePageSummary[];
 }


### PR DESCRIPTION
Redesigns the onboarding persona survey to a chip-based layout and adds category filters to the template picker.

- Chip options with an inline free-text input on "Other" (captured as `*_other` telemetry properties), skip option, e-commerce use-case option; question order is now source → role → use case
- Template gallery gets category filter pills (All / Marketing / Portfolio / ...) driven by the hub catalog's new `categories` field, persisted and pre-selected from the survey's use-case answer
- Backward compatible: hubs without `categories` render the plain grid as before

Hub counterpart: frappe/builder_hub PR adding `categories` to group manifests.

| Survey | Other input |
| --- | --- |
| ![question](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets-persona-survey/pr_question.png) | ![other](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets-persona-survey/pr_other_input.png) |

| Post-survey picker | New page dialog |
| --- | --- |
| ![gallery](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets-persona-survey/pr_gallery.png) | ![dialog](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets-persona-survey/pr_dialog.png) |
