### PR TITLE
feat: load real italic faces through the ital axis

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -666,7 +666,11 @@ def get_block_html(blocks: str | list) -> tuple[str, str, dict, bool]:
 
 
 def build_tag(
-	block: dict, state: dict, data_key: dict | None = None, ancestor_font: str | None = None
+	block: dict,
+	state: dict,
+	data_key: dict | None = None,
+	ancestor_font: str | None = None,
+	ancestor_italic: bool = False,
 ) -> bs.Tag:
 	"""
 	Transforms a single block to an HTML tag.
@@ -690,13 +694,27 @@ def build_tag(
 		)
 		or ancestor_font
 	)
+	# font-style cascades exactly like font-family: the block's own value wins,
+	# otherwise italic (or not) is inherited from the ancestor
+	resolved_italic = next(
+		(str(s["fontStyle"]).lower() in ("italic", "oblique") for s in all_styles if s.get("fontStyle")),
+		ancestor_italic,
+	)
 
 	tag = create_html_tag(block, state, ancestor_font=resolved_font)
 
+	if resolved_italic and resolved_font:
+		weight = next((s.get("fontWeight") for s in all_styles if s.get("fontWeight")), 400)
+		register_italic_font(state["font_map"], get_font_family(resolved_font), weight)
+
 	if is_repeater_block(block):
-		render_repeater_children(tag, block, data_key, state, ancestor_font=resolved_font)
+		render_repeater_children(
+			tag, block, data_key, state, ancestor_font=resolved_font, ancestor_italic=resolved_italic
+		)
 	else:
-		render_children(tag, block, data_key, state, ancestor_font=resolved_font)
+		render_children(
+			tag, block, data_key, state, ancestor_font=resolved_font, ancestor_italic=resolved_italic
+		)
 
 	attach_client_script(tag, block, state)
 
@@ -937,32 +955,20 @@ def add_inner_html_content(tag: bs.Tag, block: dict, state: dict, ancestor_font:
 
 
 def set_italics_from_html(soup, font_map, ancestor_font: str | None = None):
-	"""Register italic usage that lives inside a block's inner HTML, e.g.
-	`<i>`/`<em>` tags or inline `font-style: italic` spans, so the italic faces
-	are part of the font request instead of being browser-synthesised."""
-
-	def italic_font_for(tag) -> str | None:
-		# an inline font-family wins; otherwise the italic text inherits the
-		# block's resolved font
-		for parent in [tag, *tag.parents]:
-			style = parent.attrs.get("style") if getattr(parent, "attrs", None) else None
-			if style and "font-family" in style:
-				for declaration in style.split(";"):
-					if "font-family" in declaration:
-						return get_font_family(declaration.split(":", 1)[1])
-		return get_font_family(ancestor_font) if ancestor_font else None
-
-	def register(tag):
-		font = italic_font_for(tag)
-		if font and font in font_map:
-			register_italic_font(font_map, font, 400)
-
-	for tag in soup.find_all(["i", "em"]):
-		register(tag)
+	"""Register italics used inside a block's inner HTML: <i>/<em> tags or
+	inline font-style spans, which inherit the block's resolved font."""
+	fallback = get_font_family(ancestor_font) if ancestor_font else None
+	if soup.find(["i", "em"]):
+		register_italic_font(font_map, fallback)
 	for tag in soup.find_all(style=True):
 		style = tag.attrs.get("style", "")
-		if re.search(r"font-style\s*:\s*(italic|oblique)", style):
-			register(tag)
+		if not re.search(r"font-style\s*:\s*(italic|oblique)", style):
+			continue
+		family = None
+		for declaration in style.split(";"):
+			if "font-family" in declaration:
+				family = get_font_family(declaration.split(":", 1)[1])
+		register_italic_font(font_map, family or fallback)
 
 
 def is_repeater_block(block: dict) -> bool:
@@ -971,7 +977,12 @@ def is_repeater_block(block: dict) -> bool:
 
 
 def render_children(
-	tag: bs.Tag, block: dict, data_key: dict | None, state: dict, ancestor_font: str | None = None
+	tag: bs.Tag,
+	block: dict,
+	data_key: dict | None,
+	state: dict,
+	ancestor_font: str | None = None,
+	ancestor_italic: bool = False,
 ):
 	"""Render (non-repeater) children."""
 	for child in block.get("children", []) or []:
@@ -980,14 +991,21 @@ def render_children(
 		child_context = get_block_context(child, child_props, component_id)
 		child_context["visibility_key"] = get_visibility_condition_key(child, data_key)
 
-		child_tag = build_tag(child, state, data_key, ancestor_font=ancestor_font)
+		child_tag = build_tag(
+			child, state, data_key, ancestor_font=ancestor_font, ancestor_italic=ancestor_italic
+		)
 
 		append_child_with_context(tag, child_tag, child_context)
 		cleanup_props_stack(child_props, state["standard_props_stack"])
 
 
 def render_repeater_children(
-	tag: bs.Tag, block: dict, data_key: dict | None, state: dict, ancestor_font: str | None = None
+	tag: bs.Tag,
+	block: dict,
+	data_key: dict | None,
+	state: dict,
+	ancestor_font: str | None = None,
+	ancestor_italic: bool = False,
 ):
 	"""Render children for repeater blocks (with for loops)."""
 	loop_info = get_loop_info(block, data_key, state["standard_props_stack"])
@@ -1004,7 +1022,9 @@ def render_repeater_children(
 		data_key_key = block.get("dataKey").get("key")
 		child_context["default_props"] = extract_loop_variables(data_key_key, state["standard_props_stack"])
 
-	child_tag = build_tag(child, state, loop_info["data_key"], ancestor_font=ancestor_font)
+	child_tag = build_tag(
+		child, state, loop_info["data_key"], ancestor_font=ancestor_font, ancestor_italic=ancestor_italic
+	)
 
 	append_child_with_context(tag, child_tag, child_context)
 	cleanup_props_stack(child_props, state["standard_props_stack"])
@@ -1403,9 +1423,8 @@ def set_fonts(styles, font_map, inherited_font=None):
 	}
 	for style in styles:
 		font = style.get("fontFamily")
-		is_italic = str(style.get("fontStyle") or "").lower() in ("italic", "oblique")
-		if not font and inherited_font and (style.get("fontWeight") or is_italic):
-			# fontWeight/fontStyle is set but fontFamily is not — use the ancestor font
+		if not font and style.get("fontWeight") and inherited_font:
+			# fontWeight is set but fontFamily is not — use explicitly passed ancestor font
 			font = inherited_font
 		if font:
 			# Use the first family from a fallback list, e.g. "Inter, sans-serif" -> "Inter"
@@ -1431,9 +1450,6 @@ def set_fonts(styles, font_map, inherited_font=None):
 			else:
 				font_map[font] = {"weights": [weight]}
 
-			if is_italic:
-				register_italic_font(font_map, font, weight)
-
 
 def normalize_font_weights(font_map: dict) -> None:
 	"""Make each font's weights render-ready for the Google Fonts request: numeric,
@@ -1444,11 +1460,16 @@ def normalize_font_weights(font_map: dict) -> None:
 		options["weights"] = sorted(weights)
 
 
-def register_italic_font(font_map: dict, font: str, weight: int) -> None:
-	"""Record that `font` is used in italic at `weight` (used by the URL builder)."""
-	options = font_map.get(font)
+def register_italic_font(font_map: dict, font: str | None, weight=400) -> None:
+	"""Record that a collected font is used in italic at `weight`. Fonts that
+	set_fonts skipped (system fonts, CSS stacks) are ignored here too."""
+	options = font_map.get(font) if font else None
 	if options is None:
-		options = font_map[font] = {"weights": [weight]}
+		return
+	try:
+		weight = int(str(weight))
+	except (TypeError, ValueError):
+		weight = 400
 	italics = options.setdefault("italics", [])
 	if weight not in italics:
 		italics.append(weight)

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1476,13 +1476,9 @@ def register_italic_font(font_map: dict, font: str | None, weight=400) -> None:
 def get_google_font_urls(font_map: dict) -> list[str]:
 	"""Build one combined Google Fonts stylesheet URL per font family.
 
-	Families used only upright keep the exact `wght@...` URL shape they always
-	had. When italics are used, the same single request carries them via the
-	`ital` axis. The css2 API silently drops tuples a family doesn't ship
-	(upright faces still load, the browser falls back to synthetic italics), so
-	the axis is safe to request without consulting any font catalog; 400 italic
-	is always included so a family missing the exact italic instance still
-	serves its regular italic face."""
+	Families used in italic get the `ital` axis with 400 always included as a
+	fallback instance. css2 silently drops tuples a family doesn't ship, so
+	no font catalog is needed."""
 	normalize_font_weights(font_map)
 	urls = []
 	for font, options in font_map.items():

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -3,7 +3,10 @@
 
 import copy
 import hashlib
+import json
+import os
 import re
+from functools import lru_cache
 from typing import Any
 from urllib.parse import quote_plus
 
@@ -851,7 +854,7 @@ def create_html_tag(block: dict, state: dict, ancestor_font: str | None = None) 
 	classes = build_tag_classes(block, state, ancestor_font=ancestor_font)
 	tag.attrs["class"] = " ".join(classes)
 
-	add_inner_html_content(tag, block, state)
+	add_inner_html_content(tag, block, state, ancestor_font=ancestor_font)
 
 	if picture_tag is not None:
 		picture_tag.append(tag)
@@ -919,7 +922,7 @@ def generate_and_apply_styles(block: dict, state: dict, ancestor_font: str | Non
 	return style_class
 
 
-def add_inner_html_content(tag: bs.Tag, block: dict, state: dict):
+def add_inner_html_content(tag: bs.Tag, block: dict, state: dict, ancestor_font: str | None = None):
 	"""Add inner HTML content to the tag."""
 	inner_content = block.get("innerHTML")
 	if inner_content:
@@ -928,8 +931,38 @@ def add_inner_html_content(tag: bs.Tag, block: dict, state: dict):
 			inner_content = str(inner_content)
 		inner_soup = bs.BeautifulSoup(inner_content, "html.parser")
 		set_fonts_from_html(inner_soup, state["font_map"])
+		set_italics_from_html(inner_soup, state["font_map"], ancestor_font)
 		if inner_soup.contents:
 			tag.append(inner_soup)
+
+
+def set_italics_from_html(soup, font_map, ancestor_font: str | None = None):
+	"""Register italic usage that lives inside a block's inner HTML, e.g.
+	`<i>`/`<em>` tags or inline `font-style: italic` spans, so the italic faces
+	are part of the font request instead of being browser-synthesised."""
+
+	def italic_font_for(tag) -> str | None:
+		# an inline font-family wins; otherwise the italic text inherits the
+		# block's resolved font
+		for parent in [tag, *tag.parents]:
+			style = parent.attrs.get("style") if getattr(parent, "attrs", None) else None
+			if style and "font-family" in style:
+				for declaration in style.split(";"):
+					if "font-family" in declaration:
+						return get_font_family(declaration.split(":", 1)[1])
+		return get_font_family(ancestor_font) if ancestor_font else None
+
+	def register(tag):
+		font = italic_font_for(tag)
+		if font and font in font_map:
+			register_italic_font(font_map, font, 400)
+
+	for tag in soup.find_all(["i", "em"]):
+		register(tag)
+	for tag in soup.find_all(style=True):
+		style = tag.attrs.get("style", "")
+		if re.search(r"font-style\s*:\s*(italic|oblique)", style):
+			register(tag)
 
 
 def is_repeater_block(block: dict) -> bool:
@@ -1370,8 +1403,9 @@ def set_fonts(styles, font_map, inherited_font=None):
 	}
 	for style in styles:
 		font = style.get("fontFamily")
-		if not font and style.get("fontWeight") and inherited_font:
-			# fontWeight is set but fontFamily is not — use explicitly passed ancestor font
+		is_italic = str(style.get("fontStyle") or "").lower() in ("italic", "oblique")
+		if not font and inherited_font and (style.get("fontWeight") or is_italic):
+			# fontWeight/fontStyle is set but fontFamily is not — use the ancestor font
 			font = inherited_font
 		if font:
 			# Use the first family from a fallback list, e.g. "Inter, sans-serif" -> "Inter"
@@ -1397,6 +1431,9 @@ def set_fonts(styles, font_map, inherited_font=None):
 			else:
 				font_map[font] = {"weights": [weight]}
 
+			if is_italic:
+				register_italic_font(font_map, font, weight)
+
 
 def normalize_font_weights(font_map: dict) -> None:
 	"""Make each font's weights render-ready for the Google Fonts request: numeric,
@@ -1407,14 +1444,75 @@ def normalize_font_weights(font_map: dict) -> None:
 		options["weights"] = sorted(weights)
 
 
+def register_italic_font(font_map: dict, font: str, weight: int) -> None:
+	"""Record that `font` is used in italic at `weight` (used by the URL builder)."""
+	options = font_map.get(font)
+	if options is None:
+		options = font_map[font] = {"weights": [weight]}
+	italics = options.setdefault("italics", [])
+	if weight not in italics:
+		italics.append(weight)
+		italics.sort()
+
+
+@lru_cache(maxsize=1)
+def get_google_font_italic_weights() -> dict[str, tuple[int, ...]]:
+	"""Map of Google font family -> italic instance weights it actually ships,
+	read from the same catalog the editor's font picker uses. Families without
+	italic faces are absent, so we never emit an `ital` axis Google would reject."""
+	path = os.path.abspath(
+		os.path.join(frappe.get_app_path("builder"), "..", "frontend", "src", "utils", "fontList.json")
+	)
+	try:
+		with open(path, encoding="utf-8") as f:
+			catalog = json.load(f)
+	except (OSError, ValueError):
+		return {}
+	italic_map = {}
+	for item in catalog.get("items", []):
+		weights = set()
+		for variant in item.get("variants", []):
+			if variant == "italic":
+				weights.add(400)
+			elif variant.endswith("italic"):
+				try:
+					weights.add(int(variant[: -len("italic")]))
+				except ValueError:
+					continue
+		if weights:
+			italic_map[item.get("family")] = tuple(sorted(weights))
+	return italic_map
+
+
+def resolve_italic_weights(requested: list[int], available: tuple[int, ...] | None) -> list[int]:
+	"""Snap requested italic weights to instances the family really has, so the
+	stylesheet request stays valid. No italic faces -> no `ital` axis at all."""
+	if not requested or not available:
+		return []
+	return sorted({min(available, key=lambda a: (abs(a - weight), a)) for weight in requested})
+
+
 def get_google_font_urls(font_map: dict) -> list[str]:
-	"""Build one combined Google Fonts stylesheet URL per font family."""
+	"""Build one combined Google Fonts stylesheet URL per font family.
+
+	Families used only upright keep the exact `wght@...` URL shape they always
+	had. When italics are used AND the family ships italic faces, the same
+	single request carries them via the `ital` axis instead."""
 	normalize_font_weights(font_map)
+	italic_catalog = get_google_font_italic_weights()
 	urls = []
 	for font, options in font_map.items():
 		family = quote_plus(font)
-		weights = ";".join(str(weight) for weight in options["weights"])
-		urls.append(f"https://fonts.googleapis.com/css2?family={family}:wght@{weights}&display=swap")
+		requested_italics = sorted({int(weight) for weight in options.get("italics", [])})
+		italics = resolve_italic_weights(requested_italics, italic_catalog.get(font))
+		if italics:
+			tuples = [f"0,{weight}" for weight in options["weights"]]
+			tuples += [f"1,{weight}" for weight in italics]
+			axis = ";".join(tuples)
+			urls.append(f"https://fonts.googleapis.com/css2?family={family}:ital,wght@{axis}&display=swap")
+		else:
+			weights = ";".join(str(weight) for weight in options["weights"])
+			urls.append(f"https://fonts.googleapis.com/css2?family={family}:wght@{weights}&display=swap")
 	return urls
 
 

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -3,10 +3,7 @@
 
 import copy
 import hashlib
-import json
-import os
 import re
-from functools import lru_cache
 from typing import Any
 from urllib.parse import quote_plus
 
@@ -1476,57 +1473,22 @@ def register_italic_font(font_map: dict, font: str | None, weight=400) -> None:
 		italics.sort()
 
 
-@lru_cache(maxsize=1)
-def get_google_font_italic_weights() -> dict[str, tuple[int, ...]]:
-	"""Map of Google font family -> italic instance weights it actually ships,
-	read from the same catalog the editor's font picker uses. Families without
-	italic faces are absent, so we never emit an `ital` axis Google would reject."""
-	path = os.path.abspath(
-		os.path.join(frappe.get_app_path("builder"), "..", "frontend", "src", "utils", "fontList.json")
-	)
-	try:
-		with open(path, encoding="utf-8") as f:
-			catalog = json.load(f)
-	except (OSError, ValueError):
-		return {}
-	italic_map = {}
-	for item in catalog.get("items", []):
-		weights = set()
-		for variant in item.get("variants", []):
-			if variant == "italic":
-				weights.add(400)
-			elif variant.endswith("italic"):
-				try:
-					weights.add(int(variant[: -len("italic")]))
-				except ValueError:
-					continue
-		if weights:
-			italic_map[item.get("family")] = tuple(sorted(weights))
-	return italic_map
-
-
-def resolve_italic_weights(requested: list[int], available: tuple[int, ...] | None) -> list[int]:
-	"""Snap requested italic weights to instances the family really has, so the
-	stylesheet request stays valid. No italic faces -> no `ital` axis at all."""
-	if not requested or not available:
-		return []
-	return sorted({min(available, key=lambda a: (abs(a - weight), a)) for weight in requested})
-
-
 def get_google_font_urls(font_map: dict) -> list[str]:
 	"""Build one combined Google Fonts stylesheet URL per font family.
 
 	Families used only upright keep the exact `wght@...` URL shape they always
-	had. When italics are used AND the family ships italic faces, the same
-	single request carries them via the `ital` axis instead."""
+	had. When italics are used, the same single request carries them via the
+	`ital` axis. The css2 API silently drops tuples a family doesn't ship
+	(upright faces still load, the browser falls back to synthetic italics), so
+	the axis is safe to request without consulting any font catalog; 400 italic
+	is always included so a family missing the exact italic instance still
+	serves its regular italic face."""
 	normalize_font_weights(font_map)
-	italic_catalog = get_google_font_italic_weights()
 	urls = []
 	for font, options in font_map.items():
 		family = quote_plus(font)
-		requested_italics = sorted({int(weight) for weight in options.get("italics", [])})
-		italics = resolve_italic_weights(requested_italics, italic_catalog.get(font))
-		if italics:
+		italics = sorted({400, *(int(weight) for weight in options.get("italics", []))})
+		if options.get("italics"):
 			tuples = [f"0,{weight}" for weight in options["weights"]]
 			tuples += [f"1,{weight}" for weight in italics]
 			axis = ";".join(tuples)

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1326,10 +1326,8 @@ component.update({
 		)
 
 	def test_get_google_font_urls_with_italics(self):
-		"""Fonts used in italic get the ital axis in the same single request.
-		400 italic rides along with heavier italic weights so a family missing
-		the exact instance still serves its regular italic face (css2 silently
-		drops tuples a family doesn't ship, so extra tuples are harmless)."""
+		"""Fonts used in italic get the ital axis in the same single request,
+		with 400 italic always included as a fallback instance."""
 		from builder.builder.doctype.builder_page.builder_page import get_google_font_urls
 
 		font_map = {

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1325,6 +1325,84 @@ component.update({
 			],
 		)
 
+	def test_get_google_font_urls_with_italics(self):
+		"""Fonts used in italic get the ital axis in the same single request,
+		limited to italic instances the family actually ships."""
+		from builder.builder.doctype.builder_page.builder_page import get_google_font_urls
+
+		font_map = {
+			# Roboto ships italics at 100/300/400/500/700/900
+			"Roboto": {"weights": [400, 700], "italics": [400]},
+			# Oswald has no italic faces: the ital axis must NOT be emitted,
+			# otherwise Google rejects the whole stylesheet request
+			"Oswald": {"weights": [500], "italics": [500]},
+			# untouched fonts keep the exact legacy URL shape
+			"Open Sans": {"weights": [400]},
+		}
+		urls = get_google_font_urls(font_map)
+		self.assertEqual(
+			urls,
+			[
+				"https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap",
+				"https://fonts.googleapis.com/css2?family=Oswald:wght@400;500&display=swap",
+				"https://fonts.googleapis.com/css2?family=Open+Sans:wght@400&display=swap",
+			],
+		)
+
+	def test_resolve_italic_weights_snaps_to_available_instances(self):
+		from builder.builder.doctype.builder_page.builder_page import resolve_italic_weights
+
+		# 600 italic requested but the family only ships 400/700: snap to nearest
+		self.assertEqual(resolve_italic_weights([600], (400, 700)), [700])
+		self.assertEqual(resolve_italic_weights([450], (400, 700)), [400])
+		self.assertEqual(resolve_italic_weights([400, 700], (400, 700)), [400, 700])
+		self.assertEqual(resolve_italic_weights([400], None), [])
+		self.assertEqual(resolve_italic_weights([], (400,)), [])
+
+	def test_set_fonts_collects_font_style_italics(self):
+		from builder.builder.doctype.builder_page.builder_page import set_fonts
+
+		font_map = {}
+		set_fonts(
+			[
+				{"fontFamily": "Fraunces", "fontWeight": "600", "fontStyle": "italic"},
+				{"fontFamily": "Fraunces", "fontWeight": "400"},
+			],
+			font_map,
+		)
+		self.assertEqual(font_map["Fraunces"]["weights"], [400, 600])
+		self.assertEqual(font_map["Fraunces"]["italics"], [600])
+
+	def test_set_fonts_italic_with_inherited_family(self):
+		"""fontStyle set without fontFamily should register italics on the ancestor font."""
+		from builder.builder.doctype.builder_page.builder_page import set_fonts
+
+		font_map = {}
+		set_fonts([{"fontStyle": "italic"}], font_map, inherited_font="Newsreader")
+		self.assertEqual(font_map["Newsreader"]["italics"], [400])
+
+	def test_set_italics_from_html(self):
+		"""<i>/<em> and inline font-style inside innerHTML register italic usage
+		for the block's resolved font."""
+		import bs4 as bs
+
+		from builder.builder.doctype.builder_page.builder_page import set_italics_from_html
+
+		font_map = {"Fraunces": {"weights": [400]}, "Lora": {"weights": [400]}}
+		soup = bs.BeautifulSoup(
+			"Fire is the <i>only</i> recipe and "
+			'<span style="font-family: Lora; font-style: italic">this too</span>',
+			"html.parser",
+		)
+		set_italics_from_html(soup, font_map, ancestor_font="Fraunces")
+		self.assertEqual(font_map["Fraunces"].get("italics"), [400])
+		self.assertEqual(font_map["Lora"].get("italics"), [400])
+
+		# fonts that never made it into the map (e.g. system fonts) are ignored
+		font_map_2 = {}
+		set_italics_from_html(bs.BeautifulSoup("<i>hi</i>", "html.parser"), font_map_2, "Arial")
+		self.assertEqual(font_map_2, {})
+
 	def test_set_fonts_inherits_font_family_from_ancestor(self):
 		"""set_fonts should use inherited_font when a style has fontWeight but no fontFamily."""
 		from builder.builder.doctype.builder_page.builder_page import set_fonts

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1326,16 +1326,15 @@ component.update({
 		)
 
 	def test_get_google_font_urls_with_italics(self):
-		"""Fonts used in italic get the ital axis in the same single request,
-		limited to italic instances the family actually ships."""
+		"""Fonts used in italic get the ital axis in the same single request.
+		400 italic rides along with heavier italic weights so a family missing
+		the exact instance still serves its regular italic face (css2 silently
+		drops tuples a family doesn't ship, so extra tuples are harmless)."""
 		from builder.builder.doctype.builder_page.builder_page import get_google_font_urls
 
 		font_map = {
-			# Roboto ships italics at 100/300/400/500/700/900
 			"Roboto": {"weights": [400, 700], "italics": [400]},
-			# Oswald has no italic faces: the ital axis must NOT be emitted,
-			# otherwise Google rejects the whole stylesheet request
-			"Oswald": {"weights": [500], "italics": [500]},
+			"Lora": {"weights": [400], "italics": [600]},
 			# untouched fonts keep the exact legacy URL shape
 			"Open Sans": {"weights": [400]},
 		}
@@ -1344,20 +1343,10 @@ component.update({
 			urls,
 			[
 				"https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap",
-				"https://fonts.googleapis.com/css2?family=Oswald:wght@400;500&display=swap",
+				"https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;1,400;1,600&display=swap",
 				"https://fonts.googleapis.com/css2?family=Open+Sans:wght@400&display=swap",
 			],
 		)
-
-	def test_resolve_italic_weights_snaps_to_available_instances(self):
-		from builder.builder.doctype.builder_page.builder_page import resolve_italic_weights
-
-		# 600 italic requested but the family only ships 400/700: snap to nearest
-		self.assertEqual(resolve_italic_weights([600], (400, 700)), [700])
-		self.assertEqual(resolve_italic_weights([450], (400, 700)), [400])
-		self.assertEqual(resolve_italic_weights([400, 700], (400, 700)), [400, 700])
-		self.assertEqual(resolve_italic_weights([400], None), [])
-		self.assertEqual(resolve_italic_weights([], (400,)), [])
 
 	def test_italics_cascade_like_font_family(self):
 		"""Italic usage is resolved on the rendered block tree with CSS cascade

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -1359,27 +1359,38 @@ component.update({
 		self.assertEqual(resolve_italic_weights([400], None), [])
 		self.assertEqual(resolve_italic_weights([], (400,)), [])
 
-	def test_set_fonts_collects_font_style_italics(self):
-		from builder.builder.doctype.builder_page.builder_page import set_fonts
+	def test_italics_cascade_like_font_family(self):
+		"""Italic usage is resolved on the rendered block tree with CSS cascade
+		semantics, not per style dict."""
+		from builder.builder.doctype.builder_page.builder_page import get_block_html
 
-		font_map = {}
-		set_fonts(
-			[
-				{"fontFamily": "Fraunces", "fontWeight": "600", "fontStyle": "italic"},
-				{"fontFamily": "Fraunces", "fontWeight": "400"},
-			],
-			font_map,
+		def block(styles, children=None, element="div"):
+			return {"element": element, "baseStyles": styles, "children": children or []}
+
+		# child sets fontStyle without a family: italics land on the ancestor font
+		_, _, font_map, _ = get_block_html(
+			[block({"fontFamily": "Fraunces"}, [block({"fontStyle": "italic", "fontWeight": "600"})])]
 		)
-		self.assertEqual(font_map["Fraunces"]["weights"], [400, 600])
 		self.assertEqual(font_map["Fraunces"]["italics"], [600])
 
-	def test_set_fonts_italic_with_inherited_family(self):
-		"""fontStyle set without fontFamily should register italics on the ancestor font."""
-		from builder.builder.doctype.builder_page.builder_page import set_fonts
+		# italic parent, child only switches family: font-style inherits, so the
+		# child family needs its italic faces too
+		_, _, font_map, _ = get_block_html(
+			[block({"fontFamily": "Fraunces", "fontStyle": "italic"}, [block({"fontFamily": "Lora"})])]
+		)
+		self.assertEqual(font_map["Fraunces"]["italics"], [400])
+		self.assertEqual(font_map["Lora"]["italics"], [400])
 
-		font_map = {}
-		set_fonts([{"fontStyle": "italic"}], font_map, inherited_font="Newsreader")
-		self.assertEqual(font_map["Newsreader"]["italics"], [400])
+		# a child resetting fontStyle: normal breaks the cascade again
+		_, _, font_map, _ = get_block_html(
+			[
+				block(
+					{"fontFamily": "Fraunces", "fontStyle": "italic"},
+					[block({"fontFamily": "Lora", "fontStyle": "normal"})],
+				)
+			]
+		)
+		self.assertNotIn("italics", font_map["Lora"])
 
 	def test_set_italics_from_html(self):
 		"""<i>/<em> and inline font-style inside innerHTML register italic usage


### PR DESCRIPTION
## Problem

The Google Fonts loader on published pages only carries the `wght` axis. Any italic text (`fontStyle: italic` on a block, or `<i>`/`<em>` inside `innerHTML`) renders as a browser-synthesised slant instead of the family's real italic faces. Template authors currently work around it with a hand-written `@import ...:ital@...` CSS client script per template.

Synthesised shear (top) vs the real italic faces this PR loads (bottom), Bodoni Moda:

<img src="https://raw.githubusercontent.com/surajshetty3416/builder/assets-font-loader-italics/zoom_compare.png" width="680">

<details>
<summary>Full before/after (Fraunces + Bodoni Moda)</summary>

<img src="https://raw.githubusercontent.com/surajshetty3416/builder/assets-font-loader-italics/fonts_before_after.png" width="900">

</details>

## What this does

Italic usage is resolved on the block tree with CSS cascade semantics, in `build_tag`, right where the font-family cascade is already resolved: a block's own `fontStyle` wins, otherwise italic is inherited from the ancestor exactly like `ancestor_font`. That covers:

- `fontStyle: italic`/`oblique` on the block itself (any device style),
- a child that sets `fontStyle` without a family → italics land on the inherited font,
- an italic parent whose child only switches `font-family` → the child still renders italic (font-style inherits in CSS), so the child family gets its italic faces too; a child resetting `fontStyle: normal` breaks the cascade again,
- `<i>`/`<em>` tags and inline `font-style: italic` spans inside `innerHTML`.

`set_fonts` itself is untouched. Italic faces are folded into the **same single stylesheet request** per family via the `ital` axis:

```
before  https://fonts.googleapis.com/css2?family=Fraunces:wght@350;400;500&display=swap
after   https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,350;0,400;0,500;1,300;1,400&display=swap
```



No font catalog is consulted for this: the css2 API silently drops `ital`/`wght` tuples a family doesn't ship (upright faces still load and the browser falls back to synthetic italics, i.e. today's behaviour), so the `ital` axis is safe to request unconditionally. 400 italic always rides along, so a family missing the exact italic instance still serves its regular italic face. Families used only upright keep byte-identical URLs to today.

