### PR TITLE
fix: collapse empty Autocomplete instead of showing a blank sliver

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -58,7 +58,7 @@
 			<Teleport to="body" :disabled="!referenceElementSelector">
 				<ComboboxContent
 					ref="contentRef"
-					class="z-50 max-h-80 w-full overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base shadow-xl"
+					class="combobox-content z-50 max-h-80 w-full overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-base shadow-xl"
 					:class="[
 						referenceElementSelector ? 'fixed' : 'absolute',
 						!referenceElementSelector && openOptionsAbove ? 'bottom-full mb-1' : '',
@@ -67,7 +67,7 @@
 					:style="fixedPositionStyles"
 					@after-enter="updateOptionsPosition"
 					@after-leave="fixedPositionStyles = {}">
-					<div class="overflow-y-auto p-1">
+					<div class="options-list overflow-y-auto p-1 empty:p-0">
 						<template v-for="(option, index) in displayOptions" :key="`${option.value}-${index}`">
 							<ComboboxSeparator
 								v-if="option.value.startsWith('_separator_line')"
@@ -347,5 +347,14 @@ defineExpose({
 <style scoped>
 .can-show-arrows:hover {
 	gap: 3px !important;
+}
+
+/* Reka filters non-matching ComboboxItem elements out of the DOM itself, so once every
+   option is filtered out, the options-list div is left empty; collapse the content
+   container's border/shadow too instead of showing them around nothing. */
+.combobox-content:empty,
+.combobox-content:has(> .options-list:only-child:empty) {
+	border: none;
+	box-shadow: none;
 }
 </style>


### PR DESCRIPTION
Reka filters non-matching ComboboxItem elements out of the DOM itself, leaving the options-list div and its bordered/shadowed container empty but still rendered when a search has no matches.

Before:

https://github.com/user-attachments/assets/51292b89-d9e9-4785-bf73-e156bd1d187c

After:

https://github.com/user-attachments/assets/3aa91c26-507d-433b-b879-65afca300a94
