### PR TITLE
fix: declare color-scheme in head to avoid light flash on dark pages

### DIFF
--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -23,6 +23,17 @@
 	<link rel="icon" href="{{ favicon_dark or favicon or '/assets/builder/images/frappe_white.png' }}"  media="(prefers-color-scheme: dark)"/>
 	{% block meta_block %}{% include "templates/includes/meta_block.html" %}{% endblock %}
 	<link rel="stylesheet" href="/assets/builder/reset.css?v=6" media="screen">
+	<style>
+	:root { color-scheme: light dark }
+	:root { background: transparent; color: CanvasText }
+	:root[data-prefers-color-scheme="light"], :root[data-theme="light"] { color-scheme: light }
+	:root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { color-scheme: dark }
+	::selection { background: Highlight; color: HighlightText }
+	img { filter: var(--builder-image-dim, none) }
+	picture img { filter: none }
+	@media (prefers-color-scheme: dark) { :root:not([data-prefers-color-scheme="light"]):not([data-theme="light"]) { --builder-image-dim: brightness(0.85) contrast(1.05) } }
+	:root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { --builder-image-dim: brightness(0.85) contrast(1.05) }
+	</style>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	{% for font_url in font_urls %}

--- a/builder/templates/generators/webpage_scripts.html
+++ b/builder/templates/generators/webpage_scripts.html
@@ -18,17 +18,6 @@
 {const c=document.cookie,show=window.matchMedia("(min-width:768px)").matches&&c.includes("user_id=")&&!c.includes("user_id=Guest")&&!c.includes("system_user=no;");if(show){const link=document.createElement("a");link.rel="nofollow";link.href="{{ editor_link }}";link.target="editor-{{ page_name }}";link.style.cssText="position:fixed;bottom:40px;right:50px;height:35px;width:35px;opacity:.1";link.innerHTML='<img src="/assets/builder/frontend/builder_logo.png" alt="Edit in Builder" style="box-shadow:#bdbdbd 0 0 5px;border-radius:10px"/>';link.addEventListener("mouseover",()=>link.style.opacity="1");link.addEventListener("mouseout",()=>link.style.opacity=".1");document.body.appendChild(link)}}
 </script>
 {% endif %}
-<style>
-:root { color-scheme: light dark }
-:root { background: transparent; color: CanvasText }
-:root[data-prefers-color-scheme="light"], :root[data-theme="light"] { color-scheme: light }
-:root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { color-scheme: dark }
-::selection { background: Highlight; color: HighlightText }
-img { filter: var(--builder-image-dim, none) }
-picture img { filter: none }
-@media (prefers-color-scheme: dark) { :root:not([data-prefers-color-scheme="light"]):not([data-theme="light"]) { --builder-image-dim: brightness(0.85) contrast(1.05) } }
-:root[data-prefers-color-scheme="dark"], :root[data-theme="dark"] { --builder-image-dim: brightness(0.85) contrast(1.05) }
-</style>
 {% if has_dual_mode_image %}
 <script>
 (function(){function s(){var t=document.documentElement.getAttribute('data-theme')||document.documentElement.getAttribute('data-prefers-color-scheme');document.querySelectorAll('picture source[data-scheme="dark"]').forEach(function(s){s.media=t==='dark'?'all':t==='light'?'not all':'(prefers-color-scheme: dark)';});}new MutationObserver(s).observe(document.documentElement,{attributes:true,attributeFilter:['data-theme','data-prefers-color-scheme']});s();})();


### PR DESCRIPTION
## Problem

The `color-scheme` rules (`:root { color-scheme: light dark }` + the `data-prefers-color-scheme`/`data-theme` pins and `--builder-image-dim`) were emitted by `webpage_scripts.html`, which is appended as the **last child of `<body>`**. On a real page they end up ~15 lines from the bottom of the document.

Until that late style block parses, the document's color scheme is the default (light), so every `light-dark()` variable resolves to its light variant and the first paint is light; the page flips to dark once the tail styles land. For dark-mode users this shows as a flash of light theme on every load (observed on frappe.io).

## Fix

Move the style block into the `<head>` of `webpage.html`, right after `reset.css`, so the scheme is known before first paint. `{{ style }}`, font links and page stylesheets still load after it, so overrides behave exactly as before. No behaviour change other than the scheme (and image dimming) applying from the first frame.