### PR TITLE
perf: Trim editor bundle and fix text editor memory leak

### DIFF
--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -1,12 +1,12 @@
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
-import { findBlockInTree, resetBlock } from "@/utils/block/tree";
 import {
 	extendWithComponent,
 	rebuildWithComponent,
 	resetWithComponent,
 	syncBlockWithComponent,
 } from "@/utils/block/componentInstance";
+import { findBlockInTree, resetBlock } from "@/utils/block/tree";
 import {
 	addPxToNumber,
 	cssUrl,
@@ -50,6 +50,12 @@ const TEXT_ELEMENTS = new Set([
 const CONTAINER_ELEMENTS = new Set(["section", "div"]);
 
 const HEADER_ELEMENTS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+// editor of the currently editable text block; kept off Block instances to
+// avoid Vue reactivity and serialization. Owner tracked by blockId since
+// undo/redo swaps instances but keeps ids.
+let activeEditor: Editor | null = null;
+let activeEditorBlockId: string | null = null;
 
 class Block implements BlockOptions {
 	blockId: string;
@@ -129,7 +135,7 @@ class Block implements BlockOptions {
 					// falling back to the live component
 					const componentBlock = this.componentVersion
 						? componentStore.getComponentVersionBlock(this.componentVersion as string) ||
-							componentStore.getComponentBlock(this.isChildOfComponent as string)
+						  componentStore.getComponentBlock(this.isChildOfComponent as string)
 						: componentStore.getComponentBlock(this.isChildOfComponent as string);
 					return findBlockInTree(this.referenceBlockId as string, [componentBlock]);
 				}
@@ -724,8 +730,11 @@ class Block implements BlockOptions {
 		}
 	}
 	getEditor(): null | Editor {
-		// @ts-ignore
-		return this.__proto__.editor || null;
+		return this.blockId === activeEditorBlockId ? activeEditor : null;
+	}
+	setEditor(editor: Editor | null) {
+		activeEditor = editor;
+		activeEditorBlockId = editor ? this.blockId : null;
 	}
 	setTextColor(color: string) {
 		const editor = this.getEditor();

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -97,7 +97,13 @@ const typographySectionProperties = [
 				label: "Weight",
 				propertyKey: "fontWeight",
 				component: Autocomplete,
-				options: getFontWeightOptions((blockController.getStyle("fontFamily") || "Inter") as string),
+				// static options were never query-filtered, so ignore the search
+				// string; awaiting the list keeps all weights of a preselected
+				// font available on first open
+				getOptions: async () => {
+					await loadFontList();
+					return getFontWeightOptions((blockController.getStyle("fontFamily") || "Inter") as string);
+				},
 				step: 100,
 				min: 100,
 				max: 900,

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -6,7 +6,7 @@ import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue
 import userFonts from "@/data/userFonts";
 import { UserFont } from "@/types/doctypes";
 import blockController from "@/utils/blockController";
-import { setFont as _setFont, fontList, getFontWeightOptions } from "@/utils/fontManager";
+import { setFont as _setFont, fontListItems, getFontWeightOptions, loadFontList } from "@/utils/fontManager";
 import { BOX_UNIT_OPTIONS } from "@/utils/unitOptions";
 
 const setFont = (font: string) => {
@@ -42,7 +42,8 @@ const typographySectionProperties = [
 				label: "Family",
 				component: Autocomplete,
 				propertyKey: "fontFamily",
-				getOptions: (filterString: string) => {
+				getOptions: async (filterString: string) => {
+					await loadFontList();
 					const fontOptions = [] as { label: string; value: string }[];
 					userFonts.data?.forEach((font: UserFont) => {
 						if (fontOptions.length >= 20) {
@@ -66,7 +67,7 @@ const typographySectionProperties = [
 							value: "_separator_2",
 						});
 					}
-					fontList.items.forEach((font) => {
+					fontListItems.value.forEach((font) => {
 						if (fontOptions.length >= 20) {
 							return;
 						}

--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -72,7 +72,7 @@
 			<div class="h-full" v-show="builderStore.leftPanelActiveTab === 'Code'">
 				<PageScript
 					:key="pageStore.selectedPage"
-					v-if="pageStore.selectedPage && pageStore.activePage"
+					v-if="pageScriptMounted && pageStore.selectedPage && pageStore.activePage"
 					:page="pageStore.activePage" />
 			</div>
 		</div>
@@ -105,6 +105,15 @@ const componentLayers = ref<InstanceType<typeof BlockLayers> | null>(null);
 const canvasStore = useCanvasStore();
 const builderStore = useBuilderStore();
 const pageStore = usePageStore();
+
+// PageScript mounts a CodeMirror instance; defer it until the Code tab is
+// first opened (or a data-script dialog is requested), then keep it alive
+const pageScriptMounted = ref(false);
+watchEffect(() => {
+	if (builderStore.leftPanelActiveTab === "Code" || builderStore.showDataScriptDialog !== null) {
+		pageScriptMounted.value = true;
+	}
+});
 
 const pageCanvas = inject("pageCanvas") as Ref<InstanceType<typeof BuilderCanvas> | null>;
 const fragmentCanvas = inject("fragmentCanvas") as Ref<InstanceType<typeof BuilderCanvas> | null>;

--- a/frontend/src/components/Controls/CodeEditor.vue
+++ b/frontend/src/components/Controls/CodeEditor.vue
@@ -42,8 +42,10 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { ref, VNodeRef, watch } from "vue";
-import CodeMirrorEditor from "./CodeMirror/CodeMirrorEditor.vue";
+import { defineAsyncComponent, ref, VNodeRef, watch } from "vue";
+
+// keeps the CodeMirror stack out of the main editor bundle
+const CodeMirrorEditor = defineAsyncComponent(() => import("./CodeMirror/CodeMirrorEditor.vue"));
 
 const props = withDefaults(
 	defineProps<{

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -281,6 +281,8 @@ const isDirty = computed(() => {
 	return false;
 });
 
+// immediate: the request may have arrived before this component mounted,
+// since the left panel mounts it lazily
 watch(
 	() => builderStore.showDataScriptDialog,
 	() => {
@@ -289,5 +291,6 @@ watch(
 			builderStore.showDataScriptDialog = null;
 		}
 	},
+	{ immediate: true },
 );
 </script>

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -215,6 +215,18 @@ const getInnerHTML = (editor: Editor | null) => {
 	return innerHTML;
 };
 
+const destroyEditor = () => {
+	if (!editor.value) return;
+	// the editor stash lives on the shared Block prototype; only clear it
+	// when it still points at this component's editor
+	if (props.block.getEditor() === editor.value) {
+		// @ts-ignore
+		props.block.__proto__.editor = null;
+	}
+	editor.value.destroy();
+	editor.value = null;
+};
+
 if (!props.preview) {
 	watch(
 		() => [
@@ -228,6 +240,9 @@ if (!props.preview) {
 				canvasStore.activeCanvas?.activeBreakpoint === props.breakpoint &&
 				!blockController.multipleBlocksSelected()
 			) {
+				// undo/redo swaps the Block under a reused component, so a live
+				// editor may still exist here; destroy it or it leaks
+				destroyEditor();
 				editor.value = new Editor({
 					content: textContent.value,
 					extensions: [
@@ -281,18 +296,13 @@ if (!props.preview) {
 				props.block.__proto__.editor = editor.value;
 				editor.value?.setEditable(isEditable.value);
 			} else {
-				editor.value?.destroy();
-				editor.value = null;
-				// @ts-ignore
-				props.block.__proto__.editor = null;
+				destroyEditor();
 			}
 		},
 		{ immediate: true },
 	);
 
-	onBeforeUnmount(() => {
-		editor.value?.destroy();
-	});
+	onBeforeUnmount(destroyEditor);
 }
 
 const handleClick = (e: MouseEvent) => {

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -217,11 +217,9 @@ const getInnerHTML = (editor: Editor | null) => {
 
 const destroyEditor = () => {
 	if (!editor.value) return;
-	// the editor stash lives on the shared Block prototype; only clear it
-	// when it still points at this component's editor
+	// a newer editor may already own the slot; clear only if it's still ours
 	if (props.block.getEditor() === editor.value) {
-		// @ts-ignore
-		props.block.__proto__.editor = null;
+		props.block.setEditor(null);
 	}
 	editor.value.destroy();
 	editor.value = null;
@@ -292,8 +290,7 @@ if (!props.preview) {
 					injectCSS: false,
 				});
 
-				// @ts-ignore
-				props.block.__proto__.editor = editor.value;
+				props.block.setEditor(editor.value);
 				editor.value?.setEditable(isEditable.value);
 			} else {
 				destroyEditor();

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -1,5 +1,10 @@
 import userFont from "@/data/userFonts";
-import fontList from "@/utils/fontList.json";
+import { shallowRef } from "vue";
+
+interface FontListItem {
+	family: string;
+	variants: string[];
+}
 
 type FontWeight = "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";
 interface WeightOption {
@@ -21,6 +26,21 @@ const WEIGHT_LABELS: Record<FontWeight, string> = {
 
 const GF_CSS = "https://fonts.googleapis.com/css2";
 const fontCache = new Map<string, Promise<string>>();
+
+// the Google Fonts catalog is ~110KB, so it stays out of the main bundle
+// and loads on first use (font pickers read the reactive ref)
+const fontListItems = shallowRef<FontListItem[]>([]);
+let fontListPromise: Promise<FontListItem[]> | null = null;
+
+export function loadFontList(): Promise<FontListItem[]> {
+	if (!fontListPromise) {
+		fontListPromise = import("@/utils/fontList.json").then((m) => {
+			fontListItems.value = m.default.items as FontListItem[];
+			return fontListItems.value;
+		});
+	}
+	return fontListPromise;
+}
 
 function loadCustomFont(font: string, url: string): Promise<string> {
 	return new FontFace(font, `url("${url}")`)
@@ -84,7 +104,8 @@ export function setFontFromHTML(html: string): void {
 }
 
 export function getFontWeightOptions(font: string): WeightOption[] {
-	const fontObj = font && fontList.items.find((f) => f.family === font);
+	loadFontList();
+	const fontObj = font && fontListItems.value.find((f) => f.family === font);
 	if (!fontObj) return [{ value: "400", label: "Regular" }];
 
 	return fontObj.variants
@@ -95,4 +116,4 @@ export function getFontWeightOptions(font: string): WeightOption[] {
 		});
 }
 
-export { fontList };
+export { fontListItems };


### PR DESCRIPTION
Two editor performance fixes from a profiling pass with stress pages (361 / 1225 / 3244 blocks), measured on the production build with Playwright + CDP (forced GC between memory samples).

## 1. Lazy-load font list, CodeMirror, and the page script panel

The Google Fonts catalog (`fontList.json`, 110KB) was statically imported into the editor's critical-path chunk, and the always-mounted page data preview created a CodeMirror instance plus a `get_codemirror_completions` request on every editor load.

- `fontList.json` now loads on first use behind a reactive ref (font pickers await it; `setFont` never needed it)
- `CodeMirrorEditor` is an async component, so the whole CodeMirror stack splits into its own chunk
- `PageScript` mounts on first Code-tab open (or data script dialog request) and stays alive after that

**Bundle (uncompressed / gzip):**

| Chunk | Before | After |
| --- | --- | --- |
| PageBuilder (critical path) | 776 KB | 688 KB |
| Shared controls chunk | 696 KB | 301 KB |
| CodeMirror | in the above | 402 KB / 129 KB, lazy |
| fontList | inlined | 104 KB / 12 KB, lazy |
| JS executed at editor load | baseline | **~500 KB less (~145 KB gzip), 1 fewer request** |

Verified live: no lazy chunk or completions request at load; font family/weight pickers, Code tab, and the data script dialog (including the "Edit Data Script" shortcut that opens it before the panel ever mounted) all work.

## 2. Fix per-undo text editor leak

Undo/redo rebuilds the block tree but component instances are reused (same `blockId` keys), so `TextBlock`'s selection watch could create a new TipTap editor over a live one. Every orphaned editor kept a `selectionchange` listener on the document, executing on each caret move for the rest of the session.

**15 type+undo cycles on a 1225-block page (heap after forced GC):**

| Metric | Before | After |
| --- | --- | --- |
| JS heap | 79 → 134 MB (+~4 MB/cycle, unbounded) | flat at ~84 MB |
| Event listeners | +44 per cycle | flat (2508) |
| DOM nodes | +53 per cycle | flat (21212) |
| Live editor views after 3 cycles + deselect | 4 | 1 (the selected block's editor) |

A single `destroyEditor` guard now covers creation, deselection, and unmount, and the editor moved off Block instances into module state keyed by `blockId` (also keeps it out of reactivity and serialization).

Editing behavior re-verified after the fix on a 3244-block page: typing lands, undo reverts, resize applies, autosave payloads unchanged.