### PR TITLE
fix: keep newly created text block editable through the creating click

### DIFF
--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -583,11 +583,13 @@ class Block implements BlockOptions {
 		const childBlock = getBlockInstance(child);
 		childBlock.parentBlock = this;
 		this.children.splice(index, 0, childBlock);
-		if (childBlock.isText()) {
-			// makeBlockEditable() selects the block and enters edit mode synchronously.
-			childBlock.makeBlockEditable();
-		} else if (select) {
-			childBlock.selectBlock();
+		if (select) {
+			if (childBlock.isText()) {
+				// makeBlockEditable() selects the block and enters edit mode synchronously.
+				childBlock.makeBlockEditable();
+			} else {
+				childBlock.selectBlock();
+			}
 		}
 
 		if (childBlock.getStyle("position")) {

--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -583,11 +583,11 @@ class Block implements BlockOptions {
 		const childBlock = getBlockInstance(child);
 		childBlock.parentBlock = this;
 		this.children.splice(index, 0, childBlock);
-		if (select) {
-			childBlock.selectBlock();
-		}
 		if (childBlock.isText()) {
+			// makeBlockEditable() selects the block and enters edit mode synchronously.
 			childBlock.makeBlockEditable();
+		} else if (select) {
+			childBlock.selectBlock();
 		}
 
 		if (childBlock.getStyle("position")) {
@@ -757,7 +757,9 @@ class Block implements BlockOptions {
 	}
 	makeBlockEditable() {
 		const canvasStore = useCanvasStore();
-		this.selectBlock();
+		// canvasStore.selectBlock() runs synchronously here. A deferred call would clear
+		// editableBlock right after this line sets it.
+		canvasStore.selectBlock(this, null);
 		canvasStore.editableBlock = this;
 		nextTick(() => {
 			this.getEditor()?.commands.focus("all");

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -140,6 +140,9 @@ onBeforeMount(() => {
 });
 
 let pauseId: PauseId | undefined = undefined;
+// The creating click also fires a native click event before the block renders.
+// vOnClickOutside reads that as an outside click and ends edit mode. This flag skips it once.
+let skipNextClickOutside = false;
 
 watch(
 	() => isEditable.value,
@@ -292,6 +295,12 @@ if (!props.preview) {
 
 				props.block.setEditor(editor.value);
 				editor.value?.setEditable(isEditable.value);
+				// A block can already be editable at mount, before editor.value exists.
+				// The isEditable watch above then misses the focus call. This catches up now.
+				if (isEditable.value) {
+					editor.value?.commands.focus("all");
+					skipNextClickOutside = true;
+				}
 			} else {
 				destroyEditor();
 			}
@@ -319,6 +328,10 @@ const handleEscKey = () => {
 };
 
 const handleClickOutside = (e: MouseEvent) => {
+	if (skipNextClickOutside) {
+		skipNextClickOutside = false;
+		return;
+	}
 	if ((e.target as HTMLElement).closest(".canvas-container")) {
 		canvasStore.editableBlock = null;
 	}


### PR DESCRIPTION
Selecting synchronously in makeBlockEditable prevents the block's own deferred selectBlock call from clearing editableBlock right after it's set. TextBlock also swallows the one spurious click-outside event that the creating click's native "click" triggers before the block has rendered, and catches up the focus/edit-mode entry that the isEditable watch missed because the editor didn't exist yet at mount time.

Before:

https://github.com/user-attachments/assets/a3c125ce-50ba-465e-b896-3156d0652a92

After:

https://github.com/user-attachments/assets/49c85344-9456-4bb8-88ca-03dedf7f8c38

