### PR TITLE
feat: Inform users when the site is in read-only mode

### DIFF
--- a/builder/api.py
+++ b/builder/api.py
@@ -29,6 +29,11 @@ def get_versioned_doc(snapshot: str) -> dict:
 
 
 @frappe.whitelist()
+def is_site_read_only() -> bool:
+	return bool(frappe.flags.read_only)
+
+
+@frappe.whitelist()
 def get_page_preview_html(page: str, **kwargs) -> Response:
 	if not frappe.has_permission("Builder Page", "read", page):
 		frappe.throw("No permission to preview this page")

--- a/builder/www/_builder.py
+++ b/builder/www/_builder.py
@@ -18,5 +18,6 @@ def get_context(context):
 	# developer mode
 	context.is_developer_mode = frappe.conf.developer_mode
 	context.is_fc_site = is_fc_site()
+	context.is_read_only_mode = bool(frappe.flags.read_only)
 	if frappe.session.user != "Guest":
 		capture("active_site", "builder")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
 			window.builder_version = "{{ builder_version }}";
 			window.is_fc_site = "{{ is_fc_site }}";
 			window.is_developer_mode = "{{ is_developer_mode }}";
+			window.is_read_only_mode = "{{ is_read_only_mode }}";
 		</script>
 		<script type="module" src="/src/main.ts"></script>
 	</body>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,8 +14,8 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
-import { FrappeUIProvider, toast } from "frappe-ui";
-import { computed, onMounted, provide, watch } from "vue";
+import { frappeRequest, FrappeUIProvider, toast } from "frappe-ui";
+import { computed, nextTick, onMounted, provide, watch } from "vue";
 import { useRoute } from "vue-router";
 import { sessionUser } from "./router";
 
@@ -35,16 +35,31 @@ const title = computed(() => {
 useTitle(title);
 
 onMounted(() => {
+	let readOnlyPoll: number | null = null;
 	watch(
 		() => builderStore.isSiteInReadOnlyMode,
-		(readOnly) => {
-			if (!readOnly) return;
-			toast.warning("Site is in read-only mode", {
-				id: "site-read-only-mode",
-				duration: Infinity,
-				description:
-					"Editing is disabled while the site is being updated. Please try again in a few minutes.",
-			});
+		(readOnly, wasReadOnly) => {
+			if (readOnly) {
+				toast.warning("Site is in read-only mode", {
+					id: "site-read-only-mode",
+					duration: Infinity,
+					description:
+						"Editing is disabled while the site is being updated. Please try again in a few minutes.",
+				});
+				readOnlyPoll ??= window.setInterval(() => {
+					frappeRequest({ url: "builder.api.is_site_read_only" })
+						.then((readOnly: boolean) => (builderStore.isSiteInReadOnlyMode = readOnly))
+						.catch(() => {});
+				}, 10000);
+			} else if (wasReadOnly) {
+				if (readOnlyPoll) {
+					clearInterval(readOnlyPoll);
+					readOnlyPoll = null;
+				}
+				toast.dismiss("site-read-only-mode");
+				toast.success("Site is back online", { description: "You can continue editing." });
+				if (pageStore.selectedPage) nextTick(() => pageStore.savePage());
+			}
 		},
 		{ immediate: true },
 	);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,8 +14,8 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
-import { FrappeUIProvider } from "frappe-ui";
-import { computed, provide } from "vue";
+import { FrappeUIProvider, toast } from "frappe-ui";
+import { computed, onMounted, provide, watch } from "vue";
 import { useRoute } from "vue-router";
 import { sessionUser } from "./router";
 
@@ -33,4 +33,20 @@ const title = computed(() => {
 });
 
 useTitle(title);
+
+onMounted(() => {
+	watch(
+		() => builderStore.isSiteInReadOnlyMode,
+		(readOnly) => {
+			if (!readOnly) return;
+			toast.warning("Site is in read-only mode", {
+				id: "site-read-only-mode",
+				duration: Infinity,
+				description:
+					"Editing is disabled while the site is being updated. Please try again in a few minutes.",
+			});
+		},
+		{ immediate: true },
+	);
+});
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,8 +14,9 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
-import { frappeRequest, FrappeUIProvider, toast } from "frappe-ui";
-import { computed, nextTick, onMounted, provide, watch } from "vue";
+import { useSiteReadOnlyNotice } from "@/utils/useSiteReadOnlyNotice";
+import { FrappeUIProvider } from "frappe-ui";
+import { computed, provide } from "vue";
 import { useRoute } from "vue-router";
 import { sessionUser } from "./router";
 
@@ -34,34 +35,5 @@ const title = computed(() => {
 
 useTitle(title);
 
-onMounted(() => {
-	let readOnlyPoll: number | null = null;
-	watch(
-		() => builderStore.isSiteInReadOnlyMode,
-		(readOnly, wasReadOnly) => {
-			if (readOnly) {
-				toast.warning("Site is in read-only mode", {
-					id: "site-read-only-mode",
-					duration: Infinity,
-					description:
-						"Editing is disabled while the site is being updated. Please try again in a few minutes.",
-				});
-				readOnlyPoll ??= window.setInterval(() => {
-					frappeRequest({ url: "builder.api.is_site_read_only" })
-						.then((readOnly: boolean) => (builderStore.isSiteInReadOnlyMode = readOnly))
-						.catch(() => {});
-				}, 10000);
-			} else if (wasReadOnly) {
-				if (readOnlyPoll) {
-					clearInterval(readOnlyPoll);
-					readOnlyPoll = null;
-				}
-				toast.dismiss("site-read-only-mode");
-				toast.success("Site is back online", { description: "You can continue editing." });
-				if (pageStore.selectedPage) nextTick(() => pageStore.savePage());
-			}
-		},
-		{ immediate: true },
-	);
-});
+useSiteReadOnlyNotice();
 </script>

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -261,6 +261,7 @@ watch(
 		() => pageStore.activePage?.is_standard,
 		() => pageStore.activePage?.is_template,
 		() => canvasStore.versionPreviewBlock,
+		() => builderStore.isSiteInReadOnlyMode,
 	],
 	() => {
 		const previewing = Boolean(canvasStore.versionPreviewBlock);
@@ -268,8 +269,12 @@ watch(
 			(Boolean(pageStore.activePage?.is_standard) ||
 				Boolean(pageStore.activePage?.is_template && pageStore.activePage?.template_group)) &&
 			!window.is_developer_mode;
-		builderStore.toggleReadOnlyMode(canvasStore.editingMode === "page" && (previewing || isProtected));
+		builderStore.toggleReadOnlyMode(
+			builderStore.isSiteInReadOnlyMode ||
+				(canvasStore.editingMode === "page" && (previewing || isProtected)),
+		);
 	},
+	{ immediate: true },
 );
 
 declare global {

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -13,6 +13,7 @@ const { capture } = useTelemetry();
 declare global {
 	interface Window {
 		is_fc_site?: boolean | string;
+		is_read_only_mode?: boolean | string;
 	}
 }
 
@@ -39,6 +40,8 @@ const useBuilderStore = defineStore("builderStore", {
 		showDataScriptDialog: <"page" | null>null,
 		realtime: new RealTimeHandler(),
 		readOnlyMode: false,
+		// site-level maintenance/migration state, not the editor's edit lock
+		isSiteInReadOnlyMode: window.is_read_only_mode === "True",
 		viewers: <UserInfo[]>[],
 		isFCSite: window.is_fc_site === "True" ? true : false,
 		activeFolder: useStorage("activeFolder", ""),

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -308,6 +308,13 @@ const usePageStore = defineStore("pageStore", {
 						this.activePage = page;
 					}
 				})
+				.catch((e: { exc_type?: string }) => {
+					if (e?.exc_type === "InReadOnlyMode") {
+						builderStore.isSiteInReadOnlyMode = true;
+						return;
+					}
+					throw e;
+				})
 				.finally(() => {
 					if (this.saveId === saveId) {
 						this.saveId = null;

--- a/frontend/src/utils/useSiteReadOnlyNotice.ts
+++ b/frontend/src/utils/useSiteReadOnlyNotice.ts
@@ -1,0 +1,59 @@
+import useBuilderStore from "@/stores/builderStore";
+import usePageStore from "@/stores/pageStore";
+import { frappeRequest, toast } from "frappe-ui";
+import { nextTick, onMounted, watch } from "vue";
+
+const TOAST_ID = "site-read-only-mode";
+const POLL_INTERVAL = 10 * 1000;
+
+export function useSiteReadOnlyNotice() {
+	const builderStore = useBuilderStore();
+	const pageStore = usePageStore();
+	let poll: number | null = null;
+
+	function showNotice() {
+		toast.warning("Site is in read-only mode", {
+			id: TOAST_ID,
+			duration: Infinity,
+			description: "Editing is disabled while the site is being updated. Please try again in a few minutes.",
+		});
+	}
+
+	function checkIfSiteIsWritable() {
+		frappeRequest({ url: "builder.api.is_site_read_only" })
+			.then((readOnly) => (builderStore.isSiteInReadOnlyMode = Boolean(readOnly)))
+			.catch(() => {});
+	}
+
+	function startPolling() {
+		poll ??= window.setInterval(checkIfSiteIsWritable, POLL_INTERVAL);
+	}
+
+	function stopPolling() {
+		if (poll) clearInterval(poll);
+		poll = null;
+	}
+
+	function onSiteBackOnline() {
+		stopPolling();
+		toast.dismiss(TOAST_ID);
+		toast.success("Site is back online", { description: "You can continue editing." });
+		if (pageStore.selectedPage) nextTick(() => pageStore.savePage());
+	}
+
+	// on mount so the immediate toast fires after the ToastProvider exists
+	onMounted(() => {
+		watch(
+			() => builderStore.isSiteInReadOnlyMode,
+			(readOnly, wasReadOnly) => {
+				if (readOnly) {
+					showNotice();
+					startPolling();
+				} else if (wasReadOnly) {
+					onSiteBackOnline();
+				}
+			},
+			{ immediate: true },
+		);
+	});
+}


### PR DESCRIPTION
## Problem

When a site is being updated (maintenance mode with `allow_reads_during_maintenance`, which is how Frappe Cloud runs migrations and backups), the builder loads normally but every write fails. Users keep editing, autosave fails silently, and their changes vanish on reload with no explanation.

The user edits normally and the save succeeds. The site then enters read-only mode, the next autosave fails, and the builder explains why instead of failing silently:

![demo](https://raw.githubusercontent.com/surajshetty3416/builder/assets/read-only-mode-notice/demo.gif)


Opening the builder while the site is already in read-only mode:

![read-only editor](https://raw.githubusercontent.com/surajshetty3416/builder/assets/read-only-mode-notice/readonly-editor.png)
