### PR TITLE
fix: regenerate block ids when pasting at root with no selection

### DIFF
--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -319,7 +319,10 @@ async function insertBlocks(blocks: (Block | BlockOptions)[]) {
 		}
 		blocks.forEach((block) => parentBlock.addChild(getBlockCopy(block), null, true));
 	} else {
-		canvasStore.pushBlocks(blocks, false);
+		canvasStore.pushBlocks(
+			blocks.map((block) => (block.blockId === "root" ? block : getBlockCopy(block))),
+			false,
+		);
 	}
 }
 

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -320,7 +320,7 @@ async function insertBlocks(blocks: (Block | BlockOptions)[]) {
 		blocks.forEach((block) => parentBlock.addChild(getBlockCopy(block), null, true));
 	} else {
 		canvasStore.pushBlocks(
-			blocks.map((block) => (block.blockId === "root" ? block : getBlockCopy(block))),
+			blocks.map((block) => getBlockCopy(block)),
 			false,
 		);
 	}


### PR DESCRIPTION
Pasting with nothing selected routed clipboard blocks through canvasStore.pushBlocks -> Block.addChild, which retains the original blockId (and every nested child's id) instead of generating fresh ones. Selection and click resolution are keyed by blockId with a first-match tree search, so selecting the newly pasted block resolved back to the original. Strip and regenerate ids via getBlockCopy in this path, matching the paste-into-selected-block path, except when pasting a full page root (blockId "root"), which replaces the existing root wholesale and can't collide.

Before:

https://github.com/user-attachments/assets/ca332d1a-1b6d-44c5-a068-d50678f6e37d

After:

https://github.com/user-attachments/assets/43e2a480-86f9-46c9-b182-93731eb95a26

