### PR TITLE
feat: dark-mode variant for background images

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -1322,8 +1322,27 @@ def append_state_style(style_obj, style_tag, style_class, device="desktop"):
 		if ":" in key:
 			state, property = key.split(":", 1)
 			css_property = camel_case_to_kebab_case(property)
-			style_string = f".{style_class}:{state} {{ {css_property}: {value}; }}"
+			declaration = f"{css_property}: {value};"
+			if state == "dark":
+				style_string = dark_mode_style(style_class, declaration)
+			else:
+				style_string = f".{style_class}:{state} {{ {declaration} }}"
 			style_tag.append(wrap_with_media_query(style_string, device))
+
+
+def dark_mode_style(style_class, declaration):
+	"""CSS for a dark-mode-only style (e.g. a dark variant of a background image).
+
+	Dark mode is active for the OS scheme unless the page is manually pinned to
+	light, and for the manual dark toggle — mirroring how Builder scopes dark mode
+	elsewhere via data-theme / data-prefers-color-scheme.
+	"""
+	not_light = ':root:not([data-theme="light"]):not([data-prefers-color-scheme="light"])'
+	forced = f':root[data-theme="dark"] .{style_class}, :root[data-prefers-color-scheme="dark"] .{style_class}'
+	return (
+		f"@media (prefers-color-scheme: dark) {{ {not_light} .{style_class} {{ {declaration} }} }} "
+		f"{forced} {{ {declaration} }}"
+	)
 
 
 def get_font_family(font: str) -> str:

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -7,6 +7,7 @@
 					:component="BackgroundInput"
 					label="Background"
 					:enableStates="true"
+					:variants="bgVariants"
 					:allowDynamicValue="true"
 					placeholder="Set Background"
 					readonly
@@ -175,6 +176,10 @@ const BackgroundInput = defineComponent({
 			);
 	},
 });
+
+// "Dark Mode" sits alongside the hover/active/focus states in the "+" menu; its
+// value is stored as `dark:background*` styles and rendered under prefers-color-scheme.
+const bgVariants = [{ name: "dark", property: "dark:background", label: "Dark Mode" }];
 
 const activeState = ref<string | null>(null);
 
@@ -386,14 +391,17 @@ const handleSetVariant = (variantName: string, value: string | number | boolean 
 		return;
 	}
 
-	// Basic transition logic for states
-	blockController.getSelectedBlocks().forEach((block) => {
-		if (!block.getStyle("transitionDuration")) {
-			block.setStyle("transitionDuration", "300ms");
-			block.setStyle("transitionTimingFunction", "ease");
-			block.setStyle("transitionProperty", "all");
-		}
-	});
+	// Basic transition logic for interaction states; dark mode is a theme switch,
+	// not a hover-style state, so it shouldn't add a transition.
+	if (variantName !== "dark") {
+		blockController.getSelectedBlocks().forEach((block) => {
+			if (!block.getStyle("transitionDuration")) {
+				block.setStyle("transitionDuration", "300ms");
+				block.setStyle("transitionTimingFunction", "ease");
+				block.setStyle("transitionProperty", "all");
+			}
+		});
+	}
 
 	// the trigger input is read-only, so a non-null value here can only come from
 	// the "copy current value to state" dropdown — copy the actual base styles

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -374,7 +374,13 @@ const styles = computed(() => {
 	}
 
 	Object.keys(styleMap).forEach((key) => {
-		if (key.startsWith("hover:")) {
+		if (key.startsWith("dark:")) {
+			// preview the dark variant when the canvas is in dark mode
+			if (!props.preview && builderStore.canvasDarkMode) {
+				styleMap[key.slice(5)] = styleMap[key];
+			}
+			delete styleMap[key];
+		} else if (key.startsWith("hover:")) {
 			// state style preview on hover
 			// if (!isHovered.value) {
 			// 	delete styleMap[key];

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -389,16 +389,18 @@ function updateURLsInBlock(block: Block, currentSiteURL: string): void {
 		}
 	}
 
-	// Update background image URLs
-	if (block) {
-		const bgSrc = block.getStyle("backgroundImage");
+	// Update background image URLs (including the dark-mode variant)
+	const absolutizeBackground = (styleKey: string) => {
+		const bgSrc = block.getStyle(styleKey);
 		if (bgSrc && typeof bgSrc === "string" && bgSrc.startsWith("url(")) {
 			const urlMatch = bgSrc.match(/url\(["']?([^"']+)["']?\)/);
 			if (urlMatch && urlMatch[1] && urlMatch[1].startsWith("/")) {
-				block.setStyle("backgroundImage", `url(${currentSiteURL}${urlMatch[1]})`);
+				block.setStyle(styleKey, `url(${currentSiteURL}${urlMatch[1]})`);
 			}
 		}
-	}
+	};
+	absolutizeBackground("backgroundImage");
+	absolutizeBackground("dark:backgroundImage");
 
 	// Update href attributes for links
 	// if (block.isLink()) {


### PR DESCRIPTION
## What

Adds a **Dark Mode** option to the **Background** control's `+` menu, so a block can have a separate background (image / color / gradient) for dark mode — mirroring the dark variant already available on **Image** elements (`darkSrc`).

<!-- Select a block → Background → `+` → Dark Mode → set a dark background. -->

## How it works

- The dark background is stored as `dark:background*` styles (e.g. `dark:backgroundImage`), reusing the existing variant/state machinery — so the "+" menu, the variant row, and the popover editor all work with no new UI.
- On the published page it renders as `@media (prefers-color-scheme: dark)` **plus** `[data-theme="dark"]` / `[data-prefers-color-scheme="dark"]` selectors, matching how Builder already scopes dark mode (auto + manual toggle), instead of an invalid `:dark` pseudo-class.
- In the editor it previews live when the canvas dark-mode toggle is on (mirrors the image `darkSrc` swap).

## Changes

- **`BackgroundHandler.vue`** — expose the `dark` variant on the Background control; skip the hover-style transition for it (dark mode is a theme switch, not an interaction state).
- **`builder_page.py`** — `append_state_style` renders the `dark` state via a dark-mode media query + toggle selectors (`dark_mode_style` helper).
- **`BuilderBlock.vue`** — apply `dark:` styles in the canvas when `canvasDarkMode` is on.
- **`builderBlockCopyPaste.ts`** — absolutize the `dark:backgroundImage` URL on copy, like `darkSrc`.

## Testing

- Set a light + dark background on a block, published the page, and confirmed the background swaps between the light and dark values when the OS/browser color scheme flips.
- Verified the `+` menu lists **Dark Mode** alongside On Hover / On Active / On Focus, and that once set it appears as a variant row with its own background editor.



https://github.com/user-attachments/assets/947cc93b-50f1-483f-989a-56970488005a


