### PR TITLE
fix: modernize published page head

### DIFF
--- a/builder/templates/generators/webpage.html
+++ b/builder/templates/generators/webpage.html
@@ -6,8 +6,8 @@
 	<base href="{{ base_url }}">
 	{% endif %}
 	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="color-scheme" content="{% if disable_auto_dark_mode %}light{% elif prefers_color_scheme %}{{ prefers_color_scheme }}{% else %}light dark{% endif %}">
 	{% if disable_indexing %}
 	<meta name="robots" content="noindex, nofollow">
 	{% endif %}
@@ -46,7 +46,7 @@
 	<link rel="stylesheet" href="/builder_assets/variables.css" media="screen">
 	{%- endif -%}
 	{%- if custom_fonts -%}
-	<style>{% for font in custom_fonts %}@font-face {font-family: "{{ font.font_name }}";src: url("{{ font.font_file }}");}{% endfor %}</style>
+	<style>{% for font in custom_fonts %}@font-face {font-family: "{{ font.font_name }}";src: url("{{ font.font_file }}");font-display: swap;}{% endfor %}</style>
 	{%- endif -%}
 	{% block style %}
 		{%- if styles -%}

--- a/builder/templates/generators/webpage_scripts.html
+++ b/builder/templates/generators/webpage_scripts.html
@@ -1,7 +1,7 @@
 {% block script %}
 {%- if scripts -%}
 {% for script_path in scripts %}
-<script src="{{ script_path }}" defer></script>
+<script src="{{ script_path }}"></script>
 {% endfor %}
 {%- endif -%}
 {%- endblock %}

--- a/builder/templates/generators/webpage_scripts.html
+++ b/builder/templates/generators/webpage_scripts.html
@@ -1,7 +1,7 @@
 {% block script %}
 {%- if scripts -%}
 {% for script_path in scripts %}
-<script src="{{ script_path }}"></script>
+<script src="{{ script_path }}" defer></script>
 {% endfor %}
 {%- endif -%}
 {%- endblock %}


### PR DESCRIPTION
Small head cleanups for published pages:

- **`color-scheme` meta**: lets the browser paint the correct canvas color before CSS loads, avoiding a light flash on dark pages. Mirrors the existing `data-prefers-color-scheme` logic:

  ```html
  <meta name="color-scheme" content="light dark">
  <!-- or "light" / "dark" when auto dark mode is disabled or a scheme is pinned -->
  ```

- **`font-display: swap` for user-uploaded fonts**: text renders in a fallback font while the custom font loads instead of staying invisible.

  ```html
  <style>@font-face {font-family: "Satoshi";src: url("/files/satoshi.woff2");font-display: swap;}</style>
  ```

- Dropped the obsolete `X-UA-Compatible` IE meta.
