### PR TITLE
feat: dim images by default in dark mode

### DIFF
--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1220,6 +1220,8 @@ component.update({
 				'src="/files/another-dark-mode-image.png"'
 				in get_html_for(content, "tag", "img", index=1, only_content=False)
 			)
+			self.assertTrue("--builder-image-dim: brightness(0.85) contrast(1.05)" in content)
+			self.assertTrue("img { filter: var(--builder-image-dim, none) }" in content)
 		finally:
 			page.delete()
 

--- a/builder/templates/generators/webpage_scripts.html
+++ b/builder/templates/generators/webpage_scripts.html
@@ -24,6 +24,10 @@
 :root[data-prefers-color-scheme="light"], :root[data-theme="light"] { color-scheme: light }
 :root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { color-scheme: dark }
 ::selection { background: Highlight; color: HighlightText }
+img { filter: var(--builder-image-dim, none) }
+picture img { filter: none }
+@media (prefers-color-scheme: dark) { :root:not([data-prefers-color-scheme="light"]):not([data-theme="light"]) { --builder-image-dim: brightness(0.85) contrast(1.05) } }
+:root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { --builder-image-dim: brightness(0.85) contrast(1.05) }
 </style>
 {% if has_dual_mode_image %}
 <script>

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -204,11 +204,11 @@ const attributes = computed(() => {
 	};
 
 	if (props.block.isImage() && !props.preview) {
-		if (builderStore.canvasDarkMode && attribs.darkSrc) {
-			attribs.src = attribs.darkSrc;
-		}
-		if (attribs.darkSrc && !attribs.src) {
-			attribs.src = attribs.darkSrc;
+		if (attribs.darkSrc) {
+			if (builderStore.canvasDarkMode || !attribs.src) {
+				attribs.src = attribs.darkSrc;
+			}
+			attribs["data-dark-src"] = "";
 		}
 		delete attribs.darkSrc;
 	}

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -512,4 +512,9 @@ const renderedBreakpoints = computed(() => canvasProps.breakpoints.filter((bp) =
 		line-height: revert;
 	}
 }
+
+/* mirrors the published-page default in webpage_scripts.html */
+.scheme-dark img:not([data-dark-src]) {
+	filter: brightness(0.85) contrast(1.05);
+}
 </style>


### PR DESCRIPTION
Images without a dark variant currently render at full brightness when a page is viewed in dark mode, which makes them glare against dark backgrounds. This applies a subtle default dim, `brightness(0.85) contrast(1.05)`, to `img` elements whenever the effective color scheme is dark.

### How it works

- The published page sets a `--builder-image-dim` variable using the same scheme-resolution rules already used for `color-scheme`: system preference via media query, overridable by the manual `data-theme` / `data-prefers-color-scheme` toggles and the "disable auto dark mode" setting. All images pick it up via `filter: var(--builder-image-dim, none)`.
- The editor canvas mirrors the behavior through its dark mode toggle, so what you see while editing matches the published page.

### Opt-outs (no new settings)

- Images with a dedicated dark variant (`darkSrc`) are never dimmed, since they already have a purpose-made dark asset.
- Any filter set on an image block overrides the default (class/inline styles win over the element-level rule), so setting `brightness(1)` opts a single image out.
- Background images are intentionally not covered; they usually double as design surfaces.

### Before / after (system dark mode)

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/dark-img-dim/before-dark.png) | ![after](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/dark-img-dim/after-dark.png) |

Light mode rendering is unchanged.
