### PR TITLE
refactor: Rework the Users settings tab

### DIFF
--- a/builder/api.py
+++ b/builder/api.py
@@ -217,23 +217,40 @@ def get_builder_users() -> list[dict]:
 	from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
 
 	UserInvitation.validate_role("builder")
-	users_with_access = frappe.get_all(
+	role_rows = frappe.get_all(
 		"Has Role",
 		filters={"role": ["in", ["System Manager", "Website Manager"]], "parenttype": "User"},
-		pluck="parent",
-		distinct=True,
+		fields=["parent", "role"],
 	)
-	return frappe.get_all(
+	admins = {row.parent for row in role_rows if row.role == "System Manager"}
+	users = frappe.get_all(
 		"User",
 		filters=[
-			["name", "in", users_with_access],
+			["name", "in", list({row.parent for row in role_rows})],
 			["name", "not in", ["Administrator", "Guest"]],
 			["enabled", "=", 1],
 			["user_type", "=", "System User"],
 		],
-		fields=["name", "full_name", "user_image"],
+		fields=["name", "full_name", "user_image", "creation"],
 		order_by="full_name",
 	)
+	for user in users:
+		user.is_admin = user.name in admins
+	return users
+
+
+@frappe.whitelist()
+def remove_builder_user(user: str) -> None:
+	from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
+
+	UserInvitation.validate_role("builder")
+	if user == frappe.session.user:
+		frappe.throw(frappe._("You cannot remove yourself"))
+	user_doc = frappe.get_doc("User", user)
+	if "System Manager" in [role.role for role in user_doc.roles]:
+		frappe.throw(frappe._("Admins can only be managed from the Desk"))
+	user_doc.roles = [role for role in user_doc.roles if role.role != "Website Manager"]
+	user_doc.save(ignore_permissions=True)
 
 
 @frappe.whitelist()

--- a/builder/api.py
+++ b/builder/api.py
@@ -240,20 +240,6 @@ def get_builder_users() -> list[dict]:
 
 
 @frappe.whitelist()
-def remove_builder_user(user: str) -> None:
-	from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
-
-	UserInvitation.validate_role("builder")
-	if user == frappe.session.user:
-		frappe.throw(frappe._("You cannot remove yourself"))
-	user_doc = frappe.get_doc("User", user)
-	if "System Manager" in [role.role for role in user_doc.roles]:
-		frappe.throw(frappe._("Admins can only be managed from the Desk"))
-	user_doc.roles = [role for role in user_doc.roles if role.role != "Website Manager"]
-	user_doc.save(ignore_permissions=True)
-
-
-@frappe.whitelist()
 @redis_cache()
 def get_apps():
 	apps = get_permitted_apps()

--- a/builder/api.py
+++ b/builder/api.py
@@ -231,7 +231,7 @@ def get_builder_users() -> list[dict]:
 			["enabled", "=", 1],
 			["user_type", "=", "System User"],
 		],
-		fields=["name", "full_name", "user_image", "creation"],
+		fields=["name", "full_name", "user_image"],
 		order_by="full_name",
 	)
 	for user in users:

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -59,16 +59,7 @@
 						</span>
 						<span class="truncate text-p-xs text-ink-gray-5">{{ user.name }}</span>
 					</div>
-					<div class="ml-auto flex shrink-0 items-center gap-2">
-						<Badge v-if="user.is_admin" theme="gray">Admin</Badge>
-						<Button
-							v-if="!user.is_admin && user.name !== sessionUser"
-							variant="ghost"
-							size="sm"
-							icon="lucide-trash-2"
-							title="Remove from Builder"
-							@click="removeUser(user)" />
-					</div>
+					<Badge v-if="user.is_admin" theme="gray" class="ml-auto shrink-0">Admin</Badge>
 				</div>
 				<div v-if="!filteredMembers.length" class="py-6 text-center text-p-sm text-ink-gray-5">
 					<template v-if="searchQuery.trim()">No members match "{{ searchQuery }}"</template>
@@ -143,10 +134,6 @@ const resendResource = createResource({
 	url: "frappe.core.api.user_invitation.resend_invitation",
 });
 
-const removeResource = createResource({
-	url: "builder.api.remove_builder_user",
-});
-
 const matchesSearch = (...values: (string | undefined)[]) => {
 	const query = searchQuery.value.toLowerCase().trim();
 	return !query || values.some((value) => value?.toLowerCase().includes(query));
@@ -208,17 +195,6 @@ const resendInvite = async (invite: PendingInvite) => {
 	try {
 		await resendResource.submit({ name: invite.name, app_name: "builder" });
 		toast.success(`Invitation resent to ${invite.email}`);
-	} catch (error) {
-		toast.error(errorMessage(error));
-	}
-};
-
-const removeUser = async (user: BuilderUser) => {
-	if (!(await confirm(`Remove ${user.full_name} from Builder?`))) return;
-	try {
-		await removeResource.submit({ user: user.name });
-		toast.success(`${user.full_name} removed from Builder`);
-		builderUsers.fetch();
 	} catch (error) {
 		toast.error(errorMessage(error));
 	}

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex h-full flex-col gap-3">
+	<div class="flex h-full flex-col gap-5">
 		<div class="flex items-center justify-between gap-2">
 			<BuilderInput
 				type="text"
@@ -12,20 +12,20 @@
 		</div>
 
 		<div class="min-h-0 flex-1 overflow-y-auto">
-			<div v-if="filteredInvites.length" class="mb-5 flex flex-col">
-				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-sm text-ink-gray-5">
+			<div v-if="filteredInvites.length" class="mb-6 flex flex-col">
+				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-p-sm text-ink-gray-5">
 					Pending Invites ({{ filteredInvites.length }})
 				</span>
 				<div
 					v-for="invite in filteredInvites"
 					:key="invite.name"
-					class="flex items-center justify-between gap-2 border-b border-outline-gray-1 py-2">
+					class="flex items-center justify-between gap-2 border-b border-outline-gray-1 py-2 last:border-b-0">
 					<div class="flex min-w-0 items-center gap-2">
 						<Avatar shape="circle" :label="invite.email" size="lg" />
 						<div class="flex min-w-0 flex-col">
-							<span class="truncate text-sm text-ink-gray-8">{{ invite.email }}</span>
+							<span class="truncate text-p-sm text-ink-gray-8">{{ invite.email }}</span>
 							<UseTimeAgo v-slot="{ timeAgo }" :time="invite.creation">
-								<span class="truncate text-xs text-ink-gray-5">
+								<span class="truncate text-p-xs text-ink-gray-5">
 									Invited {{ timeAgo }}{{ invite.invited_by_name ? ` by ${invite.invited_by_name}` : "" }}
 								</span>
 							</UseTimeAgo>
@@ -44,40 +44,33 @@
 			</div>
 
 			<div class="flex flex-col">
-				<div
-					class="sticky top-0 z-10 border-b border-outline-gray-1 bg-surface-base pb-2 text-sm text-ink-gray-5"
-					:class="rowGridClass">
-					<span>User</span>
-					<span>Role</span>
-					<span>User since</span>
-					<span></span>
-				</div>
+				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-p-sm text-ink-gray-5">
+					Members ({{ filteredMembers.length }})
+				</span>
 				<div
 					v-for="user in filteredMembers"
 					:key="user.name"
-					class="group border-b border-outline-gray-1 py-2"
-					:class="rowGridClass">
-					<div class="flex min-w-0 items-center gap-2">
-						<Avatar shape="circle" :image="user.user_image" :label="user.full_name" size="lg" />
-						<div class="flex min-w-0 flex-col">
-							<span class="truncate text-sm text-ink-gray-8">
-								{{ user.full_name }}
-								<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">You</Badge>
-							</span>
-							<span class="truncate text-xs text-ink-gray-5">{{ user.name }}</span>
-						</div>
+					class="flex items-center gap-2 border-b border-outline-gray-1 py-2 last:border-b-0">
+					<Avatar shape="circle" :image="user.user_image" :label="user.full_name" size="lg" />
+					<div class="flex min-w-0 flex-col">
+						<span class="truncate text-p-sm text-ink-gray-8">
+							{{ user.full_name }}
+							<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">You</Badge>
+						</span>
+						<span class="truncate text-p-xs text-ink-gray-5">{{ user.name }}</span>
 					</div>
-					<span class="text-sm text-ink-gray-7">{{ user.is_admin ? "Admin" : "User" }}</span>
-					<span class="text-sm text-ink-gray-7">{{ memberSince(user.creation) }}</span>
-					<Button
-						v-if="!user.is_admin && user.name !== sessionUser"
-						variant="ghost"
-						size="sm"
-						icon="lucide-trash-2"
-						title="Remove from Builder"
-						@click="removeUser(user)" />
+					<div class="ml-auto flex shrink-0 items-center gap-2">
+						<Badge v-if="user.is_admin" theme="gray">Admin</Badge>
+						<Button
+							v-if="!user.is_admin && user.name !== sessionUser"
+							variant="ghost"
+							size="sm"
+							icon="lucide-trash-2"
+							title="Remove from Builder"
+							@click="removeUser(user)" />
+					</div>
 				</div>
-				<div v-if="!filteredMembers.length" class="py-6 text-center text-sm text-ink-gray-5">
+				<div v-if="!filteredMembers.length" class="py-6 text-center text-p-sm text-ink-gray-5">
 					<template v-if="searchQuery.trim()">No members match "{{ searchQuery }}"</template>
 					<template v-else>No members yet. Invite someone to give them access to Builder.</template>
 				</div>
@@ -119,11 +112,8 @@ type BuilderUser = {
 	name: string;
 	full_name: string;
 	user_image?: string;
-	creation: string;
 	is_admin: boolean;
 };
-
-const rowGridClass = "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_32px] items-center gap-x-2";
 
 const inviteEmails = ref("");
 const searchQuery = ref("");
@@ -156,9 +146,6 @@ const resendResource = createResource({
 const removeResource = createResource({
 	url: "builder.api.remove_builder_user",
 });
-
-const memberSince = (creation: string) =>
-	new Date(creation).toLocaleDateString(undefined, { month: "short", year: "numeric" });
 
 const matchesSearch = (...values: (string | undefined)[]) => {
 	const query = searchQuery.value.toLowerCase().trim();

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -1,29 +1,15 @@
 <template>
 	<div class="flex h-full flex-col gap-3">
-		<div class="flex items-center gap-2">
+		<div class="flex items-center justify-between gap-2">
 			<BuilderInput
 				type="text"
-				class="flex-1"
-				placeholder="Invite by email, comma-separated"
-				:modelValue="inviteEmails"
-				:hideClearButton="true"
-				@input="(val: string) => (inviteEmails = val)"
-				@keydown.enter.prevent="sendInvites" />
-			<Button
-				variant="solid"
-				:disabled="!inviteEmails.trim()"
-				:loading="inviteResource.loading"
-				@click="sendInvites">
-				Invite
-			</Button>
+				class="w-72"
+				placeholder="Search by name or email"
+				icon-left="search"
+				:modelValue="searchQuery"
+				@input="(val: string) => (searchQuery = val)" />
+			<Button variant="solid" icon-left="lucide-plus" @click="openInviteDialog">Invite</Button>
 		</div>
-
-		<BuilderInput
-			type="text"
-			placeholder="Search members"
-			icon-left="search"
-			:modelValue="searchQuery"
-			@input="(val: string) => (searchQuery = val)" />
 
 		<div class="min-h-0 flex-1 overflow-y-auto">
 			<div v-if="filteredInvites.length" class="mb-5 flex flex-col">
@@ -58,19 +44,38 @@
 			</div>
 
 			<div class="flex flex-col">
-				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-sm text-ink-gray-5">
-					Members ({{ filteredMembers.length }})
-				</span>
+				<div
+					class="sticky top-0 z-10 border-b border-outline-gray-1 bg-surface-base pb-2 text-sm text-ink-gray-5"
+					:class="rowGridClass">
+					<span>User</span>
+					<span>Role</span>
+					<span>User since</span>
+					<span></span>
+				</div>
 				<div
 					v-for="user in filteredMembers"
 					:key="user.name"
-					class="flex items-center gap-2 border-b border-outline-gray-1 py-2">
-					<Avatar shape="circle" :image="user.user_image" :label="user.full_name" size="lg" />
-					<div class="flex min-w-0 flex-col">
-						<span class="truncate text-sm text-ink-gray-8">{{ user.full_name }}</span>
-						<span class="truncate text-xs text-ink-gray-5">{{ user.name }}</span>
+					class="group border-b border-outline-gray-1 py-2"
+					:class="rowGridClass">
+					<div class="flex min-w-0 items-center gap-2">
+						<Avatar shape="circle" :image="user.user_image" :label="user.full_name" size="lg" />
+						<div class="flex min-w-0 flex-col">
+							<span class="truncate text-sm text-ink-gray-8">
+								{{ user.full_name }}
+								<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">You</Badge>
+							</span>
+							<span class="truncate text-xs text-ink-gray-5">{{ user.name }}</span>
+						</div>
 					</div>
-					<Badge v-if="user.name === sessionUser" theme="gray" class="ml-auto">You</Badge>
+					<span class="text-sm text-ink-gray-7">{{ user.is_admin ? "Admin" : "User" }}</span>
+					<span class="text-sm text-ink-gray-7">{{ memberSince(user.creation) }}</span>
+					<Button
+						v-if="!user.is_admin && user.name !== sessionUser"
+						variant="ghost"
+						size="sm"
+						icon="lucide-trash-2"
+						title="Remove from Builder"
+						@click="removeUser(user)" />
 				</div>
 				<div v-if="!filteredMembers.length" class="py-6 text-center text-sm text-ink-gray-5">
 					<template v-if="searchQuery.trim()">No members match "{{ searchQuery }}"</template>
@@ -78,14 +83,31 @@
 				</div>
 			</div>
 		</div>
+
+		<Dialog
+			v-model="showInviteDialog"
+			title="Invite Users"
+			:actions="[{ label: 'Send Invitation', variant: 'solid', onClick: sendInvites }]">
+			<template #default>
+				<BuilderInput
+					:ref="(el) => (inviteInputRef = el)"
+					type="text"
+					label="Email addresses"
+					placeholder="jane@example.com, john@example.com"
+					:hideClearButton="true"
+					:modelValue="inviteEmails"
+					@input="(val: string) => (inviteEmails = val)"
+					@keydown.enter.prevent="sendInvites" />
+			</template>
+		</Dialog>
 	</div>
 </template>
 <script setup lang="ts">
 import router, { sessionUser } from "@/router";
 import { confirm } from "@/utils/helpers";
 import { UseTimeAgo } from "@vueuse/components";
-import { Avatar, Badge, createResource, toast } from "frappe-ui";
-import { computed, ref } from "vue";
+import { Avatar, Badge, Dialog, createResource, toast } from "frappe-ui";
+import { computed, nextTick, ref } from "vue";
 
 type PendingInvite = {
 	name: string;
@@ -93,10 +115,20 @@ type PendingInvite = {
 	creation: string;
 	invited_by_name?: string;
 };
-type BuilderUser = { name: string; full_name: string; user_image?: string };
+type BuilderUser = {
+	name: string;
+	full_name: string;
+	user_image?: string;
+	creation: string;
+	is_admin: boolean;
+};
+
+const rowGridClass = "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_32px] items-center gap-x-2";
 
 const inviteEmails = ref("");
 const searchQuery = ref("");
+const showInviteDialog = ref(false);
+const inviteInputRef = ref<any>(null);
 const builderPath = router.options.history.base || "/builder";
 
 const builderUsers = createResource({
@@ -121,6 +153,13 @@ const resendResource = createResource({
 	url: "frappe.core.api.user_invitation.resend_invitation",
 });
 
+const removeResource = createResource({
+	url: "builder.api.remove_builder_user",
+});
+
+const memberSince = (creation: string) =>
+	new Date(creation).toLocaleDateString(undefined, { month: "short", year: "numeric" });
+
 const matchesSearch = (...values: (string | undefined)[]) => {
 	const query = searchQuery.value.toLowerCase().trim();
 	return !query || values.some((value) => value?.toLowerCase().includes(query));
@@ -138,6 +177,13 @@ const filteredMembers = computed<BuilderUser[]>(() => {
 		a.name === sessionUser.value ? -1 : b.name === sessionUser.value ? 1 : 0,
 	);
 });
+
+const openInviteDialog = async () => {
+	inviteEmails.value = "";
+	showInviteDialog.value = true;
+	await nextTick();
+	inviteInputRef.value?.$el?.querySelector?.("input")?.focus();
+};
 
 const errorMessage = (error: any) => error?.messages?.[0] || error?.message || String(error);
 
@@ -163,6 +209,7 @@ const sendInvites = async () => {
 		if (res.disabled_user_emails.length) {
 			toast.error(`User is disabled: ${res.disabled_user_emails.join(", ")}`);
 		}
+		showInviteDialog.value = false;
 		inviteEmails.value = "";
 		pendingInvites.fetch();
 	} catch (error) {
@@ -174,6 +221,17 @@ const resendInvite = async (invite: PendingInvite) => {
 	try {
 		await resendResource.submit({ name: invite.name, app_name: "builder" });
 		toast.success(`Invitation resent to ${invite.email}`);
+	} catch (error) {
+		toast.error(errorMessage(error));
+	}
+};
+
+const removeUser = async (user: BuilderUser) => {
+	if (!(await confirm(`Remove ${user.full_name} from Builder?`))) return;
+	try {
+		await removeResource.submit({ user: user.name });
+		toast.success(`${user.full_name} removed from Builder`);
+		builderUsers.fetch();
 	} catch (error) {
 		toast.error(errorMessage(error));
 	}

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -84,7 +84,7 @@
 			<template #default>
 				<BuilderInput
 					:ref="(el) => (inviteInputRef = el)"
-					type="text"
+					type="textarea"
 					label="Email addresses"
 					placeholder="jane@example.com, john@example.com"
 					:hideClearButton="true"
@@ -169,7 +169,7 @@ const openInviteDialog = async () => {
 	inviteEmails.value = "";
 	showInviteDialog.value = true;
 	await nextTick();
-	inviteInputRef.value?.$el?.querySelector?.("input")?.focus();
+	inviteInputRef.value?.$el?.querySelector?.("textarea, input")?.focus();
 };
 
 const errorMessage = (error: any) => error?.messages?.[0] || error?.message || String(error);


### PR DESCRIPTION
## What

Follow-up to #688. Reworks the Users tab based on feedback from using it on a real site:

- Header row: compact search (name or email) + **+ Invite** button that opens a dialog with a textarea for multiple emails
- Pending invites show when and by whom they were sent, with always-visible Resend / Cancel
- Members list with an **Admin** badge where it applies, a `You` badge on your own row (sorted first)
- Paragraph typography tokens for row line-height and consistent section spacing

## Before / After

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/surajshetty3416/builder/assets/users-tab-ux/before.jpg) | ![after](https://raw.githubusercontent.com/surajshetty3416/builder/assets/users-tab-ux/after.jpg) |

## API changes

- `get_builder_users` returns an `is_admin` flag
- `get_pending_invitations` returns `creation` and `invited_by_name` (queries the doctype directly instead of delegating to the core endpoint)

## Demo

https://github.com/user-attachments/assets/b32b5ade-a403-4689-ad2c-dd1f856aef23

