### PR TITLE
fix: Use only shorthand properties for margin and padding

### DIFF
--- a/frontend/src/components/MarginHandler.vue
+++ b/frontend/src/components/MarginHandler.vue
@@ -27,7 +27,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handleMargin($event, Position.Top)" />
 			<div class="m-auto text-sm text-yellow-900" v-show="updating">
-				{{ blockStyles.marginTop || "auto" }}
+				{{ getMarginValue(Position.Top) || "auto" }}
 			</div>
 		</div>
 		<div
@@ -51,7 +51,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handleMargin($event, Position.Bottom)" />
 			<div class="m-auto text-sm text-yellow-900" v-show="updating">
-				{{ blockStyles.marginBottom || "auto" }}
+				{{ getMarginValue(Position.Bottom) || "auto" }}
 			</div>
 		</div>
 		<div
@@ -75,7 +75,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handleMargin($event, Position.Left)" />
 			<div class="m-auto text-sm text-yellow-900" v-show="updating">
-				{{ blockStyles.marginLeft || "auto" }}
+				{{ getMarginValue(Position.Left) || "auto" }}
 			</div>
 		</div>
 		<div
@@ -99,7 +99,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handleMargin($event, Position.Right)" />
 			<div class="m-auto text-sm text-yellow-900" v-show="updating">
-				{{ blockStyles.marginRight || "auto" }}
+				{{ getMarginValue(Position.Right) || "auto" }}
 			</div>
 		</div>
 	</div>
@@ -129,6 +129,7 @@ const {
 	canvasProps,
 	updating,
 	blockStyles,
+	getSpacingValue,
 	handleBorderWidth,
 	longHandleSize,
 	sideHandleSize,
@@ -153,14 +154,12 @@ const leftMarginHandlerWidth = computed(() => getMargin("Left"));
 const rightMarginHandlerWidth = computed(() => getMargin("Right"));
 
 const getMargin = (side: "Top" | "Left" | "Right" | "Bottom") => {
-	blockStyles.value.marginTop;
-	blockStyles.value.marginBottom;
-	blockStyles.value.marginLeft;
-	blockStyles.value.marginRight;
 	blockStyles.value.margin;
 	blockStyles.value.display;
 	return getNumberFromPx(getComputedStyle(props.target)[`margin${side}`]) * canvasProps.scale;
 };
+
+const getMarginValue = (position: Position) => getSpacingValue("margin", position);
 
 const topHandle = computed(() => {
 	const { width, height } = longHandleSize.value;

--- a/frontend/src/components/PaddingHandler.vue
+++ b/frontend/src/components/PaddingHandler.vue
@@ -26,7 +26,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handlePadding($event, Position.Top)" />
 			<div class="m-auto text-sm text-purple-900" v-show="updating">
-				{{ blockStyles.paddingTop }}
+				{{ getPaddingValue(Position.Top) }}
 			</div>
 		</div>
 		<div
@@ -49,7 +49,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handlePadding($event, Position.Bottom)" />
 			<div class="m-auto text-sm text-purple-900" v-show="updating">
-				{{ blockStyles.paddingBottom }}
+				{{ getPaddingValue(Position.Bottom) }}
 			</div>
 		</div>
 		<div
@@ -72,7 +72,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handlePadding($event, Position.Left)" />
 			<div class="m-auto text-sm text-purple-900" v-show="updating">
-				{{ blockStyles.paddingLeft }}
+				{{ getPaddingValue(Position.Left) }}
 			</div>
 		</div>
 		<div
@@ -95,7 +95,7 @@
 				:class="{ hidden: updating }"
 				@mousedown.stop="handlePadding($event, Position.Right)" />
 			<div class="m-auto text-sm text-purple-900" v-show="updating">
-				{{ blockStyles.paddingRight }}
+				{{ getPaddingValue(Position.Right) }}
 			</div>
 		</div>
 	</div>
@@ -126,6 +126,7 @@ const {
 	canvasProps,
 	updating,
 	blockStyles,
+	getSpacingValue,
 	handleBorderWidth,
 	longHandleSize,
 	sideHandleSize,
@@ -161,13 +162,11 @@ const rightPaddingHandlerWidth = computed(() => {
 });
 
 const getPadding = (side: "Top" | "Left" | "Right" | "Bottom") => {
-	blockStyles.value.paddingRight;
-	blockStyles.value.paddingTop;
-	blockStyles.value.paddingBottom;
-	blockStyles.value.paddingLeft;
 	blockStyles.value.padding;
 	return getNumberFromPx(getComputedStyle(props.target)[`padding${side}`]) * canvasProps.scale;
 };
+
+const getPaddingValue = (position: Position) => getSpacingValue("padding", position);
 
 const topHandle = computed(() => {
 	const { width, height } = longHandleSize.value;

--- a/frontend/src/components/SpacingControl.vue
+++ b/frontend/src/components/SpacingControl.vue
@@ -16,6 +16,7 @@
 			:getPlaceholder="getPlaceholder"
 			:getVariantValue="readValue"
 			:getMergedValue
+			:setModelValue
 			:getControlAttrs="getControlAttrs" />
 	</div>
 </template>
@@ -65,5 +66,11 @@ const getControlAttrs = (variant: string | null) => {
 		enableSlider,
 		"onUpdate:split": (split: boolean) => (splitModes.value[key] = split),
 	};
+};
+
+const setModelValue = (val: string | boolean | number) => {
+	if (typeof val == "boolean") return;
+	if (props.type == "margin") blockController.setMargin(String(val));
+	else if (props.type == "padding") blockController.setPadding(String(val));
 };
 </script>

--- a/frontend/src/composables/useSpacingHandler.ts
+++ b/frontend/src/composables/useSpacingHandler.ts
@@ -1,5 +1,6 @@
 import type Block from "@/block";
 import { CanvasProps } from "@/types/Builder/BuilderCanvas";
+import { collapseBoxShorthand, expandBoxShorthand } from "@/utils/cssUtils";
 import { startDrag } from "@/utils/cursor";
 import { getNumberFromPx } from "@/utils/helpers";
 import { toLocalDelta } from "@/utils/rotation";
@@ -25,10 +26,10 @@ type SpacingDragOptions = {
 
 // `outward` is the sign of a drag pointing away from the block along the side's axis.
 const sides = {
-	[Position.Top]: { axis: "y", outward: -1, styleSuffix: "Top" },
-	[Position.Bottom]: { axis: "y", outward: 1, styleSuffix: "Bottom" },
-	[Position.Left]: { axis: "x", outward: -1, styleSuffix: "Left" },
-	[Position.Right]: { axis: "x", outward: 1, styleSuffix: "Right" },
+	[Position.Top]: { axis: "y", outward: -1, styleSuffix: "Top", index: 0 },
+	[Position.Right]: { axis: "x", outward: 1, styleSuffix: "Right", index: 1 },
+	[Position.Bottom]: { axis: "y", outward: 1, styleSuffix: "Bottom", index: 2 },
+	[Position.Left]: { axis: "x", outward: -1, styleSuffix: "Left", index: 3 },
 } as const;
 
 const verticalSides = [Position.Top, Position.Bottom];
@@ -70,8 +71,33 @@ export function useSpacingHandler(getTargetBlock: () => Block, getBreakpoint: ()
 	const styleKey = (property: SpacingProperty, side: Position) =>
 		`${property}${sides[side].styleSuffix}` as styleProperty;
 
-	const setSpacing = (property: SpacingProperty, side: Position, value: number) =>
-		getTargetBlock().setStyle(styleKey(property, side), `${value}px`);
+	// Side-specific spacing styles are legacy data. Read them for display/editing,
+	// then collapse every update back into the single shorthand style.
+	const getSpacingParts = (property: SpacingProperty) => {
+		const styles = blockStyles.value;
+		const parts = expandBoxShorthand(styles[property] ?? "", "0px");
+		allSides.forEach((side) => {
+			const sideValue = styles[styleKey(property, side)];
+			if (sideValue) parts[sides[side].index] = String(sideValue);
+		});
+		return parts;
+	};
+
+	const getSpacingValue = (property: SpacingProperty, side: Position) =>
+		getSpacingParts(property)[sides[side].index];
+
+	const setSpacingShorthand = (property: SpacingProperty, updatedSides: Position[], value: number) => {
+		const block = getTargetBlock();
+		const parts = getSpacingParts(property);
+		updatedSides.forEach((updatedSide) => {
+			parts[sides[updatedSide].index] = `${value}px`;
+		});
+		block.setStyle(`${property}Top`, null);
+		block.setStyle(`${property}Right`, null);
+		block.setStyle(`${property}Bottom`, null);
+		block.setStyle(`${property}Left`, null);
+		block.setStyle(property, collapseBoxShorthand(parts));
+	};
 
 	// Shift spreads the value to all four sides, alt to both sides of the dragged axis.
 	const sidesToUpdate = (event: MouseEvent, side: Position) => {
@@ -88,7 +114,7 @@ export function useSpacingHandler(getTargetBlock: () => Block, getBreakpoint: ()
 		const { axis, outward } = sides[side];
 		// the handles sit on the block's edge, so dragging outward grows a margin but shrinks a padding
 		const sign = property === "margin" ? outward : -outward;
-		const startValue = getNumberFromPx(blockStyles.value[styleKey(property, side)] as string) || fallback;
+		const startValue = getNumberFromPx(getSpacingValue(property, side)) || fallback;
 		const startPoint = { x: event.clientX, y: event.clientY };
 
 		event.preventDefault();
@@ -104,7 +130,7 @@ export function useSpacingHandler(getTargetBlock: () => Block, getBreakpoint: ()
 					getRotation(),
 				);
 				const value = Math.round(Math.max(startValue + sign * delta[axis], 0));
-				sidesToUpdate(moveEvent, side).forEach((updatedSide) => setSpacing(property, updatedSide, value));
+				setSpacingShorthand(property, sidesToUpdate(moveEvent, side), value);
 			},
 			onEnd: () => {
 				updating.value = false;
@@ -119,6 +145,7 @@ export function useSpacingHandler(getTargetBlock: () => Block, getBreakpoint: ()
 		handleBorderWidth,
 		longHandleSize,
 		sideHandleSize,
+		getSpacingValue,
 		startSpacingDrag,
 	};
 }

--- a/frontend/src/utils/cssUtils.ts
+++ b/frontend/src/utils/cssUtils.ts
@@ -294,6 +294,28 @@ function removeDefaultUnit(value: string, defaultUnit: string): string {
 }
 
 /**
+ * Splits a CSS value list on whitespace, ignoring whitespace inside
+ * parentheses so functional values like `calc(10px + 5%)` stay intact.
+ */
+function splitCssValueList(value: string): string[] {
+	const parts: string[] = [];
+	let current = "";
+	let depth = 0;
+	for (const char of value) {
+		if (char === "(") depth++;
+		if (char === ")") depth--;
+		if (/\s/.test(char) && depth === 0) {
+			if (current) parts.push(current);
+			current = "";
+		} else {
+			current += char;
+		}
+	}
+	if (current) parts.push(current);
+	return parts;
+}
+
+/**
  * Expands a CSS box shorthand (margin, padding, border-radius) into its four
  * component values following the standard 1/2/3/4-value rules.
  * @param value - Shorthand value string
@@ -301,10 +323,7 @@ function removeDefaultUnit(value: string, defaultUnit: string): string {
  * @returns Array of exactly four side values
  */
 function expandBoxShorthand(value: unknown, fallback = "0"): string[] {
-	const parts = String(value ?? "")
-		.trim()
-		.split(/\s+/)
-		.filter(Boolean);
+	const parts = splitCssValueList(String(value ?? "").trim());
 	if (!parts.length) return Array(4).fill(fallback);
 	if (parts.length === 1) return Array(4).fill(parts[0]);
 	if (parts.length === 2) return [parts[0], parts[1], parts[0], parts[1]];

--- a/frontend/src/utils/cssUtils.ts
+++ b/frontend/src/utils/cssUtils.ts
@@ -223,26 +223,8 @@ function shortenNumber(num: number): string {
 function setBoxSpacing(block: Block, type: "padding" | "margin", value: string) {
 	const props = [type, `${type}Top`, `${type}Right`, `${type}Bottom`, `${type}Left`];
 	props.forEach((prop) => block.setStyle(prop, null));
-	if (!value) return;
-	const arr = value.split(" ");
-	if (arr.length === 1) {
-		block.setStyle(type, arr[0]);
-	} else if (arr.length === 2) {
-		block.setStyle(`${type}Top`, arr[0]);
-		block.setStyle(`${type}Bottom`, arr[0]);
-		block.setStyle(`${type}Left`, arr[1]);
-		block.setStyle(`${type}Right`, arr[1]);
-	} else if (arr.length === 3) {
-		block.setStyle(`${type}Top`, arr[0]);
-		block.setStyle(`${type}Left`, arr[1]);
-		block.setStyle(`${type}Right`, arr[1]);
-		block.setStyle(`${type}Bottom`, arr[2]);
-	} else if (arr.length === 4) {
-		block.setStyle(`${type}Top`, arr[0]);
-		block.setStyle(`${type}Right`, arr[1]);
-		block.setStyle(`${type}Bottom`, arr[2]);
-		block.setStyle(`${type}Left`, arr[3]);
-	}
+	const shorthand = value.trim();
+	if (shorthand) block.setStyle(type, shorthand);
 }
 
 function getBoxSpacing(
@@ -254,21 +236,22 @@ function getBoxSpacing(
 	const cascading = opts?.cascading ?? false;
 	const baseValue = block.getStyle(type, undefined, nativeOnly, cascading);
 	const base = String(baseValue ?? (nativeOnly && !cascading ? "" : "unset"));
-	const top = block.getStyle(`${type}Top`, undefined, nativeOnly, cascading) ?? base;
-	const bottom = block.getStyle(`${type}Bottom`, undefined, nativeOnly, cascading) ?? base;
-	const left = block.getStyle(`${type}Left`, undefined, nativeOnly, cascading) ?? base;
-	const right = block.getStyle(`${type}Right`, undefined, nativeOnly, cascading) ?? base;
+	const baseParts = expandBoxShorthand(base, base);
+	const top = block.getStyle(`${type}Top`, undefined, nativeOnly, cascading) ?? baseParts[0];
+	const right = block.getStyle(`${type}Right`, undefined, nativeOnly, cascading) ?? baseParts[1];
+	const bottom = block.getStyle(`${type}Bottom`, undefined, nativeOnly, cascading) ?? baseParts[2];
+	const left = block.getStyle(`${type}Left`, undefined, nativeOnly, cascading) ?? baseParts[3];
 	const sTop = String(top);
+	const sRight = String(right);
 	const sBottom = String(bottom);
 	const sLeft = String(left);
-	const sRight = String(right);
-	if (sTop === base && sBottom === base && sLeft === base && sRight === base) return base;
-	if (sTop === sBottom && sTop === sRight && sTop === sLeft) return sTop;
+	if (sTop === baseParts[0] && sRight === baseParts[1] && sBottom === baseParts[2] && sLeft === baseParts[3]) {
+		return base;
+	}
 	// A side left unset while others are set falls back to an empty base; treat it as 0
 	// so the reconstructed shorthand stays well-formed and expands to the right corners.
 	const fill = (value: string) => value || "0px";
-	if (sTop === sBottom && sLeft === sRight) return `${fill(sTop)} ${fill(sLeft)}`;
-	return `${fill(sTop)} ${fill(sRight)} ${fill(sBottom)} ${fill(sLeft)}`;
+	return collapseBoxShorthand([fill(sTop), fill(sRight), fill(sBottom), fill(sLeft)]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- After https://github.com/frappe/builder/pull/665 a block could end up with more than two margin/padding styles set at once — one shorthand (`margin`) and separate per-side ones (`margin{Position}`), which could conflict.
- Spacing is now written and read back using only the shorthand property.

Before:

https://github.com/user-attachments/assets/e27dab9f-69d4-455f-adbd-0a241d69415a

After:

https://github.com/user-attachments/assets/7302520f-c2a3-464b-93d6-c047f819313f

Fixes: https://github.com/frappe/builder/issues/690