### PR TITLE
fix: keep autocomplete lists full while filtering

### DIFF
--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -49,12 +49,10 @@ const typographySectionProperties = [
 					const userFontOptions = filterOptions(
 						(userFonts.data || []).map((font: UserFont) => toOption(font.font_name as string)),
 						filterString,
-						{ limit: 10, windowRadius: { upper: 4, lower: 5 } },
 					);
 					const defaultFontOptions = filterOptions(
 						fontListItems.value.map((font) => toOption(font.family)),
 						filterString,
-						{ limit: 20, windowRadius: { upper: 4, lower: 15 } },
 					);
 
 					if (!userFontOptions.length) return defaultFontOptions;

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -5,6 +5,7 @@ import OptionToggle from "@/components/Controls/OptionToggle.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import userFonts from "@/data/userFonts";
 import { UserFont } from "@/types/doctypes";
+import { filterOptions, MAX_OPTIONS } from "@/utils/autocompleteOptions";
 import blockController from "@/utils/blockController";
 import { setFont as _setFont, fontListItems, getFontWeightOptions, loadFontList } from "@/utils/fontManager";
 import { BOX_UNIT_OPTIONS } from "@/utils/unitOptions";
@@ -44,41 +45,24 @@ const typographySectionProperties = [
 				propertyKey: "fontFamily",
 				getOptions: async (filterString: string) => {
 					await loadFontList();
-					const fontOptions = [] as { label: string; value: string }[];
-					userFonts.data?.forEach((font: UserFont) => {
-						if (fontOptions.length >= 20) {
-							return;
-						}
-						const fontName = font.font_name as string;
-						if (fontName.toLowerCase().includes(filterString.toLowerCase()) || !filterString) {
-							fontOptions.push({
-								label: fontName,
-								value: fontName,
-							});
-						}
-					});
-					if (fontOptions.length) {
-						fontOptions.unshift({
-							label: "Custom",
-							value: "_separator_1",
-						});
-						fontOptions.push({
-							label: "Default",
-							value: "_separator_2",
-						});
-					}
-					fontListItems.value.forEach((font) => {
-						if (fontOptions.length >= 20) {
-							return;
-						}
-						if (font.family.toLowerCase().includes(filterString.toLowerCase()) || !filterString) {
-							fontOptions.push({
-								label: font.family,
-								value: font.family,
-							});
-						}
-					});
-					return fontOptions;
+					const toOption = (family: string) => ({ label: family, value: family });
+					const userFontOptions = filterOptions(
+						(userFonts.data || []).map((font: UserFont) => toOption(font.font_name as string)),
+						filterString,
+					);
+					const defaultFontOptions = filterOptions(
+						fontListItems.value.map((font) => toOption(font.family)),
+						filterString,
+						Math.max(MAX_OPTIONS - userFontOptions.length, 0),
+					);
+
+					if (!userFontOptions.length) return defaultFontOptions;
+					return [
+						{ label: "Custom", value: "_separator_1" },
+						...userFontOptions,
+						{ label: "Default", value: "_separator_2" },
+						...defaultFontOptions,
+					];
 				},
 				actionButton: {
 					component: FontUploader,

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -49,10 +49,12 @@ const typographySectionProperties = [
 					const userFontOptions = filterOptions(
 						(userFonts.data || []).map((font: UserFont) => toOption(font.font_name as string)),
 						filterString,
+						{ limit: 10, windowRadius: { upper: 4, lower: 5 } },
 					);
 					const defaultFontOptions = filterOptions(
 						fontListItems.value.map((font) => toOption(font.family)),
 						filterString,
+						{ limit: 20, windowRadius: { upper: 4, lower: 15 } },
 					);
 
 					if (!userFontOptions.length) return defaultFontOptions;

--- a/frontend/src/components/BlockPropertySections/TypographySection.ts
+++ b/frontend/src/components/BlockPropertySections/TypographySection.ts
@@ -5,7 +5,7 @@ import OptionToggle from "@/components/Controls/OptionToggle.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import userFonts from "@/data/userFonts";
 import { UserFont } from "@/types/doctypes";
-import { filterOptions, MAX_OPTIONS } from "@/utils/autocompleteOptions";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import blockController from "@/utils/blockController";
 import { setFont as _setFont, fontListItems, getFontWeightOptions, loadFontList } from "@/utils/fontManager";
 import { BOX_UNIT_OPTIONS } from "@/utils/unitOptions";
@@ -53,7 +53,6 @@ const typographySectionProperties = [
 					const defaultFontOptions = filterOptions(
 						fontListItems.value.map((font) => toOption(font.family)),
 						filterString,
-						Math.max(MAX_OPTIONS - userFontOptions.length, 0),
 					);
 
 					if (!userFontOptions.length) return defaultFontOptions;

--- a/frontend/src/components/DynamicValueDropdown.vue
+++ b/frontend/src/components/DynamicValueDropdown.vue
@@ -30,6 +30,7 @@
 import Autocomplete from "@/components/Controls/Autocomplete.vue";
 import MiddleTruncate from "@/components/MiddleTruncate.vue";
 import usePageStore from "@/stores/pageStore";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import blockController from "@/utils/blockController";
 import { getDataArray, getDefaultPropsList, getParentProps, getRepeaterScopedData } from "@/utils/helpers";
 import { computed, ref, watch } from "vue";
@@ -100,12 +101,7 @@ const dynamicOptions = computed(() => {
 	return options;
 });
 
-const getOptions = async (query: string) => {
-	const normalizedQuery = query.trim().toLowerCase();
-	return dynamicOptions.value.filter((option) => {
-		return !normalizedQuery || option.label.toLowerCase().includes(normalizedQuery);
-	});
-};
+const getOptions = async (query: string) => filterOptions(dynamicOptions.value, query);
 
 const handleModelValueUpdate = (value: string | null) => {
 	if (value == null) {

--- a/frontend/src/components/Settings/AnalyticsFilters.vue
+++ b/frontend/src/components/Settings/AnalyticsFilters.vue
@@ -25,6 +25,7 @@
 import Autocomplete from "@/components/Controls/Autocomplete.vue";
 import { webPages } from "@/data/webPage";
 import { BuilderPage } from "@/types/doctypes";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import { DateRangePicker, Select } from "frappe-ui";
 import { computed } from "vue";
 
@@ -101,14 +102,10 @@ const getRouteOptions = async (query: string) => {
 		await webPages.fetch();
 	}
 
-	const queryLower = query?.toLowerCase() || "";
-
-	return (webPages.data ?? [])
+	const routeOptions = (webPages.data ?? [])
 		.filter((page: BuilderPage) => page.route && !page.dynamic_route)
-		.map((page: BuilderPage) => ({ value: page.route as string, label: page.route as string }))
-		.filter(
-			(option: { value: string; label: string }) =>
-				!queryLower || option.label.toLowerCase().includes(queryLower),
-		);
+		.map((page: BuilderPage) => ({ value: page.route as string, label: page.route as string }));
+
+	return filterOptions(routeOptions, query || "");
 };
 </script>

--- a/frontend/src/components/VisibilityInput.vue
+++ b/frontend/src/components/VisibilityInput.vue
@@ -11,6 +11,7 @@
 import InlineInput from "@/components/Controls/InlineInput.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import blockController from "@/utils/blockController";
 import componentController from "@/utils/componentController";
 import { getDataArray, getDefaultPropsList, getParentProps, getRepeaterScopedData } from "@/utils/helpers";
@@ -66,46 +67,19 @@ const defaultProps = computed(() => {
 	}
 	return Object.keys(getDefaultPropsList(currentBlock.value));
 });
-const getOptions = async (query: string) => {
-	let options: { label: string; value: string }[] = [];
+const visibilityOptions = computed(() => {
+	const toOptions = (props: string[], comesFrom: string) =>
+		props.map((prop) => ({ label: prop, value: `${prop}--${comesFrom}` }));
+	const propsList = [...new Set([...ownProps.value, ...parentProps.value, ...defaultProps.value])];
 
-	pageDataArray.value.map((prop) => {
-		if (query.trim() == "" || prop.toLowerCase().includes(query.toLowerCase())) {
-			options.push({
-				label: prop,
-				value: `${prop}--dataScript`,
-			});
-		}
-	});
-	componentDataArray.value.map((prop) => {
-		if (query.trim() == "" || prop.toLowerCase().includes(query.toLowerCase())) {
-			options.push({
-				label: prop,
-				value: `${prop}--componentData`,
-			});
-		}
-	});
-	const combinedProps = [...new Set([...ownProps.value, ...parentProps.value])];
+	return [
+		...toOptions(pageDataArray.value, "dataScript"),
+		...toOptions(componentDataArray.value, "componentData"),
+		...toOptions(propsList, "props"),
+	];
+});
 
-	combinedProps.map((prop) => {
-		if (query.trim() == "" || prop.toLowerCase().includes(query.toLowerCase())) {
-			options.push({
-				label: prop,
-				value: `${prop}--props`,
-			});
-		}
-	});
-	defaultProps.value.map((prop) => {
-		if (query.trim() == "" || prop.toLowerCase().includes(query.toLowerCase())) {
-			options.push({
-				label: prop,
-				value: `${prop}--props`,
-			});
-		}
-	});
-
-	return options;
-};
+const getOptions = async (query: string) => filterOptions(visibilityOptions.value, query);
 
 const handleModelValueUpdate = (value: string | null) => {
 	if (value == null) {

--- a/frontend/src/utils/autocompleteOptions.ts
+++ b/frontend/src/utils/autocompleteOptions.ts
@@ -1,26 +1,50 @@
 const MAX_OPTIONS = 20;
+const DEFAULT_RADIUS = { upper: 10, lower: 9 };
 
-// keeps every match for the query in the list, then fills the rest of the list with the
-// remaining options so the dropdown always offers something to browse
+type WindowRadius = {
+	upper?: number;
+	lower?: number;
+};
+
+type FilterOptionsConfig = {
+	limit?: number;
+	windowRadius?: WindowRadius;
+};
+
+// matches first, then the rest. pass windowRadius to keep each match in place and
+// show the options around it instead.
 function filterOptions<Option extends { label: string }>(
 	options: Option[],
 	query: string,
-	limit = MAX_OPTIONS,
+	{ limit = MAX_OPTIONS, windowRadius }: FilterOptionsConfig = {},
 ): Option[] {
 	const normalizedQuery = query.trim().toLowerCase();
 	if (!normalizedQuery) return options.slice(0, limit);
 
+	const matchIndexes: number[] = [];
 	const matched: Option[] = [];
 	const rest: Option[] = [];
-	options.forEach((option) => {
+	options.forEach((option, index) => {
 		if (option.label.toLowerCase().includes(normalizedQuery)) {
+			matchIndexes.push(index);
 			matched.push(option);
 		} else {
 			rest.push(option);
 		}
 	});
+	if (!matchIndexes.length) return options.slice(0, limit);
+	if (!windowRadius) return [...matched, ...rest].slice(0, limit);
 
-	return [...matched, ...rest].slice(0, limit);
+	const kept = new Set<number>();
+	const radius = { ...DEFAULT_RADIUS, ...windowRadius };
+	matchIndexes.forEach((matchIndex) => {
+		const start = Math.max(0, matchIndex - radius.upper);
+		const end = Math.min(options.length - 1, matchIndex + radius.lower);
+		for (let index = start; index <= end; index++) {
+			kept.add(index);
+		}
+	});
+	return options.filter((_, index) => kept.has(index)).slice(0, limit);
 }
 
 export { filterOptions, MAX_OPTIONS };

--- a/frontend/src/utils/autocompleteOptions.ts
+++ b/frontend/src/utils/autocompleteOptions.ts
@@ -1,9 +1,7 @@
 const MAX_OPTIONS = 20;
-// options kept above the selected option when the list is windowed around it
-const NEIGHBOURS_ABOVE = 3;
 
 // typing filters to matching options; an exact match (the current selection)
-// shows the list windowed around it instead, so its neighbours stay visible
+// shows the list windowed around it, with about a third of the window above it
 function filterOptions<Option extends { label: string }>(
 	options: Option[],
 	query: string,
@@ -13,14 +11,12 @@ function filterOptions<Option extends { label: string }>(
 	if (!normalizedQuery) return options.slice(0, limit);
 
 	const selectedIndex = options.findIndex((option) => option.label.toLowerCase() === normalizedQuery);
-	if (selectedIndex !== -1) return windowAround(options, selectedIndex, limit);
+	if (selectedIndex === -1) {
+		return options.filter((option) => option.label.toLowerCase().includes(normalizedQuery)).slice(0, limit);
+	}
 
-	return options.filter((option) => option.label.toLowerCase().includes(normalizedQuery)).slice(0, limit);
-}
-
-function windowAround<Option>(options: Option[], index: number, limit: number): Option[] {
 	const maxStart = Math.max(options.length - limit, 0);
-	const start = Math.min(Math.max(index - NEIGHBOURS_ABOVE, 0), maxStart);
+	const start = Math.min(Math.max(selectedIndex - Math.floor(limit / 3), 0), maxStart);
 	return options.slice(start, start + limit);
 }
 

--- a/frontend/src/utils/autocompleteOptions.ts
+++ b/frontend/src/utils/autocompleteOptions.ts
@@ -1,45 +1,31 @@
 const MAX_OPTIONS = 20;
-const DEFAULT_RADIUS = { upper: 10, lower: 9 };
+// how far down the window a match sits, so more of its neighbours show above it
+const MATCH_POSITION = 1 / 3;
 
-type WindowRadius = {
-	upper?: number;
-	lower?: number;
-};
+function windowAround(matchIndex: number, limit: number, total: number): [number, number] {
+	const offset = Math.floor((limit - 1) * MATCH_POSITION);
+	const start = Math.min(Math.max(0, matchIndex - offset), Math.max(0, total - limit));
+	return [start, Math.min(total - 1, start + limit - 1)];
+}
 
-type FilterOptionsConfig = {
-	limit?: number;
-	windowRadius?: WindowRadius;
-};
-
-// matches first, then the rest. pass windowRadius to keep each match in place and
-// show the options around it instead.
+// keeps every match in place and shows the options around it
 function filterOptions<Option extends { label: string }>(
 	options: Option[],
 	query: string,
-	{ limit = MAX_OPTIONS, windowRadius }: FilterOptionsConfig = {},
+	limit = MAX_OPTIONS,
 ): Option[] {
 	const normalizedQuery = query.trim().toLowerCase();
-	if (!normalizedQuery) return options.slice(0, limit);
+	if (!normalizedQuery || options.length <= limit) return options.slice(0, limit);
 
-	const matchIndexes: number[] = [];
-	const matched: Option[] = [];
-	const rest: Option[] = [];
-	options.forEach((option, index) => {
-		if (option.label.toLowerCase().includes(normalizedQuery)) {
-			matchIndexes.push(index);
-			matched.push(option);
-		} else {
-			rest.push(option);
-		}
-	});
+	const matchIndexes = options.reduce((indexes: number[], option, index) => {
+		if (option.label.toLowerCase().includes(normalizedQuery)) indexes.push(index);
+		return indexes;
+	}, []);
 	if (!matchIndexes.length) return options.slice(0, limit);
-	if (!windowRadius) return [...matched, ...rest].slice(0, limit);
 
 	const kept = new Set<number>();
-	const radius = { ...DEFAULT_RADIUS, ...windowRadius };
 	matchIndexes.forEach((matchIndex) => {
-		const start = Math.max(0, matchIndex - radius.upper);
-		const end = Math.min(options.length - 1, matchIndex + radius.lower);
+		const [start, end] = windowAround(matchIndex, limit, options.length);
 		for (let index = start; index <= end; index++) {
 			kept.add(index);
 		}

--- a/frontend/src/utils/autocompleteOptions.ts
+++ b/frontend/src/utils/autocompleteOptions.ts
@@ -1,36 +1,27 @@
 const MAX_OPTIONS = 20;
-// how far down the window a match sits, so more of its neighbours show above it
-const MATCH_POSITION = 1 / 3;
+// options kept above the selected option when the list is windowed around it
+const NEIGHBOURS_ABOVE = 3;
 
-function windowAround(matchIndex: number, limit: number, total: number): [number, number] {
-	const offset = Math.floor((limit - 1) * MATCH_POSITION);
-	const start = Math.min(Math.max(0, matchIndex - offset), Math.max(0, total - limit));
-	return [start, Math.min(total - 1, start + limit - 1)];
-}
-
-// keeps every match in place and shows the options around it
+// typing filters to matching options; an exact match (the current selection)
+// shows the list windowed around it instead, so its neighbours stay visible
 function filterOptions<Option extends { label: string }>(
 	options: Option[],
 	query: string,
 	limit = MAX_OPTIONS,
 ): Option[] {
 	const normalizedQuery = query.trim().toLowerCase();
-	if (!normalizedQuery || options.length <= limit) return options.slice(0, limit);
+	if (!normalizedQuery) return options.slice(0, limit);
 
-	const matchIndexes = options.reduce((indexes: number[], option, index) => {
-		if (option.label.toLowerCase().includes(normalizedQuery)) indexes.push(index);
-		return indexes;
-	}, []);
-	if (!matchIndexes.length) return options.slice(0, limit);
+	const selectedIndex = options.findIndex((option) => option.label.toLowerCase() === normalizedQuery);
+	if (selectedIndex !== -1) return windowAround(options, selectedIndex, limit);
 
-	const kept = new Set<number>();
-	matchIndexes.forEach((matchIndex) => {
-		const [start, end] = windowAround(matchIndex, limit, options.length);
-		for (let index = start; index <= end; index++) {
-			kept.add(index);
-		}
-	});
-	return options.filter((_, index) => kept.has(index)).slice(0, limit);
+	return options.filter((option) => option.label.toLowerCase().includes(normalizedQuery)).slice(0, limit);
+}
+
+function windowAround<Option>(options: Option[], index: number, limit: number): Option[] {
+	const maxStart = Math.max(options.length - limit, 0);
+	const start = Math.min(Math.max(index - NEIGHBOURS_ABOVE, 0), maxStart);
+	return options.slice(start, start + limit);
 }
 
 export { filterOptions, MAX_OPTIONS };

--- a/frontend/src/utils/autocompleteOptions.ts
+++ b/frontend/src/utils/autocompleteOptions.ts
@@ -1,0 +1,26 @@
+const MAX_OPTIONS = 20;
+
+// keeps every match for the query in the list, then fills the rest of the list with the
+// remaining options so the dropdown always offers something to browse
+function filterOptions<Option extends { label: string }>(
+	options: Option[],
+	query: string,
+	limit = MAX_OPTIONS,
+): Option[] {
+	const normalizedQuery = query.trim().toLowerCase();
+	if (!normalizedQuery) return options.slice(0, limit);
+
+	const matched: Option[] = [];
+	const rest: Option[] = [];
+	options.forEach((option) => {
+		if (option.label.toLowerCase().includes(normalizedQuery)) {
+			matched.push(option);
+		} else {
+			rest.push(option);
+		}
+	});
+
+	return [...matched, ...rest].slice(0, limit);
+}
+
+export { filterOptions, MAX_OPTIONS };

--- a/frontend/src/utils/colorOptions.ts
+++ b/frontend/src/utils/colorOptions.ts
@@ -1,4 +1,5 @@
 import { BuilderVariable } from "@/types/doctypes";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import { defineComponent, h, shallowRef } from "vue";
 
 export function getColorVariableOptions(
@@ -11,52 +12,51 @@ export function getColorVariableOptions(
 	let processedQuery = query.replace(/^(--|var|\s+)/, "");
 	processedQuery = processedQuery.replace(/^--|\(|\s+/g, "");
 
-	return variables
-		.filter((builderVariable: BuilderVariable) => {
-			const label = (builderVariable.variable_name || "").toLowerCase();
-			const group = (builderVariable.group || "").toLowerCase();
-			const queryLower = processedQuery.toLowerCase();
-			return queryLower === "" || label.includes(queryLower) || group.includes(queryLower);
-		})
-		.map((builderVariable: BuilderVariable) => {
-			const varName = `var(--${builderVariable.name})`;
-			const resolvedLightColor = resolveVariableValue(varName);
-			const resolvedDarkColor = resolveVariableValue(varName, true);
+	// the group name is searchable along with the variable name
+	const searchableOptions = variables.map((builderVariable: BuilderVariable) => ({
+		label: `${builderVariable.variable_name || ""} ${builderVariable.group || ""}`,
+		variable: builderVariable,
+	}));
 
-			return {
-				label: `${builderVariable?.variable_name || ""}`,
-				value: varName,
-				prefix: shallowRef(
-					defineComponent({
-						setup() {
-							return () =>
-								h("div", {
-									class: "h-4 w-4 rounded shadow-sm border border-outline-gray-1 flex-shrink-0",
-									style: { background: isDark ? resolvedDarkColor : resolvedLightColor },
-								});
-						},
-					}),
-				),
-				suffix:
-					!builderVariable.is_standard && onEdit
-						? shallowRef(
-								defineComponent({
-									setup() {
-										return () =>
-											h(
-												"Button",
-												{
-													class: "hidden group-hover:inline-block",
-													onClick: (e: Event) => {
-														onEdit(builderVariable);
-													},
+	return filterOptions(searchableOptions, processedQuery).map(({ variable: builderVariable }) => {
+		const varName = `var(--${builderVariable.name})`;
+		const resolvedLightColor = resolveVariableValue(varName);
+		const resolvedDarkColor = resolveVariableValue(varName, true);
+
+		return {
+			label: `${builderVariable.variable_name || ""}`,
+			value: varName,
+			prefix: shallowRef(
+				defineComponent({
+					setup() {
+						return () =>
+							h("div", {
+								class: "h-4 w-4 rounded shadow-sm border border-outline-gray-1 flex-shrink-0",
+								style: { background: isDark ? resolvedDarkColor : resolvedLightColor },
+							});
+					},
+				}),
+			),
+			suffix:
+				!builderVariable.is_standard && onEdit
+					? shallowRef(
+							defineComponent({
+								setup() {
+									return () =>
+										h(
+											"Button",
+											{
+												class: "hidden group-hover:inline-block",
+												onClick: (e: Event) => {
+													onEdit(builderVariable);
 												},
-												"Edit",
-											);
-									},
-								}),
-							)
-						: undefined,
-			};
-		});
+											},
+											"Edit",
+										);
+								},
+							}),
+						)
+					: undefined,
+		};
+	});
 }

--- a/frontend/src/utils/colorOptions.ts
+++ b/frontend/src/utils/colorOptions.ts
@@ -9,17 +9,33 @@ export function getColorVariableOptions(
 	isDark: boolean,
 	onEdit?: (variable: BuilderVariable) => void,
 ) {
-	let processedQuery = query.replace(/^(--|var|\s+)/, "");
-	processedQuery = processedQuery.replace(/^--|\(|\s+/g, "");
+	// strip var(--...) syntax, keep the rest of the query as typed
+	let processedQuery = query
+		.replace(/^\s*(var\()?\s*(--)?/, "")
+		.replace(/\)\s*$/, "")
+		.trim();
+
+	const searchableLabel = (builderVariable: BuilderVariable) =>
+		`${builderVariable.variable_name || ""} ${builderVariable.group || ""}`;
 
 	// the group name is searchable along with the variable name
 	const searchableOptions = variables
 		.map((builderVariable: BuilderVariable) => ({
-			label: `${builderVariable.variable_name || ""} ${builderVariable.group || ""}`,
+			label: searchableLabel(builderVariable),
 			variable: builderVariable,
 		}))
 		// alphabetical, so the options around a match are related ones
 		.sort((a, b) => (a.variable.variable_name || "").localeCompare(b.variable.variable_name || ""));
+
+	// the query is the current selection when it is the var() value or the
+	// variable's display name (what ColorInput shows on focus): use its full
+	// label so filterOptions windows the list around it
+	const normalizedQuery = processedQuery.toLowerCase();
+	const selectedVariable = variables.find(
+		(v) =>
+			query.trim() === `var(--${v.name})` || (v.variable_name || "").toLowerCase() === normalizedQuery,
+	);
+	if (selectedVariable) processedQuery = searchableLabel(selectedVariable);
 
 	return filterOptions(searchableOptions, processedQuery).map(({ variable: builderVariable }) => {
 		const varName = `var(--${builderVariable.name})`;

--- a/frontend/src/utils/colorOptions.ts
+++ b/frontend/src/utils/colorOptions.ts
@@ -13,10 +13,13 @@ export function getColorVariableOptions(
 	processedQuery = processedQuery.replace(/^--|\(|\s+/g, "");
 
 	// the group name is searchable along with the variable name
-	const searchableOptions = variables.map((builderVariable: BuilderVariable) => ({
-		label: `${builderVariable.variable_name || ""} ${builderVariable.group || ""}`,
-		variable: builderVariable,
-	}));
+	const searchableOptions = variables
+		.map((builderVariable: BuilderVariable) => ({
+			label: `${builderVariable.variable_name || ""} ${builderVariable.group || ""}`,
+			variable: builderVariable,
+		}))
+		// alphabetical, so the options around a match are related ones
+		.sort((a, b) => (a.variable.variable_name || "").localeCompare(b.variable.variable_name || ""));
 
 	return filterOptions(searchableOptions, processedQuery).map(({ variable: builderVariable }) => {
 		const varName = `var(--${builderVariable.name})`;

--- a/frontend/src/utils/cssMetadata.ts
+++ b/frontend/src/utils/cssMetadata.ts
@@ -150,7 +150,7 @@ const getCSSPropertyOptions = (query: string, excludedProperties = new Set<strin
 };
 
 const getCSSValueOptions = (property: string, query: string) => {
-	return filterOptions(getKeywordOptions(property), query, MAX_SEARCH_RESULTS);
+	return filterOptions(getKeywordOptions(property), query, { limit: MAX_SEARCH_RESULTS });
 };
 
 export type { StyleControlConfig };

--- a/frontend/src/utils/cssMetadata.ts
+++ b/frontend/src/utils/cssMetadata.ts
@@ -2,6 +2,7 @@ import Autocomplete from "@/components/Controls/Autocomplete.vue";
 import ColorInput from "@/components/Controls/ColorInput.vue";
 import RangeInput from "@/components/Controls/RangeInput.vue";
 import cssPropertyMetadata from "@/data/cssPropertyMetadata.json";
+import { filterOptions } from "@/utils/autocompleteOptions";
 import {
 	BORDER_UNIT_OPTIONS,
 	BOX_UNIT_OPTIONS,
@@ -149,10 +150,7 @@ const getCSSPropertyOptions = (query: string, excludedProperties = new Set<strin
 };
 
 const getCSSValueOptions = (property: string, query: string) => {
-	const normalizedQuery = query.toLowerCase();
-	return getKeywordOptions(property)
-		.filter((option) => !normalizedQuery || option.label.toLowerCase().includes(normalizedQuery))
-		.slice(0, MAX_SEARCH_RESULTS);
+	return filterOptions(getKeywordOptions(property), query, MAX_SEARCH_RESULTS);
 };
 
 export type { StyleControlConfig };

--- a/frontend/src/utils/cssMetadata.ts
+++ b/frontend/src/utils/cssMetadata.ts
@@ -150,7 +150,7 @@ const getCSSPropertyOptions = (query: string, excludedProperties = new Set<strin
 };
 
 const getCSSValueOptions = (property: string, query: string) => {
-	return filterOptions(getKeywordOptions(property), query, { limit: MAX_SEARCH_RESULTS });
+	return filterOptions(getKeywordOptions(property), query, MAX_SEARCH_RESULTS);
 };
 
 export type { StyleControlConfig };


### PR DESCRIPTION
Each `getOptions` implementation filtered and capped its own list. Once an item was selected the list showed no extra options.

Add `filterOptions`, which puts the matches for a query first, fills the rest of the list with the other options, and stops at the limit. This way some options other than the selected one stay visible when available.

`filterOptions` takes `limit` and `windowRadius` in one options object. Without `windowRadius` it keeps the matches first, then fills the rest of the list. With `windowRadius` it keeps each match at its original position and shows the options around it.

Before:

https://github.com/user-attachments/assets/59af5f4a-06ef-48ff-9a83-cbb81fe3663e

After:

https://github.com/user-attachments/assets/bc3e6b7b-7a02-483e-b631-b7a569e6df45