### PR TITLE
fix: UX improvements for per-corner controls

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -58,6 +58,7 @@ declare module 'vue' {
     ComponentUpdates: typeof import('./src/components/ComponentUpdates.vue')['default']
     ContextMenu: typeof import('./src/components/ContextMenu.vue')['default']
     CSS: typeof import('./src/components/Icons/CSS.vue')['default']
+    CursorTooltip: typeof import('./src/components/CursorTooltip.vue')['default']
     CustomSearchPanel: typeof import('./src/components/Controls/CodeMirror/CustomSearchPanel.vue')['default']
     DashboardContent: typeof import('./src/components/DashboardContent.vue')['default']
     DashboardHead: typeof import('./src/components/DashboardHead.vue')['default']

--- a/frontend/src/components/BorderRadiusControl.vue
+++ b/frontend/src/components/BorderRadiusControl.vue
@@ -25,7 +25,7 @@
 import SplitModeInput from "@/components/Controls/SplitModeInput.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import blockController from "@/utils/blockController";
-import { expandBoxShorthand, normalizeValueWithUnits } from "@/utils/cssUtils";
+import { collapseBoxShorthand, expandBoxShorthand, normalizeValueWithUnits } from "@/utils/cssUtils";
 import { RADIUS_UNIT_OPTIONS } from "@/utils/unitOptions";
 import { ref, watch } from "vue";
 
@@ -51,7 +51,7 @@ const ensureRoundedContentIsClipped = (value: BoxValue) => {
 
 const toControlValues = (value: unknown) => expandBoxShorthand(value);
 const normalize = (value: BoxValue) => normalizeValueWithUnits(String(value || "0"), "px");
-const toModelValue = (parts: BoxValue[]) => parts.join(" ");
+const toModelValue = (parts: BoxValue[]) => collapseBoxShorthand(parts);
 const getMergedValue = (parts: BoxValue[]) => parts[0] ?? "0px";
 const getControlAttrs = (variant: string | null) => {
 	const key = variant ?? "main";

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -1,4 +1,6 @@
 <template>
+	<CursorTooltip v-if="updating" :position="cursorPosition">{{ borderRadius }}</CursorTooltip>
+
 	<div
 		ref="handler"
 		class="border-radius-resize pointer-events-auto absolute h-[10px] w-[10px] cursor-pointer rounded-full border-2 border-blue-400 bg-white"
@@ -7,13 +9,7 @@
 			'border-purple-400': targetBlock.isExtendedFromComponent(),
 		}"
 		:style="handlerPosition"
-		@mousedown.stop="handleRounded">
-		<div
-			v-show="updating"
-			class="absolute left-2 top-2 w-fit rounded-full bg-gray-800 px-3 py-2 text-xs text-white opacity-60">
-			{{ borderRadius }}
-		</div>
-	</div>
+		@mousedown.stop="handleRounded" />
 </template>
 
 <script setup lang="ts">
@@ -22,6 +18,7 @@ import { getNumberFromPx } from "@/utils/helpers";
 import { useElementBounding } from "@vueuse/core";
 import type { Ref } from "vue";
 import { computed, inject, onMounted, reactive, ref, watchEffect } from "vue";
+import CursorTooltip from "./CursorTooltip.vue";
 
 const props = defineProps<{
 	targetBlock: Block;
@@ -30,6 +27,7 @@ const props = defineProps<{
 
 const borderRadius = ref(parseInt(props.target.style.borderRadius, 10) || 0);
 const updating = ref(false);
+const cursorPosition = ref({ x: 0, y: 0 });
 const canvasProps = inject("canvasProps") as CanvasProps;
 const handler = ref() as Ref<HTMLElement>;
 const handlerTop = ref(10);
@@ -74,11 +72,13 @@ const handleRounded = (ev: MouseEvent) => {
 	let lastX = startX;
 	let lastY = startY;
 	updating.value = true;
+	cursorPosition.value = { x: startX, y: startY };
 
 	const handleDimensions = handler.value.getBoundingClientRect();
 
 	const mousemove = (mouseMoveEvent: MouseEvent) => {
 		mouseMoveEvent.preventDefault();
+		cursorPosition.value = { x: mouseMoveEvent.clientX, y: mouseMoveEvent.clientY };
 		const movementX = mouseMoveEvent.clientX - lastX;
 		const movementY = mouseMoveEvent.clientY - lastY;
 		const movement = ((movementX + movementY) / 2) * 2;

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -18,7 +18,7 @@ import { startDrag } from "@/utils/cursor";
 import { getNumberFromPx } from "@/utils/helpers";
 import { useElementBounding } from "@vueuse/core";
 import type { Ref } from "vue";
-import { computed, inject, onMounted, reactive, ref, watchEffect } from "vue";
+import { computed, inject, reactive, ref, watchEffect } from "vue";
 import CursorTooltip from "./CursorTooltip.vue";
 
 const props = defineProps<{
@@ -123,7 +123,7 @@ const handleRounded = (ev: MouseEvent) => {
 	});
 };
 
-onMounted(() => setHandlerPosition(borderRadius.value));
+watchEffect(() => setHandlerPosition(borderRadius.value));
 
 watchEffect(() => {
 	props.targetBlock.getStyle("height");

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -14,6 +14,7 @@
 
 <script setup lang="ts">
 import type Block from "@/block";
+import { startDrag } from "@/utils/cursor";
 import { getNumberFromPx } from "@/utils/helpers";
 import { useElementBounding } from "@vueuse/core";
 import type { Ref } from "vue";
@@ -76,42 +77,38 @@ const handleRounded = (ev: MouseEvent) => {
 
 	const handleDimensions = handler.value.getBoundingClientRect();
 
-	const mousemove = (mouseMoveEvent: MouseEvent) => {
-		mouseMoveEvent.preventDefault();
-		cursorPosition.value = { x: mouseMoveEvent.clientX, y: mouseMoveEvent.clientY };
-		const movementX = mouseMoveEvent.clientX - lastX;
-		const movementY = mouseMoveEvent.clientY - lastY;
-		const movement = ((movementX + movementY) / 2) * 2;
+	startDrag({
+		cursor: window.getComputedStyle(ev.target as HTMLElement).cursor,
+		onMove: (mouseMoveEvent) => {
+			cursorPosition.value = { x: mouseMoveEvent.clientX, y: mouseMoveEvent.clientY };
+			const movementX = mouseMoveEvent.clientX - lastX;
+			const movementY = mouseMoveEvent.clientY - lastY;
+			const movement = ((movementX + movementY) / 2) * 2;
 
-		if (movement < 0) {
-			MIN_POSITION.top = -(handleDimensions.height / 2);
-			MIN_POSITION.left = -(handleDimensions.width / 2);
-		}
+			if (movement < 0) {
+				MIN_POSITION.top = -(handleDimensions.height / 2);
+				MIN_POSITION.left = -(handleDimensions.width / 2);
+			}
 
-		const radius = Math.round(
-			Math.max(0, Math.min(getNumberFromPx(props.target.style.borderRadius) + movement, maxRadius.value)),
-		);
+			const radius = Math.round(
+				Math.max(0, Math.min(getNumberFromPx(props.target.style.borderRadius) + movement, maxRadius.value)),
+			);
 
-		borderRadius.value = radius;
-		setHandlerPosition(radius);
-		props.targetBlock.setStyle("borderRadius", `${radius}px`);
+			borderRadius.value = radius;
+			setHandlerPosition(radius);
+			props.targetBlock.setStyle("borderRadius", `${radius}px`);
 
-		lastX = mouseMoveEvent.clientX;
-		lastY = mouseMoveEvent.clientY;
-	};
-
-	const mouseup = (mouseUpEvent: MouseEvent) => {
-		mouseUpEvent.preventDefault();
-		if (getNumberFromPx(props.targetBlock.getStyle("borderRadius")) < 10) {
-			handlerTop.value = MIN_POSITION.top;
-			handlerLeft.value = MIN_POSITION.left;
-		}
-		updating.value = false;
-		document.removeEventListener("mousemove", mousemove);
-	};
-
-	document.addEventListener("mousemove", mousemove);
-	document.addEventListener("mouseup", mouseup, { once: true });
+			lastX = mouseMoveEvent.clientX;
+			lastY = mouseMoveEvent.clientY;
+		},
+		onEnd: () => {
+			if (getNumberFromPx(props.targetBlock.getStyle("borderRadius") as string) < 10) {
+				handlerTop.value = MIN_POSITION.top;
+				handlerLeft.value = MIN_POSITION.left;
+			}
+			updating.value = false;
+		},
+	});
 };
 
 onMounted(() => {

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -76,6 +76,9 @@ const handleRounded = (ev: MouseEvent) => {
 	cursorPosition.value = { x: startX, y: startY };
 
 	const handleDimensions = handler.value.getBoundingClientRect();
+	const startRadius = props.targetBlock.getStyle("borderRadius", null, true);
+	const startBorderRadius = borderRadius.value;
+	const startMinPosition = { ...MIN_POSITION };
 
 	startDrag({
 		cursor: window.getComputedStyle(ev.target as HTMLElement).cursor,
@@ -100,6 +103,13 @@ const handleRounded = (ev: MouseEvent) => {
 
 			lastX = mouseMoveEvent.clientX;
 			lastY = mouseMoveEvent.clientY;
+		},
+		onCancel: () => {
+			props.targetBlock.setStyle("borderRadius", startRadius ?? null);
+			borderRadius.value = startBorderRadius;
+			// onMove drags this below zero to let the handle sit outside the corner
+			Object.assign(MIN_POSITION, startMinPosition);
+			setHandlerPosition(startBorderRadius);
 		},
 		onEnd: () => {
 			if (getNumberFromPx(props.targetBlock.getStyle("borderRadius") as string) < 10) {

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -26,7 +26,6 @@ const props = defineProps<{
 	target: HTMLElement | SVGElement;
 }>();
 
-const borderRadius = ref(parseInt(props.target.style.borderRadius, 10) || 0);
 const updating = ref(false);
 const cursorPosition = ref({ x: 0, y: 0 });
 const canvasProps = inject("canvasProps") as CanvasProps;
@@ -45,6 +44,11 @@ const maxRadius = computed(() => {
 	props.targetBlock.getStyle("height");
 	const targetStyle = window.getComputedStyle(props.target);
 	return Math.min(parseInt(targetStyle.height, 10), parseInt(targetStyle.width, 10)) / 2;
+});
+
+const borderRadius = computed(() => {
+	const radius = getNumberFromPx(props.targetBlock.getStyle("borderRadius") as string);
+	return Math.max(0, Math.min(radius, maxRadius.value));
 });
 
 const handlerPosition = computed(() => ({
@@ -76,8 +80,8 @@ const handleRounded = (ev: MouseEvent) => {
 	cursorPosition.value = { x: startX, y: startY };
 
 	const handleDimensions = handler.value.getBoundingClientRect();
-	const startRadius = props.targetBlock.getStyle("borderRadius", null, true);
-	const startBorderRadius = borderRadius.value;
+	// Native read so Escape can restore the original unit, or its absence when inherited.
+	const startRadiusStyle = props.targetBlock.getStyle("borderRadius", null, true);
 	const startMinPosition = { ...MIN_POSITION };
 
 	startDrag({
@@ -94,25 +98,23 @@ const handleRounded = (ev: MouseEvent) => {
 			}
 
 			const radius = Math.round(
-				Math.max(0, Math.min(getNumberFromPx(props.target.style.borderRadius) + movement, maxRadius.value)),
+				Math.max(0, Math.min(borderRadius.value + movement, maxRadius.value)),
 			);
 
-			borderRadius.value = radius;
-			setHandlerPosition(radius);
 			props.targetBlock.setStyle("borderRadius", `${radius}px`);
+			setHandlerPosition(radius);
 
 			lastX = mouseMoveEvent.clientX;
 			lastY = mouseMoveEvent.clientY;
 		},
 		onCancel: () => {
-			props.targetBlock.setStyle("borderRadius", startRadius ?? null);
-			borderRadius.value = startBorderRadius;
+			props.targetBlock.setStyle("borderRadius", startRadiusStyle ?? null);
 			// onMove drags this below zero to let the handle sit outside the corner
 			Object.assign(MIN_POSITION, startMinPosition);
-			setHandlerPosition(startBorderRadius);
+			setHandlerPosition(borderRadius.value);
 		},
 		onEnd: () => {
-			if (getNumberFromPx(props.targetBlock.getStyle("borderRadius") as string) < 10) {
+			if (borderRadius.value < 10) {
 				handlerTop.value = MIN_POSITION.top;
 				handlerLeft.value = MIN_POSITION.left;
 			}
@@ -121,11 +123,7 @@ const handleRounded = (ev: MouseEvent) => {
 	});
 };
 
-onMounted(() => {
-	const radius = Math.max(0, Math.min(borderRadius.value, maxRadius.value));
-	borderRadius.value = radius;
-	setHandlerPosition(radius);
-});
+onMounted(() => setHandlerPosition(borderRadius.value));
 
 watchEffect(() => {
 	props.targetBlock.getStyle("height");

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -152,6 +152,14 @@ const handleResize = (ev: MouseEvent, { horizontal, vertical }: ResizeDirection)
 	const blockStartHeight = props.targetBlock.getStyle("height") as string;
 	const startFontSize = fontSize.value || 0;
 	const canReposition = props.targetBlock.isMovable();
+	// Captured natively so Escape can delete styles the block did not own before the drag.
+	const startStyles = {
+		width: props.targetBlock.getStyle("width", null, true),
+		height: props.targetBlock.getStyle("height", null, true),
+		left: props.targetBlock.getStyle("left", null, true),
+		top: props.targetBlock.getStyle("top", null, true),
+		fontSize: props.targetBlock.getStyle("fontSize", null, true),
+	};
 
 	cursorPosition.value = { x: ev.clientX, y: ev.clientY };
 	resizing.value = true;
@@ -201,6 +209,11 @@ const handleResize = (ev: MouseEvent, { horizontal, vertical }: ResizeDirection)
 				props.targetBlock.setStyle("left", `${Math.round(startLeft + positionDelta.x)}px`);
 				props.targetBlock.setStyle("top", `${Math.round(startTop + positionDelta.y)}px`);
 			}
+		},
+		onCancel: () => {
+			Object.entries(startStyles).forEach(([style, value]) => {
+				props.targetBlock.setStyle(style as styleProperty, value ?? null);
+			});
 		},
 		onEnd: () => {
 			resizing.value = false;

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -152,7 +152,7 @@ const handleResize = (ev: MouseEvent, { horizontal, vertical }: ResizeDirection)
 	const blockStartHeight = props.targetBlock.getStyle("height") as string;
 	const startFontSize = fontSize.value || 0;
 	const canReposition = props.targetBlock.isMovable();
-	// Captured natively so Escape can delete styles the block did not own before the drag.
+	// pressing `esc` resetsnto startStyles
 	const startStyles = {
 		width: props.targetBlock.getStyle("width", null, true),
 		height: props.targetBlock.getStyle("height", null, true),

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -1,8 +1,8 @@
 <template>
-	<TransformPreview v-if="resizing" :position="cursorPosition" :wide="!props.targetBlock.isText()">
+	<CursorTooltip v-if="resizing" :position="cursorPosition" :wide="!props.targetBlock.isText()">
 		<template v-if="props.targetBlock.isText()">{{ fontSize }}</template>
 		<template v-else>{{ targetWidth }} x {{ targetHeight }}</template>
-	</TransformPreview>
+	</CursorTooltip>
 
 	<div
 		class="left-handle pointer-events-auto absolute bottom-0 left-[-2px] top-0 w-2 border-none bg-transparent"
@@ -40,7 +40,7 @@ import { getNumberFromPx } from "@/utils/helpers";
 import { clamp } from "@vueuse/core";
 import { computed, inject, onMounted, ref, watch } from "vue";
 import guidesTracker from "../utils/guidesTracker";
-import TransformPreview from "./TransformPreview.vue";
+import CursorTooltip from "./CursorTooltip.vue";
 
 const canvasStore = useCanvasStore();
 const props = defineProps<{

--- a/frontend/src/components/BoxResizer.vue
+++ b/frontend/src/components/BoxResizer.vue
@@ -5,25 +5,25 @@
 	</CursorTooltip>
 
 	<div
-		class="left-handle pointer-events-auto absolute bottom-0 left-[-2px] top-0 w-2 border-none bg-transparent"
+		class="left-handle pointer-events-auto absolute bottom-0 left-[-6px] top-0 w-3 border-none bg-transparent"
 		:style="{ cursor: horizontalCursor }"
 		@mousedown.stop="(ev) => handleResize(ev, resizeDirections.left)" />
 	<div
-		class="right-handle pointer-events-auto absolute bottom-0 right-[-2px] top-0 w-2 border-none bg-transparent"
+		class="right-handle pointer-events-auto absolute bottom-0 right-[-6px] top-0 w-3 border-none bg-transparent"
 		:style="{ cursor: horizontalCursor }"
 		@mousedown.stop="(ev) => handleResize(ev, resizeDirections.right)" />
 	<div
-		class="top-handle pointer-events-auto absolute left-0 right-0 top-[-2px] h-2 border-none bg-transparent"
+		class="top-handle pointer-events-auto absolute left-0 right-0 top-[-6px] h-3 border-none bg-transparent"
 		:style="{ cursor: verticalCursor }"
 		@mousedown.stop="(ev) => handleResize(ev, resizeDirections.top)" />
 	<div
-		class="bottom-handle pointer-events-auto absolute bottom-[-2px] left-0 right-0 h-2 border-none bg-transparent"
+		class="bottom-handle pointer-events-auto absolute bottom-[-6px] left-0 right-0 h-3 border-none bg-transparent"
 		:style="{ cursor: verticalCursor }"
 		@mousedown.stop="(ev) => handleResize(ev, resizeDirections.bottom)" />
 	<div
 		v-for="corner in visibleCorners"
 		:key="corner.name"
-		class="pointer-events-auto absolute h-[10px] w-[10px] rounded-full border-2 border-blue-400 bg-white"
+		class="pointer-events-auto absolute h-[10px] w-[10px] rounded-full border-2 border-blue-400 bg-white before:absolute before:-inset-2 before:content-['']"
 		:class="[corner.positionClass, { 'border-purple-400': targetBlock.isExtendedFromComponent() }]"
 		:style="{ cursor: corner.cursor.value }"
 		v-show="!resizing"

--- a/frontend/src/components/Controls/SplitInput.vue
+++ b/frontend/src/components/Controls/SplitInput.vue
@@ -87,8 +87,10 @@ const gridStyle = computed(() => ({
 const getInputAttrs = (index: number) => ({ ...props.inputAttrs, ...splits.value[index]?.attrs });
 
 const updateValue = (index: number, value: InputValue) => {
-	const nextValues: InputValue[] = [...values.value];
-	nextValues[index] = props.normalizeValue(value, index);
+	// Every side is normalized, not just the edited one, so units stay consistent across sides.
+	const nextValues = values.value.map((current, side) =>
+		props.normalizeValue(side === index ? value : current, side),
+	);
 	emit("update:modelValue", props.toModelValue(nextValues, index));
 };
 

--- a/frontend/src/components/Controls/SplitInput.vue
+++ b/frontend/src/components/Controls/SplitInput.vue
@@ -11,8 +11,10 @@
 				}"
 				:modelValue="values[index]"
 				:aria-label="split.label"
+				:type="type"
 				:hideClearButton="true"
 				v-bind="getInputAttrs(index)"
+				@keydown="(event: KeyboardEvent) => handleKeyDown(event, index)"
 				@update:modelValue="(value) => updateValue(index, value)" />
 		</div>
 
@@ -50,6 +52,7 @@ const props = withDefaults(
 		normalizeValue?: (value: InputValue, index: number) => InputValue;
 		inputAttrs?: InputAttrs;
 		enableSlider?: boolean;
+		type?: string;
 	}>(),
 	{
 		toControlValues: (value: unknown) => (Array.isArray(value) ? value : [value as InputValue]),
@@ -89,6 +92,31 @@ const updateValue = (index: number, value: InputValue) => {
 	emit("update:modelValue", props.toModelValue(nextValues, index));
 };
 
+// Slider and arrow keys share the same step/bounds, read off the input's own attrs.
+const getNumericBounds = (index: number) => {
+	const attrs = getInputAttrs(index);
+	return {
+		step: Number(attrs.step) || 1,
+		min: attrs.min === undefined ? -Infinity : Number(attrs.min),
+		max: attrs.max === undefined ? Infinity : Number(attrs.max),
+	};
+};
+
+const setNumericValue = (index: number, value: number, unit: string, min: number, max: number) => {
+	updateValue(index, `${Math.max(min, Math.min(max, value))}${unit}`);
+};
+
+// TODO: Duplicating code over BasePropertyControl, refactor
+const handleKeyDown = (event: KeyboardEvent, index: number) => {
+	if (!props.enableSlider || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
+	event.preventDefault();
+
+	const { number, unit } = extractNumberAndUnit(String(values.value[index] ?? ""));
+	const { step, min, max } = getNumericBounds(index);
+	const direction = event.key === "ArrowUp" ? 1 : -1;
+	setNumericValue(index, Number(number) + direction * step, unit, min, max);
+};
+
 const handleLabelMouseDown = (event: MouseEvent, index: number) => {
 	if (!props.enableSlider || !splits.value[index]?.label) return;
 	event.preventDefault();
@@ -96,17 +124,13 @@ const handleLabelMouseDown = (event: MouseEvent, index: number) => {
 	const { number, unit } = extractNumberAndUnit(String(values.value[index] ?? ""));
 	const startValue = Number(number);
 	const startY = event.clientY;
-	const attrs = getInputAttrs(index);
-	const step = Number(attrs.step) || 1;
-	const min = attrs.min === undefined ? -Infinity : Number(attrs.min);
-	const max = attrs.max === undefined ? Infinity : Number(attrs.max);
+	const { step, min, max } = getNumericBounds(index);
 
 	startDrag({
 		cursor: window.getComputedStyle(event.currentTarget as HTMLElement).cursor,
 		onMove: (moveEvent) => {
 			const difference = Math.round(startY - moveEvent.clientY) * step;
-			const nextValue = Math.max(min, Math.min(max, startValue + difference));
-			updateValue(index, `${nextValue}${unit}`);
+			setNumericValue(index, startValue + difference, unit, min, max);
 		},
 	});
 };

--- a/frontend/src/components/Controls/SplitInput.vue
+++ b/frontend/src/components/Controls/SplitInput.vue
@@ -92,7 +92,6 @@ const updateValue = (index: number, value: InputValue) => {
 	emit("update:modelValue", props.toModelValue(nextValues, index));
 };
 
-// Slider and arrow keys share the same step/bounds, read off the input's own attrs.
 const getNumericBounds = (index: number) => {
 	const attrs = getInputAttrs(index);
 	return {

--- a/frontend/src/components/Controls/SplitModeInput.vue
+++ b/frontend/src/components/Controls/SplitModeInput.vue
@@ -5,6 +5,7 @@
 				class="min-w-0 flex-1"
 				:modelValue="displayValue"
 				:placeholder="split && splitCount && !displayValue ? 'Mixed' : placeholder"
+				:type="type"
 				v-bind="controlAttrs"
 				@update:modelValue="setUniformValue" />
 
@@ -24,6 +25,7 @@
 			:normalizeValue="normalizeValue"
 			:inputAttrs="inputAttrs"
 			:enableSlider="enableSlider"
+			:type="type"
 			@update:modelValue="setIndividualValue" />
 	</div>
 </template>
@@ -57,6 +59,7 @@ const props = withDefaults(
 		normalizeValue?: (value: InputValue, index: number) => InputValue;
 		inputAttrs?: InputAttrs;
 		enableSlider?: boolean;
+		type?: string;
 		getMergedValue: (values: InputValue[]) => InputValue;
 	}>(),
 	{

--- a/frontend/src/components/CursorTooltip.vue
+++ b/frontend/src/components/CursorTooltip.vue
@@ -3,7 +3,7 @@
 		<span
 			class="pointer-events-none fixed z-[1000] flex h-8 items-center justify-center whitespace-nowrap rounded-full bg-gray-600 p-2 text-sm text-white opacity-80"
 			:class="wide ? 'w-20' : 'w-fit'"
-			:style="previewStyle">
+			:style="tooltipStyle">
 			<slot />
 		</span>
 	</Teleport>
@@ -17,7 +17,7 @@ const props = defineProps<{
 	wide?: boolean;
 }>();
 
-const previewStyle = computed(() => ({
+const tooltipStyle = computed(() => ({
 	left: `${props.position.x + 12}px`,
 	top: `${props.position.y + 12}px`,
 }));

--- a/frontend/src/components/RotationHandler.vue
+++ b/frontend/src/components/RotationHandler.vue
@@ -1,5 +1,5 @@
 <template>
-	<TransformPreview v-if="rotating" :position="cursorPosition">{{ currentRotation }}°</TransformPreview>
+	<CursorTooltip v-if="rotating" :position="cursorPosition">{{ currentRotation }}°</CursorTooltip>
 	<div
 		v-for="corner in corners"
 		v-show="!rotating"
@@ -18,7 +18,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import { getRotatedCursor, setDragCursor, startDrag } from "@/utils/cursor";
 import { getElementRotation } from "@/utils/rotation";
 import { ref } from "vue";
-import TransformPreview from "./TransformPreview.vue";
+import CursorTooltip from "./CursorTooltip.vue";
 
 const props = defineProps<{
 	targetBlock: Block;

--- a/frontend/src/components/RotationHandler.vue
+++ b/frontend/src/components/RotationHandler.vue
@@ -32,10 +32,10 @@ const emit = defineEmits<{
 const canvasStore = useCanvasStore();
 
 const cornerLayout = [
-	{ name: "bottom-right", positionClass: "bottom-[-20px] right-[-20px]", baseAngle: 0 },
-	{ name: "bottom-left", positionClass: "bottom-[-20px] left-[-20px]", baseAngle: 90 },
-	{ name: "top-left", positionClass: "top-[-20px] left-[-20px]", baseAngle: 180 },
-	{ name: "top-right", positionClass: "top-[-20px] right-[-20px]", baseAngle: 270 },
+	{ name: "bottom-right", positionClass: "bottom-[-26px] right-[-26px]", baseAngle: 0 },
+	{ name: "bottom-left", positionClass: "bottom-[-26px] left-[-26px]", baseAngle: 90 },
+	{ name: "top-left", positionClass: "top-[-26px] left-[-26px]", baseAngle: 180 },
+	{ name: "top-right", positionClass: "top-[-26px] right-[-26px]", baseAngle: 270 },
 ] as const;
 
 const rotating = ref(false);

--- a/frontend/src/components/RotationHandler.vue
+++ b/frontend/src/components/RotationHandler.vue
@@ -61,6 +61,7 @@ const handleRotate = (ev: MouseEvent, baseAngle: number) => {
 	// ancestors don't rotate mid-drag, so their contribution can be captured once up front
 	const ancestorRotation = getElementRotation((props.target as Element).parentElement);
 	const pauseId = canvasStore.activeCanvas?.history?.pause();
+	const startRotate = props.targetBlock.getStyle("rotate", null, true);
 	let lastCursorAngle: number | null = null;
 	const dragCursor = (angle: number) =>
 		getRotatedCursor(rotationCursorSvg, ancestorRotation + angle + baseAngle, "pointer");
@@ -93,6 +94,7 @@ const handleRotate = (ev: MouseEvent, baseAngle: number) => {
 				setDragCursor(dragCursor(finalRotation));
 			}
 		},
+		onCancel: () => props.targetBlock.setStyle("rotate", startRotate ?? null),
 		onEnd: () => {
 			rotating.value = false;
 			emit("rotating", false);

--- a/frontend/src/components/SpacingControl.vue
+++ b/frontend/src/components/SpacingControl.vue
@@ -24,7 +24,7 @@
 import SplitModeInput from "@/components/Controls/SplitModeInput.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import blockController from "@/utils/blockController";
-import { expandBoxShorthand, normalizeValueWithUnits } from "@/utils/cssUtils";
+import { collapseBoxShorthand, expandBoxShorthand, normalizeValueWithUnits } from "@/utils/cssUtils";
 import { BOX_UNIT_OPTIONS } from "@/utils/unitOptions";
 import { computed, ref, watch } from "vue";
 
@@ -56,7 +56,7 @@ const getPlaceholder = () => String(getBaseValue(true));
 
 const toControlValues = (value: unknown) => expandBoxShorthand(value);
 const normalize = (value: BoxValue) => normalizeValueWithUnits(String(value || "0"), "px");
-const toModelValue = (parts: BoxValue[]) => parts.join(" ");
+const toModelValue = (parts: BoxValue[]) => collapseBoxShorthand(parts);
 const getMergedValue = (parts: BoxValue[]) => parts[0] ?? 0;
 const getControlAttrs = (variant: string | null) => {
 	const key = variant ?? "main";

--- a/frontend/src/utils/cssUtils.ts
+++ b/frontend/src/utils/cssUtils.ts
@@ -330,6 +330,23 @@ function expandBoxShorthand(value: unknown, fallback = "0"): string[] {
 }
 
 /**
+ * Collapses four side values into the shortest shorthand that expands back to them.
+ * @param parts - Four side values, in the order expandBoxShorthand returns
+ * @returns Shorthand value string
+ */
+function collapseBoxShorthand(parts: unknown[]): string {
+	console.log(parts)
+	const [top, right, bottom, left] = parts.map((part) => String(part ?? ""));
+	if (top === right && top === bottom && top === left) {
+		console.log(99)
+		return top;
+	};
+	if (top === bottom && right === left) return `${top} ${right}`;
+	if (right === left) return `${top} ${right} ${bottom}`;
+	return [top, right, bottom, left].join(" ");
+}
+
+/**
  * Normalizes CSS values by adding the default unit where missing.
  * Handles both single and whitespace-separated numeric values.
  * @param value - CSS value string
@@ -346,6 +363,7 @@ function normalizeValueWithUnits(value: string, defaultUnit: string): string {
 
 export {
 	addPxToNumber,
+	collapseBoxShorthand,
 	expandBoxShorthand,
 	extractNumberAndUnit,
 	getBoxSpacing,

--- a/frontend/src/utils/cssUtils.ts
+++ b/frontend/src/utils/cssUtils.ts
@@ -335,12 +335,8 @@ function expandBoxShorthand(value: unknown, fallback = "0"): string[] {
  * @returns Shorthand value string
  */
 function collapseBoxShorthand(parts: unknown[]): string {
-	console.log(parts)
 	const [top, right, bottom, left] = parts.map((part) => String(part ?? ""));
-	if (top === right && top === bottom && top === left) {
-		console.log(99)
-		return top;
-	};
+	if (top === right && top === bottom && top === left) return top;
 	if (top === bottom && right === left) return `${top} ${right}`;
 	if (right === left) return `${top} ${right} ${bottom}`;
 	return [top, right, bottom, left].join(" ");

--- a/frontend/src/utils/cursor.ts
+++ b/frontend/src/utils/cursor.ts
@@ -37,11 +37,12 @@ type DragOptions = {
 	cursor?: string;
 	onMove: (event: MouseEvent) => void;
 	onEnd?: (event?: MouseEvent) => void;
-	// Escape aborts the drag; restore whatever was captured at mousedown. onEnd still runs after.
+	// Runs before onEnd.
 	onCancel?: () => void;
 };
 
-// Runs a mouse drag with the cursor locked for its duration, tearing down its listeners on mouseup.
+// Runs a mouse drag with the cursor locked for its duration, tearing down its listeners on mouseup
+// or Escape.
 function startDrag({ cursor, onMove, onEnd, onCancel }: DragOptions) {
 	if (cursor) setDragCursor(cursor);
 

--- a/frontend/src/utils/cursor.ts
+++ b/frontend/src/utils/cursor.ts
@@ -36,11 +36,13 @@ function clearDragCursor() {
 type DragOptions = {
 	cursor?: string;
 	onMove: (event: MouseEvent) => void;
-	onEnd?: (event: MouseEvent) => void;
+	onEnd?: (event?: MouseEvent) => void;
+	// Escape aborts the drag; restore whatever was captured at mousedown. onEnd still runs after.
+	onCancel?: () => void;
 };
 
 // Runs a mouse drag with the cursor locked for its duration, tearing down its listeners on mouseup.
-function startDrag({ cursor, onMove, onEnd }: DragOptions) {
+function startDrag({ cursor, onMove, onEnd, onCancel }: DragOptions) {
 	if (cursor) setDragCursor(cursor);
 
 	const mousemove = (moveEvent: MouseEvent) => {
@@ -48,17 +50,31 @@ function startDrag({ cursor, onMove, onEnd }: DragOptions) {
 		moveEvent.preventDefault();
 	};
 
+	const stop = () => {
+		document.removeEventListener("mousemove", mousemove);
+		document.removeEventListener("mouseup", mouseup);
+		document.removeEventListener("keydown", keydown);
+		clearDragCursor();
+	};
+
+	const mouseup = (upEvent: MouseEvent) => {
+		stop();
+		onEnd?.(upEvent);
+		upEvent.preventDefault();
+	};
+
+	// Dropping the mouseup listener keeps the pending release from ending the drag a second time.
+	const keydown = (keyEvent: KeyboardEvent) => {
+		if (keyEvent.key !== "Escape") return;
+		keyEvent.preventDefault();
+		stop();
+		onCancel?.();
+		onEnd?.();
+	};
+
 	document.addEventListener("mousemove", mousemove);
-	document.addEventListener(
-		"mouseup",
-		(upEvent) => {
-			document.removeEventListener("mousemove", mousemove);
-			clearDragCursor();
-			onEnd?.(upEvent);
-			upEvent.preventDefault();
-		},
-		{ once: true },
-	);
+	document.addEventListener("mouseup", mouseup);
+	document.addEventListener("keydown", keydown);
 }
 
 export { clearDragCursor, getRotatedCursor, setDragCursor, startDrag };


### PR DESCRIPTION
- Pressing `esc` now cancels drag action

https://github.com/user-attachments/assets/be3fc47f-a0bf-4dc9-ae40-8c88d716cf14

- Added cursor tracking for border radius handle

https://github.com/user-attachments/assets/20dcf18a-4a26-41d6-b8f3-7d967714e8d1

- Added arrow key inputs to SplitInput

https://github.com/user-attachments/assets/e115015d-0239-40ef-9ac6-6124587ca344

- Increased trigger area for box resizing
- Border radius handle position now watches border radius value (https://github.com/frappe/builder/commit/9883a67d06db007c1d9922574c5ac98a35879875)
- Auto collapse box shorthand values (`"0 0 0 0"` -> `"0"`)