### PR TITLE
feat: render the canvas in a shadow root

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     BuilderBlock: typeof import('./src/components/BuilderBlock.vue')['default']
     BuilderBlockTemplates: typeof import('./src/components/BuilderBlockTemplates.vue')['default']
     BuilderCanvas: typeof import('./src/components/BuilderCanvas.vue')['default']
+    BuilderCanvasShadowRoot: typeof import('./src/components/BuilderCanvasShadowRoot.vue')['default']
     BuilderCommandPalette: typeof import('./src/components/BuilderCommandPalette.vue')['default']
     BuilderLeftPanel: typeof import('./src/components/BuilderLeftPanel.vue')['default']
     BuilderRightPanel: typeof import('./src/components/BuilderRightPanel.vue')['default']

--- a/frontend/src/builder.d.ts
+++ b/frontend/src/builder.d.ts
@@ -132,6 +132,9 @@ declare interface CanvasProps {
 	settingCanvas: boolean;
 	overlayElement: HTMLElement | null;
 	breakpoints: Breakpoint[];
+	scriptsRunning: boolean;
+	// bumped by the canvas's Refresh control to force a clean re-run of already-running scripts
+	scriptsRefreshNonce: number;
 }
 
 declare type EditingMode = "page" | "fragment";

--- a/frontend/src/builder.d.ts
+++ b/frontend/src/builder.d.ts
@@ -133,8 +133,6 @@ declare interface CanvasProps {
 	overlayElement: HTMLElement | null;
 	breakpoints: Breakpoint[];
 	scriptsRunning: boolean;
-	// bumped by the canvas's Refresh control to force a clean re-run of already-running scripts
-	scriptsRefreshNonce: number;
 }
 
 declare type EditingMode = "page" | "fragment";

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -46,6 +46,7 @@ import type Block from "@/block";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import blockController from "@/utils/blockController";
+import { elementFromPoint } from "@/utils/canvasShadowDom";
 import { addPxToNumber } from "@/utils/helpers";
 import { isReorderable, startBlockReorder } from "@/utils/useBlockReorder";
 import { Ref, computed, inject, nextTick, onMounted, ref, watch, watchEffect } from "vue";
@@ -240,11 +241,11 @@ const handleClick = (ev: MouseEvent) => {
 
 	const editorWrapper = editor.value;
 	editorWrapper.classList.add("pointer-events-none");
-	let element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
+	let element = elementFromPoint(ev.x, ev.y) as HTMLElement;
 	if (element.classList.contains("editor")) {
 		element.classList.remove("pointer-events-auto");
 		element.classList.add("pointer-events-none");
-		element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
+		element = elementFromPoint(ev.x, ev.y) as HTMLElement;
 	}
 	if (element.classList.contains("__builder_component__")) {
 		element.dispatchEvent(new MouseEvent("click", ev));

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -416,11 +416,10 @@ watch(
 		() => builderSettings.doc?.execute_block_scripts_in_editor,
 		() => pageStore.settingPage,
 		() => canvasProps?.scriptsRunning,
-		() => canvasProps?.scriptsRefreshNonce,
 		componentDataReady,
 	],
 	(
-		[element, clientScript, componentData, resolvedProps, , settingPage, scriptsRunning, , dataReady],
+		[element, clientScript, componentData, resolvedProps, , settingPage, scriptsRunning, dataReady],
 		_,
 		onCleanup,
 	) => {

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -415,9 +415,15 @@ watch(
 		allResolvedProps,
 		() => builderSettings.doc?.execute_block_scripts_in_editor,
 		() => pageStore.settingPage,
+		() => canvasProps?.scriptsRunning,
+		() => canvasProps?.scriptsRefreshNonce,
 		componentDataReady,
 	],
-	([element, clientScript, componentData, resolvedProps, , settingPage, dataReady], _, onCleanup) => {
+	(
+		[element, clientScript, componentData, resolvedProps, , settingPage, scriptsRunning, , dataReady],
+		_,
+		onCleanup,
+	) => {
 		if (!element || !clientScript) return;
 		const waitsForComponentData = Boolean(props.block.extendedFromComponent);
 		const cleanup = emulateBlockClientScript({
@@ -426,7 +432,7 @@ watch(
 			breakpoint: props.breakpoint,
 			css: clientScript.css ?? "",
 			javascript:
-				settingPage || (waitsForComponentData && !editingComponentId.value && !dataReady)
+				!scriptsRunning || settingPage || (waitsForComponentData && !editingComponentId.value && !dataReady)
 					? ""
 					: clientScript.javascript ?? "",
 			componentData: componentData ?? {},

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -50,6 +50,8 @@ import usePageStore from "@/stores/pageStore";
 import { BlockValueResolver } from "@/utils/blockValueResolver";
 import componentController from "@/utils/componentController.js";
 import { setFont } from "@/utils/fontManager";
+import { blockSelector, toStateStyleRules } from "@/utils/blockStateStyles";
+import type { BlockStateStyleRegistrar } from "@/utils/blockStateStyles";
 import { extractComponentId } from "@/utils/helpers";
 import type { BlockClientScriptEmulator } from "@/utils/scriptSandbox";
 import { useDraggableBlock } from "@/utils/useDraggableBlock";
@@ -245,6 +247,7 @@ const emulateBlockClientScript = inject<BlockClientScriptEmulator>(
 	"emulateBlockClientScript",
 	() => () => {},
 );
+const registerBlockStateStyles = inject<BlockStateStyleRegistrar>("registerBlockStateStyles", () => () => {});
 
 const target = computed(() => {
 	if (!component.value) return null;
@@ -288,21 +291,27 @@ const styles = computed(() => {
 		styleMap.fontFamily = (styleMap.fontFamily as string).replace(/ /g, "\\ ");
 	}
 
+	// state styles are not valid inline properties; stateStyleRules emits them
+	// as real rules into the canvas stylesheet instead
 	Object.keys(styleMap).forEach((key) => {
-		if (key.startsWith("hover:")) {
-			// state style preview on hover
-			// if (!isHovered.value) {
-			// 	delete styleMap[key];
-			// } else {
-			// 	styleMap[key.replace("hover:", "")] = styleMap[key];
-			// 	delete styleMap[key];
-			// }
-			delete styleMap[key];
-		}
+		if (key.includes(":")) delete styleMap[key];
 	});
 
 	return styleMap;
 });
+
+const stateStyleRules = computed(() =>
+	toStateStyleRules(props.block.getStyles(props.breakpoint), blockSelector(uidToUse, props.breakpoint)),
+);
+
+watch(
+	stateStyleRules,
+	(rules, _, onCleanup) => {
+		if (!rules) return;
+		onCleanup(registerBlockStateStyles(uidToUse, props.breakpoint, rules));
+	},
+	{ immediate: true },
+);
 
 const loadEditor = computed(() => {
 	return (

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -4,10 +4,6 @@
 		:data-builder-canvas="canvasId"
 		@click="handleClick"
 		@mousedown="handleMarqueeStart">
-		<component
-			:is="'style'"
-			v-if="blockClientStyles && !shadowCanvasEnabled"
-			v-text="blockClientStyles" />
 		<Transition name="fade">
 			<div
 				class="absolute bottom-0 left-0 right-0 top-0 grid w-full place-items-center bg-surface-gray-1 p-10 text-ink-gray-5"
@@ -37,6 +33,30 @@
 						<span
 							:class="[builderStore.canvasDarkMode ? 'lucide-sun' : 'lucide-moon', 'h-8 w-6 text-ink-gray-8']"
 							aria-hidden="true" />
+					</div>
+				</Tooltip>
+				<div
+					v-show="!canvasProps.scaling && !canvasProps.panning"
+					class="m-2 my-3 w-px bg-[var(--outline-gray-2)]"></div>
+				<Tooltip :text="canvasProps.scriptsRunning ? 'Stop Client Scripts' : 'Run Client Scripts'" :hoverDelay="0.6">
+					<div
+						v-show="!canvasProps.scaling && !canvasProps.panning"
+						class="w-auto cursor-pointer p-2"
+						@click.stop="canvasProps.scriptsRunning = !canvasProps.scriptsRunning">
+						<span
+							:class="[
+								canvasProps.scriptsRunning ? 'lucide-square' : 'lucide-play',
+								'h-8 w-6 text-ink-gray-8',
+							]"
+							aria-hidden="true" />
+					</div>
+				</Tooltip>
+				<Tooltip text="Refresh Client Scripts" :hoverDelay="0.6">
+					<div
+						v-show="!canvasProps.scaling && !canvasProps.panning && canvasProps.scriptsRunning"
+						class="w-auto cursor-pointer p-2"
+						@click.stop="refreshClientScripts">
+						<span class="lucide-refresh-cw h-8 w-6 text-ink-gray-8" aria-hidden="true" />
 					</div>
 				</Tooltip>
 				<div
@@ -79,13 +99,9 @@
 					{{ breakpoint.displayName }}
 				</div>
 				<BuilderCanvasShadowRoot
-					:disabled="!shadowCanvasEnabled"
 					@ready="(root) => registerCanvasRoot(breakpoint, root)"
 					@teardown="releaseCanvasRoot(breakpoint)">
-					<component
-						:is="'style'"
-						v-if="blockClientStyles && shadowCanvasEnabled"
-						v-text="blockClientStyles" />
+					<component :is="'style'" v-if="blockClientStyles" v-text="blockClientStyles" />
 					<BuilderBlock
 						class="h-full min-h-[inherit]"
 						:block="block"
@@ -139,7 +155,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
-import { elementFromPoint, getShadowRootOf, shadowCanvasEnabled } from "@/utils/canvasShadowDom";
+import { elementFromPoint, getShadowRootOf } from "@/utils/canvasShadowDom";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
 import { PageScriptRuntime } from "@/utils/pageScriptEmulation";
 import {
@@ -222,6 +238,10 @@ const canvasProps = reactive({
 	settingCanvas: true,
 	scaling: false,
 	panning: false,
+	// scripts are opt-in per session: they run in the editor's own realm,
+	// so an editor left open shouldn't execute arbitrary page/block JS by default
+	scriptsRunning: false,
+	scriptsRefreshNonce: 0,
 	breakpoints: [
 		{
 			icon: "lucide-monitor",
@@ -471,17 +491,12 @@ function escapeAttributeValue(value: string) {
 	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
-function blockStyleSelector(script: BlockClientScriptRuntime) {
-	const blockSelector = `[data-block-uid="${escapeAttributeValue(
-		script.key,
-	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
-	// a shadow root already scopes its styles to one canvas
-	return shadowCanvasEnabled ? blockSelector : `[data-builder-canvas="${canvasId}"] ${blockSelector}`;
-}
-
 function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 	const registrationKey = `${script.key}:${script.breakpoint}`;
-	const selector = blockStyleSelector(script);
+	// each breakpoint's shadow root already scopes its own styles to one canvas
+	const selector = `[data-block-uid="${escapeAttributeValue(
+		script.key,
+	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
 	blockStyles.set(registrationKey, script.css ? `${selector} { ${script.css} }` : "");
 
 	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
@@ -525,9 +540,17 @@ function releaseCanvasRoot(breakpoint: BreakpointConfig) {
 
 function applyPageClientScripts() {
 	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
+	const runJavaScript = canvasProps.scriptsRunning && mode !== "Don't Execute";
 	pageScriptRuntimes.forEach((runtime) =>
-		runtime.apply(pageStore.activePageScripts, mode !== "Don't Execute", pageStore.pageData),
+		runtime.apply(pageStore.activePageScripts, runJavaScript, pageStore.pageData),
 	);
+}
+
+// Refresh restarts scripts already running — new timers, listeners and a clean
+// JavaScript pass — without the user having to stop and start again.
+function refreshClientScripts() {
+	applyPageClientScripts();
+	canvasProps.scriptsRefreshNonce++;
 }
 
 watch(
@@ -536,6 +559,7 @@ watch(
 		() => pageStore.pageData,
 		() => builderSettings.doc?.execute_block_scripts_in_editor,
 		() => pageStore.settingPage,
+		() => canvasProps.scriptsRunning,
 	],
 	applyPageClientScripts,
 	{ deep: true },

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -214,11 +214,11 @@ const canvasProps = reactive({
 	settingCanvas: true,
 	scaling: false,
 	panning: false,
-	// scripts are opt-in per session: they run in the editor's own realm,
-	// so an editor left open shouldn't execute arbitrary page/block JS by default
+	// Scripts are opt-in per session. They share the editor's own realm, so an
+	// open editor should not run arbitrary page or block JavaScript unless asked.
 	scriptsRunning: false,
 	// bumped on Stop to force the block tree to remount, undoing any raw DOM
-	// mutation a script made directly (e.g. document.body.innerHTML = ...)
+	// mutation a script made (e.g. document.body.innerHTML = ...)
 	pageRestoreNonce: 0,
 	breakpoints: [
 		{
@@ -508,8 +508,8 @@ const pageScriptRuntimes = new Map<string, PageScriptRuntime>();
 
 function registerCanvasRoot(breakpoint: BreakpointConfig, root: ShadowRoot) {
 	pageScriptRuntimes.set(breakpoint.device, new PageScriptRuntime(root, breakpoint.width));
-	// the shadow root exists before Vue has teleported the block tree into it,
-	// so a script run right now would find no root block
+	// the shadow root exists before Vue teleports the block tree into it,
+	// so a script run now finds no root block
 	nextTick(applyPageClientScripts);
 }
 
@@ -538,10 +538,10 @@ watch(
 	{ deep: true },
 );
 
-// Stopping cleans up listeners and timers, but a script can also mutate the
-// DOM directly (document.body.innerHTML = ...), which Vue has no way to know
-// about or undo on its own. Force the block tree to remount from the Block
-// model so the page comes back to what it should be.
+// Stopping cleans up listeners and timers only. A script can also mutate the
+// DOM directly, such as document.body.innerHTML = ... Vue has no way to detect
+// or undo that on its own. So this remounts the block tree from the Block
+// model to bring the page back.
 watch(
 	() => canvasProps.scriptsRunning,
 	(running, wasRunning) => {

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -134,6 +134,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
+import { blockSelector } from "@/utils/blockStateStyles";
 import { elementFromPoint, getShadowRootOf } from "@/utils/canvasShadowDom";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
 import { PageScriptRuntime } from "@/utils/pageScriptEmulation";
@@ -177,7 +178,9 @@ const canvasContainer = ref(null) as Ref<HTMLElement | null>;
 const canvas = ref(null);
 const showBlocks = ref(false);
 const overlay = ref(null);
-const blockStyles = reactive(new Map<string, { breakpoint: string; css: string }>());
+type BreakpointStyles = { breakpoint: string; css: string };
+const blockStyles = reactive(new Map<string, BreakpointStyles>());
+const blockStateStyles = reactive(new Map<string, BreakpointStyles>());
 
 const props = withDefaults(
 	defineProps<{
@@ -191,13 +194,19 @@ const props = withDefaults(
 
 const block = ref(props.blockData) as Ref<Block>;
 const history = ref(null) as Ref<null> | CanvasHistory;
+// State styles resolve only while previewing. Editing means hovering blocks to
+// select them, and a block that restyles itself under the pointer is unusable.
+const previewingStates = computed(() => canvasProps.scriptsRunning);
+
 // grouped by breakpoint so each shadow root only gets the CSS for blocks it actually contains
 const blockStylesByBreakpoint = computed(() => {
 	const grouped = new Map<string, string>();
-	blockStyles.forEach(({ breakpoint, css }) => {
+	const append = ({ breakpoint, css }: BreakpointStyles) => {
 		if (!css) return;
 		grouped.set(breakpoint, grouped.has(breakpoint) ? `${grouped.get(breakpoint)}\n${css}` : css);
-	});
+	};
+	blockStyles.forEach(append);
+	if (previewingStates.value) blockStateStyles.forEach(append);
 	return grouped;
 });
 
@@ -410,6 +419,7 @@ watch(
 
 provide("canvasProps", canvasProps);
 provide("emulateBlockClientScript", emulateBlockClientScript);
+provide("registerBlockStateStyles", registerBlockStateStyles);
 
 defineExpose({
 	setScaleAndTranslate,
@@ -476,8 +486,12 @@ function selectBreakpoint(ev: MouseEvent, breakpoint: BreakpointConfig) {
 	}
 }
 
-function escapeAttributeValue(value: string) {
-	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+// Registered whatever the mode, so toggling preview flips one computed here
+// rather than re-running every block's watcher.
+function registerBlockStateStyles(uid: string, breakpoint: string, css: string) {
+	const registrationKey = `${uid}:${breakpoint}`;
+	blockStateStyles.set(registrationKey, { breakpoint, css });
+	return () => blockStateStyles.delete(registrationKey);
 }
 
 function emulateBlockClientScript(script: BlockClientScriptRuntime) {
@@ -488,9 +502,7 @@ function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 	const scriptsActive = canvasProps.scriptsRunning && mode !== "Don't Execute";
 
 	// each breakpoint's shadow root already scopes its own styles to one canvas
-	const selector = `[data-block-uid="${escapeAttributeValue(
-		script.key,
-	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
+	const selector = blockSelector(script.key, script.breakpoint);
 	const css = scriptsActive ? script.css : "";
 	blockStyles.set(registrationKey, {
 		breakpoint: script.breakpoint,

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -38,30 +38,6 @@
 				<div
 					v-show="!canvasProps.scaling && !canvasProps.panning"
 					class="m-2 my-3 w-px bg-[var(--outline-gray-2)]"></div>
-				<Tooltip :text="canvasProps.scriptsRunning ? 'Stop Client Scripts' : 'Run Client Scripts'" :hoverDelay="0.6">
-					<div
-						v-show="!canvasProps.scaling && !canvasProps.panning"
-						class="w-auto cursor-pointer p-2"
-						@click.stop="canvasProps.scriptsRunning = !canvasProps.scriptsRunning">
-						<span
-							:class="[
-								canvasProps.scriptsRunning ? 'lucide-square' : 'lucide-play',
-								'h-8 w-6 text-ink-gray-8',
-							]"
-							aria-hidden="true" />
-					</div>
-				</Tooltip>
-				<Tooltip text="Refresh Client Scripts" :hoverDelay="0.6">
-					<div
-						v-show="!canvasProps.scaling && !canvasProps.panning && canvasProps.scriptsRunning"
-						class="w-auto cursor-pointer p-2"
-						@click.stop="refreshClientScripts">
-						<span class="lucide-refresh-cw h-8 w-6 text-ink-gray-8" aria-hidden="true" />
-					</div>
-				</Tooltip>
-				<div
-					v-show="!canvasProps.scaling && !canvasProps.panning"
-					class="m-2 my-3 w-px bg-[var(--outline-gray-2)]"></div>
 				<div
 					v-show="!canvasProps.scaling && !canvasProps.panning"
 					class="w-auto cursor-pointer p-2"
@@ -241,7 +217,6 @@ const canvasProps = reactive({
 	// scripts are opt-in per session: they run in the editor's own realm,
 	// so an editor left open shouldn't execute arbitrary page/block JS by default
 	scriptsRunning: false,
-	scriptsRefreshNonce: 0,
 	breakpoints: [
 		{
 			icon: "lucide-monitor",
@@ -544,13 +519,6 @@ function applyPageClientScripts() {
 	pageScriptRuntimes.forEach((runtime) =>
 		runtime.apply(pageStore.activePageScripts, runJavaScript, pageStore.pageData),
 	);
-}
-
-// Refresh restarts scripts already running — new timers, listeners and a clean
-// JavaScript pass — without the user having to stop and start again.
-function refreshClientScripts() {
-	applyPageClientScripts();
-	canvasProps.scriptsRefreshNonce++;
 }
 
 watch(

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -77,7 +77,10 @@
 				<BuilderCanvasShadowRoot
 					@ready="(root) => registerCanvasRoot(breakpoint, root)"
 					@teardown="releaseCanvasRoot(breakpoint)">
-					<component :is="'style'" v-if="blockClientStyles" v-text="blockClientStyles" />
+					<component
+						:is="'style'"
+						v-if="blockStylesByBreakpoint.get(breakpoint.device)"
+						v-text="blockStylesByBreakpoint.get(breakpoint.device)" />
 					<BuilderBlock
 						class="h-full min-h-[inherit]"
 						:block="block"
@@ -174,7 +177,7 @@ const canvasContainer = ref(null) as Ref<HTMLElement | null>;
 const canvas = ref(null);
 const showBlocks = ref(false);
 const overlay = ref(null);
-const blockStyles = reactive(new Map<string, string>());
+const blockStyles = reactive(new Map<string, { breakpoint: string; css: string }>());
 
 const props = withDefaults(
 	defineProps<{
@@ -188,7 +191,15 @@ const props = withDefaults(
 
 const block = ref(props.blockData) as Ref<Block>;
 const history = ref(null) as Ref<null> | CanvasHistory;
-const blockClientStyles = computed(() => Array.from(blockStyles.values()).join("\n"));
+// grouped by breakpoint so each shadow root only gets the CSS for blocks it actually contains
+const blockStylesByBreakpoint = computed(() => {
+	const grouped = new Map<string, string>();
+	blockStyles.forEach(({ breakpoint, css }) => {
+		if (!css) return;
+		grouped.set(breakpoint, grouped.has(breakpoint) ? `${grouped.get(breakpoint)}\n${css}` : css);
+	});
+	return grouped;
+});
 
 const activeBreakpoint = ref("desktop") as Ref<string | null>;
 const hoveredBreakpoint = ref("desktop") as Ref<string | null>;
@@ -481,7 +492,10 @@ function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 		script.key,
 	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
 	const css = scriptsActive ? script.css : "";
-	blockStyles.set(registrationKey, css ? `${selector} { ${css} }` : "");
+	blockStyles.set(registrationKey, {
+		breakpoint: script.breakpoint,
+		css: css ? `${selector} { ${css} }` : "",
+	});
 
 	let cleanup = () => {};
 	if (scriptsActive && script.javascript.trim()) {

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -147,7 +147,7 @@ import { useCanvasEvents } from "@/utils/useCanvasEvents";
 import { useCanvasMarqueeSelection } from "@/utils/useCanvasMarqueeSelection";
 import { useCanvasUtils } from "@/utils/useCanvasUtils";
 import { Tooltip } from "frappe-ui";
-import { Ref, computed, onMounted, onUnmounted, provide, reactive, ref, useId, watch } from "vue";
+import { Ref, computed, nextTick, onMounted, onUnmounted, provide, reactive, ref, useId, watch } from "vue";
 import setPanAndZoom from "../utils/panAndZoom";
 import BlockSnapGuides from "./BlockSnapGuides.vue";
 import BuilderBlock from "./BuilderBlock.vue";
@@ -505,7 +505,9 @@ const pageScriptRuntimes = new Map<string, PageScriptRuntime>();
 
 function registerCanvasRoot(breakpoint: BreakpointConfig, root: ShadowRoot) {
 	pageScriptRuntimes.set(breakpoint.device, new PageScriptRuntime(root, breakpoint.width));
-	applyPageClientScripts();
+	// the shadow root exists before Vue has teleported the block tree into it,
+	// so a script run right now would find no root block
+	nextTick(applyPageClientScripts);
 }
 
 function releaseCanvasRoot(breakpoint: BreakpointConfig) {

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -471,15 +471,20 @@ function escapeAttributeValue(value: string) {
 
 function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 	const registrationKey = `${script.key}:${script.breakpoint}`;
+	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
+	// CSS runs alongside the JavaScript, under the same Run/Stop and mode gate,
+	// not on its own
+	const scriptsActive = canvasProps.scriptsRunning && mode !== "Don't Execute";
+
 	// each breakpoint's shadow root already scopes its own styles to one canvas
 	const selector = `[data-block-uid="${escapeAttributeValue(
 		script.key,
 	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
-	blockStyles.set(registrationKey, script.css ? `${selector} { ${script.css} }` : "");
+	const css = scriptsActive ? script.css : "";
+	blockStyles.set(registrationKey, css ? `${selector} { ${css} }` : "");
 
-	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
 	let cleanup = () => {};
-	if (mode !== "Don't Execute" && script.javascript.trim()) {
+	if (scriptsActive && script.javascript.trim()) {
 		const context = {
 			componentData: script.componentData,
 			props: script.props,
@@ -520,9 +525,9 @@ function releaseCanvasRoot(breakpoint: BreakpointConfig) {
 
 function applyPageClientScripts() {
 	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
-	const runJavaScript = canvasProps.scriptsRunning && mode !== "Don't Execute";
+	const runScripts = canvasProps.scriptsRunning && mode !== "Don't Execute";
 	pageScriptRuntimes.forEach((runtime) =>
-		runtime.apply(pageStore.activePageScripts, runJavaScript, pageStore.pageData),
+		runtime.apply(pageStore.activePageScripts, runScripts, pageStore.pageData),
 	);
 }
 

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -82,7 +82,7 @@
 						class="h-full min-h-[inherit]"
 						:block="block"
 						:style="variables"
-						:key="block.blockId"
+						:key="`${block.blockId}-${canvasProps.pageRestoreNonce}`"
 						:readonly="builderStore.readOnlyMode"
 						v-if="showBlocks"
 						:breakpoint="breakpoint.device"
@@ -217,6 +217,9 @@ const canvasProps = reactive({
 	// scripts are opt-in per session: they run in the editor's own realm,
 	// so an editor left open shouldn't execute arbitrary page/block JS by default
 	scriptsRunning: false,
+	// bumped on Stop to force the block tree to remount, undoing any raw DOM
+	// mutation a script made directly (e.g. document.body.innerHTML = ...)
+	pageRestoreNonce: 0,
 	breakpoints: [
 		{
 			icon: "lucide-monitor",
@@ -533,6 +536,17 @@ watch(
 	],
 	applyPageClientScripts,
 	{ deep: true },
+);
+
+// Stopping cleans up listeners and timers, but a script can also mutate the
+// DOM directly (document.body.innerHTML = ...), which Vue has no way to know
+// about or undo on its own. Force the block tree to remount from the Block
+// model so the page comes back to what it should be.
+watch(
+	() => canvasProps.scriptsRunning,
+	(running, wasRunning) => {
+		if (!running && wasRunning) canvasProps.pageRestoreNonce++;
+	},
 );
 </script>
 <style>

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -4,7 +4,10 @@
 		:data-builder-canvas="canvasId"
 		@click="handleClick"
 		@mousedown="handleMarqueeStart">
-		<component :is="'style'" v-if="blockClientStyles" v-text="blockClientStyles" />
+		<component
+			:is="'style'"
+			v-if="blockClientStyles && !shadowCanvasEnabled"
+			v-text="blockClientStyles" />
 		<Transition name="fade">
 			<div
 				class="absolute bottom-0 left-0 right-0 top-0 grid w-full place-items-center bg-surface-gray-1 p-10 text-ink-gray-5"
@@ -75,15 +78,24 @@
 					@click="activeBreakpoint = breakpoint.device">
 					{{ breakpoint.displayName }}
 				</div>
-				<BuilderBlock
-					class="h-full min-h-[inherit]"
-					:block="block"
-					:style="variables"
-					:key="block.blockId"
-					:readonly="builderStore.readOnlyMode"
-					v-if="showBlocks"
-					:breakpoint="breakpoint.device"
-					:data="pageStore.pageData" />
+				<BuilderCanvasShadowRoot
+					:disabled="!shadowCanvasEnabled"
+					@ready="(root) => registerCanvasRoot(breakpoint, root)"
+					@teardown="releaseCanvasRoot(breakpoint)">
+					<component
+						:is="'style'"
+						v-if="blockClientStyles && shadowCanvasEnabled"
+						v-text="blockClientStyles" />
+					<BuilderBlock
+						class="h-full min-h-[inherit]"
+						:block="block"
+						:style="variables"
+						:key="block.blockId"
+						:readonly="builderStore.readOnlyMode"
+						v-if="showBlocks"
+						:breakpoint="breakpoint.device"
+						:data="pageStore.pageData" />
+				</BuilderCanvasShadowRoot>
 			</div>
 		</div>
 		<div
@@ -127,7 +139,9 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
+import { elementFromPoint, getShadowRootOf, shadowCanvasEnabled } from "@/utils/canvasShadowDom";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
+import { PageScriptRuntime } from "@/utils/pageScriptEmulation";
 import {
 	type BlockClientScriptRuntime,
 	executeClientScriptRestricted,
@@ -145,6 +159,7 @@ import { Ref, computed, onMounted, onUnmounted, provide, reactive, ref, useId, w
 import setPanAndZoom from "../utils/panAndZoom";
 import BlockSnapGuides from "./BlockSnapGuides.vue";
 import BuilderBlock from "./BuilderBlock.vue";
+import BuilderCanvasShadowRoot from "./BuilderCanvasShadowRoot.vue";
 import DropIndicator from "./DropIndicator.vue";
 import FitScreenIcon from "./Icons/FitScreen.vue";
 
@@ -187,6 +202,7 @@ const activeBreakpoint = ref("desktop") as Ref<string | null>;
 const hoveredBreakpoint = ref("desktop") as Ref<string | null>;
 const hoveredBlock = ref(null) as Ref<string | null>;
 const setCanvasZoom = ref<(scale: number, pinchPoint: { x: number; y: number } | "center") => void>();
+let cleanupShadowCanvasEvents = () => {};
 
 const {
 	clearSelection,
@@ -282,7 +298,7 @@ onMounted(() => {
 		(readOnly) => (readOnly ? history.value?.disable() : history.value?.enable()),
 		{ immediate: true },
 	);
-	useCanvasEvents(
+	cleanupShadowCanvasEvents = useCanvasEvents(
 		canvasContainer as unknown as Ref<HTMLElement>,
 		canvasProps,
 		history as CanvasHistory,
@@ -297,6 +313,9 @@ onMounted(() => {
 
 onUnmounted(() => {
 	cleanupMarqueeListeners();
+	cleanupShadowCanvasEvents();
+	pageScriptRuntimes.forEach((runtime) => runtime.destroy());
+	pageScriptRuntimes.clear();
 });
 
 const handleClick = (ev: MouseEvent) => {
@@ -305,7 +324,7 @@ const handleClick = (ev: MouseEvent) => {
 		return;
 	}
 
-	const target = document.elementFromPoint(ev.clientX, ev.clientY);
+	const target = elementFromPoint(ev.clientX, ev.clientY);
 	// hack to ensure if click is on canvas-container
 	// TODO: Still clears selection if space handlers are dragged over canvas-container
 	if (target?.classList.contains("canvas-container")) {
@@ -452,11 +471,17 @@ function escapeAttributeValue(value: string) {
 	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
-function emulateBlockClientScript(script: BlockClientScriptRuntime) {
-	const registrationKey = `${script.key}:${script.breakpoint}`;
-	const selector = `[data-builder-canvas="${canvasId}"] [data-block-uid="${escapeAttributeValue(
+function blockStyleSelector(script: BlockClientScriptRuntime) {
+	const blockSelector = `[data-block-uid="${escapeAttributeValue(
 		script.key,
 	)}"][data-breakpoint="${escapeAttributeValue(script.breakpoint)}"]`;
+	// a shadow root already scopes its styles to one canvas
+	return shadowCanvasEnabled ? blockSelector : `[data-builder-canvas="${canvasId}"] ${blockSelector}`;
+}
+
+function emulateBlockClientScript(script: BlockClientScriptRuntime) {
+	const registrationKey = `${script.key}:${script.breakpoint}`;
+	const selector = blockStyleSelector(script);
 	blockStyles.set(registrationKey, script.css ? `${selector} { ${script.css} }` : "");
 
 	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
@@ -466,10 +491,12 @@ function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 			componentData: script.componentData,
 			props: script.props,
 		};
+		// the block's own shadow root is a tighter sandbox than the whole canvas
+		const sandboxRoot = getShadowRootOf(script.element) ?? canvasContainer.value;
 		cleanup =
 			mode === "Unrestricted"
 				? executeClientScriptUnrestricted(script.element, script.javascript, context)
-				: executeClientScriptRestricted(script.element, canvasContainer.value, script.javascript, context);
+				: executeClientScriptRestricted(script.element, sandboxRoot, script.javascript, context);
 	}
 
 	return () => {
@@ -482,6 +509,37 @@ function emulateBlockClientScript(script: BlockClientScriptRuntime) {
 }
 
 const renderedBreakpoints = computed(() => canvasProps.breakpoints.filter((bp) => bp.renderedOnce));
+
+// Page client scripts run once per breakpoint, against that breakpoint's shadow root.
+const pageScriptRuntimes = new Map<string, PageScriptRuntime>();
+
+function registerCanvasRoot(breakpoint: BreakpointConfig, root: ShadowRoot) {
+	pageScriptRuntimes.set(breakpoint.device, new PageScriptRuntime(root, breakpoint.width));
+	applyPageClientScripts();
+}
+
+function releaseCanvasRoot(breakpoint: BreakpointConfig) {
+	pageScriptRuntimes.get(breakpoint.device)?.destroy();
+	pageScriptRuntimes.delete(breakpoint.device);
+}
+
+function applyPageClientScripts() {
+	const mode = builderSettings.doc?.execute_block_scripts_in_editor ?? "Restricted";
+	pageScriptRuntimes.forEach((runtime) =>
+		runtime.apply(pageStore.activePageScripts, mode !== "Don't Execute", pageStore.pageData),
+	);
+}
+
+watch(
+	[
+		() => pageStore.activePageScripts,
+		() => pageStore.pageData,
+		() => builderSettings.doc?.execute_block_scripts_in_editor,
+		() => pageStore.settingPage,
+	],
+	applyPageClientScripts,
+	{ deep: true },
+);
 </script>
 <style>
 .fade-enter-active,

--- a/frontend/src/components/BuilderCanvasShadowRoot.vue
+++ b/frontend/src/components/BuilderCanvasShadowRoot.vue
@@ -9,9 +9,9 @@
 /**
  * Renders one breakpoint inside a shadow root.
  *
- * The slot content stays in the parent render scope, so provide/inject, stores
+ * The slot content stays in the parent render scope, so provide/inject, stores,
  * and the block tree work as before. Only the rendered nodes move across the
- * boundary. Editor overlays are not affected: BuilderBlock already teleports
+ * boundary. This does not affect editor overlays: BuilderBlock already teleports
  * BlockEditor to the light DOM overlay element.
  */
 import { registerCanvasShadowRoot } from "@/utils/canvasShadowDom";
@@ -44,9 +44,9 @@ onBeforeUnmount(() => {
 
 /**
  * Mirrors the canvas box so the block tree keeps the layout it had as a direct
- * child of .canvas. display:contents looks tidier but breaks two things: the
- * min-height:inherit chain the root block relies on, and getBoundingClientRect
- * for code that reads a block's parentElement.
+ * child of .canvas. display:contents looks tidier, but it breaks the
+ * min-height:inherit chain the root block relies on. It also breaks
+ * getBoundingClientRect for any code that reads a block's parentElement.
  */
 function createMountPoint() {
 	const element = document.createElement("div");

--- a/frontend/src/components/BuilderCanvasShadowRoot.vue
+++ b/frontend/src/components/BuilderCanvasShadowRoot.vue
@@ -15,7 +15,7 @@
  * BlockEditor to the light DOM overlay element.
  */
 import { registerCanvasShadowRoot } from "@/utils/canvasShadowDom";
-import { ShadowStyleSync } from "@/utils/canvasShadowStyles";
+import { registerShadowStyles } from "@/utils/canvasShadowStyles";
 import { Ref, onBeforeUnmount, onMounted, ref } from "vue";
 
 const emit = defineEmits<{ ready: [ShadowRoot]; teardown: [] }>();
@@ -23,14 +23,13 @@ const emit = defineEmits<{ ready: [ShadowRoot]; teardown: [] }>();
 const host = ref(null) as Ref<HTMLElement | null>;
 const mountPoint = ref(null) as Ref<HTMLElement | null>;
 
-let styleSync: ShadowStyleSync | null = null;
+let unregisterShadowStyles = () => {};
 let unregisterShadowRoot = () => {};
 
 onMounted(() => {
 	const shadowRoot = host.value?.attachShadow({ mode: "open" });
 	if (!shadowRoot) return;
-	styleSync = new ShadowStyleSync(shadowRoot);
-	styleSync.start();
+	unregisterShadowStyles = registerShadowStyles(shadowRoot);
 	unregisterShadowRoot = registerCanvasShadowRoot(shadowRoot);
 	mountPoint.value = shadowRoot.appendChild(createMountPoint());
 	emit("ready", shadowRoot);
@@ -38,7 +37,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	emit("teardown");
-	styleSync?.stop();
+	unregisterShadowStyles();
 	unregisterShadowRoot();
 });
 

--- a/frontend/src/components/BuilderCanvasShadowRoot.vue
+++ b/frontend/src/components/BuilderCanvasShadowRoot.vue
@@ -1,6 +1,5 @@
 <template>
-	<slot v-if="disabled" />
-	<div v-else ref="host" class="flex h-full min-h-[inherit] w-full">
+	<div ref="host" class="flex h-full min-h-[inherit] w-full">
 		<Teleport :to="mountPoint" v-if="mountPoint">
 			<slot />
 		</Teleport>
@@ -19,7 +18,6 @@ import { registerCanvasShadowRoot } from "@/utils/canvasShadowDom";
 import { ShadowStyleSync } from "@/utils/canvasShadowStyles";
 import { Ref, onBeforeUnmount, onMounted, ref } from "vue";
 
-const props = defineProps<{ disabled?: boolean }>();
 const emit = defineEmits<{ ready: [ShadowRoot]; teardown: [] }>();
 
 const host = ref(null) as Ref<HTMLElement | null>;
@@ -29,7 +27,6 @@ let styleSync: ShadowStyleSync | null = null;
 let unregisterShadowRoot = () => {};
 
 onMounted(() => {
-	if (props.disabled) return;
 	const shadowRoot = host.value?.attachShadow({ mode: "open" });
 	if (!shadowRoot) return;
 	styleSync = new ShadowStyleSync(shadowRoot);

--- a/frontend/src/components/BuilderCanvasShadowRoot.vue
+++ b/frontend/src/components/BuilderCanvasShadowRoot.vue
@@ -1,0 +1,59 @@
+<template>
+	<slot v-if="disabled" />
+	<div v-else ref="host" class="flex h-full min-h-[inherit] w-full">
+		<Teleport :to="mountPoint" v-if="mountPoint">
+			<slot />
+		</Teleport>
+	</div>
+</template>
+<script setup lang="ts">
+/**
+ * Renders one breakpoint inside a shadow root.
+ *
+ * The slot content stays in the parent render scope, so provide/inject, stores
+ * and the block tree work as before. Only the rendered nodes move across the
+ * boundary. Editor overlays are not affected: BuilderBlock already teleports
+ * BlockEditor to the light DOM overlay element.
+ */
+import { registerCanvasShadowRoot } from "@/utils/canvasShadowDom";
+import { ShadowStyleSync } from "@/utils/canvasShadowStyles";
+import { Ref, onBeforeUnmount, onMounted, ref } from "vue";
+
+const props = defineProps<{ disabled?: boolean }>();
+const emit = defineEmits<{ ready: [ShadowRoot]; teardown: [] }>();
+
+const host = ref(null) as Ref<HTMLElement | null>;
+const mountPoint = ref(null) as Ref<HTMLElement | null>;
+
+let styleSync: ShadowStyleSync | null = null;
+let unregisterShadowRoot = () => {};
+
+onMounted(() => {
+	if (props.disabled) return;
+	const shadowRoot = host.value?.attachShadow({ mode: "open" });
+	if (!shadowRoot) return;
+	styleSync = new ShadowStyleSync(shadowRoot);
+	styleSync.start();
+	unregisterShadowRoot = registerCanvasShadowRoot(shadowRoot);
+	mountPoint.value = shadowRoot.appendChild(createMountPoint());
+	emit("ready", shadowRoot);
+});
+
+onBeforeUnmount(() => {
+	emit("teardown");
+	styleSync?.stop();
+	unregisterShadowRoot();
+});
+
+/**
+ * Mirrors the canvas box so the block tree keeps the layout it had as a direct
+ * child of .canvas. display:contents looks tidier but breaks two things: the
+ * min-height:inherit chain the root block relies on, and getBoundingClientRect
+ * for code that reads a block's parentElement.
+ */
+function createMountPoint() {
+	const element = document.createElement("div");
+	element.style.cssText = "display: flex; width: 100%; height: 100%; min-height: inherit;";
+	return element;
+}
+</script>

--- a/frontend/src/components/BuilderCommandPalette.vue
+++ b/frontend/src/components/BuilderCommandPalette.vue
@@ -18,7 +18,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import { useDark, useToggle, watchDebounced } from "@vueuse/core";
-import { useShortcut } from "frappe-ui";
+import { toast, useShortcut } from "frappe-ui";
 import { computed, inject, nextTick, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import type { CommandPaletteItem as CPItem } from "./CommandPalette.vue";
@@ -49,9 +49,13 @@ useShortcut({
 	},
 });
 
+// Preview leaves no lasting mark on the canvas, so say which way it just went.
+// Only the deliberate toggle announces itself; a hold is self-evident.
 function toggleClientScripts() {
 	const canvasProps = canvasStore.activeCanvas?.canvasProps;
-	if (canvasProps) canvasProps.scriptsRunning = !canvasProps.scriptsRunning;
+	if (!canvasProps) return;
+	canvasProps.scriptsRunning = !canvasProps.scriptsRunning;
+	toast.info(canvasProps.scriptsRunning ? "Canvas preview on" : "Canvas preview off");
 }
 
 // Remembers the Run/Stop state from before a preview hold, so releasing the
@@ -137,7 +141,7 @@ const staticCommands = computed<Command[]>(() => {
 						group: "Navigate",
 						action: () => router.push({ name: "home" }),
 					},
-				]
+			  ]
 			: []),
 		...(isBuilder
 			? [
@@ -181,7 +185,7 @@ const staticCommands = computed<Command[]>(() => {
 						group: "Page",
 						action: toggleClientScripts,
 					},
-				]
+			  ]
 			: []),
 		...(isBuilder
 			? [
@@ -211,7 +215,7 @@ const staticCommands = computed<Command[]>(() => {
 							builderStore.activeLayers?.collapseAll();
 						},
 					},
-				]
+			  ]
 			: []),
 		...(isBuilder
 			? [
@@ -235,7 +239,7 @@ const staticCommands = computed<Command[]>(() => {
 							builderStore.showRightPanel = !builderStore.showRightPanel;
 						},
 					},
-				]
+			  ]
 			: []),
 		{
 			name: "toggle-theme",
@@ -255,7 +259,7 @@ const staticCommands = computed<Command[]>(() => {
 						group: "General",
 						action: () => showShortcuts(),
 					},
-				]
+			  ]
 			: []),
 		{
 			name: "settings",
@@ -485,7 +489,7 @@ const commandGroups = computed(() => {
 		const items = q
 			? settingsCommands.value.filter(
 					(s) => s.title.toLowerCase().includes(q) || s.description?.toLowerCase().includes(q),
-				)
+			  )
 			: settingsCommands.value;
 		const pageItems = items.filter((s) => (s as SettingsCommand).section === "page");
 		const globalItems = items.filter((s) => (s as SettingsCommand).section === "global");
@@ -511,7 +515,7 @@ const commandGroups = computed(() => {
 							component: CommandPaletteItem,
 							items: pageSearchResults.value,
 						},
-					]
+				  ]
 				: [];
 		}
 		return recentPages.value.length
@@ -523,7 +527,7 @@ const commandGroups = computed(() => {
 						component: CommandPaletteItem,
 						items: recentPages.value,
 					},
-				]
+			  ]
 			: [];
 	}
 

--- a/frontend/src/components/BuilderCommandPalette.vue
+++ b/frontend/src/components/BuilderCommandPalette.vue
@@ -14,6 +14,7 @@
 <script setup lang="ts">
 import { searchablePages } from "@/data/webPage";
 import useBuilderStore from "@/stores/builderStore";
+import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import { useDark, useToggle, watchDebounced } from "@vueuse/core";
@@ -30,6 +31,7 @@ const activeStep = ref<{ id: string; label: string; placeholder: string; hint: s
 
 const builderStore = useBuilderStore();
 const pageStore = usePageStore();
+const canvasStore = useCanvasStore();
 const route = useRoute();
 const router = useRouter();
 const showShortcuts = inject<() => void>("showShortcuts", () => {});
@@ -137,6 +139,17 @@ const staticCommands = computed<Command[]>(() => {
 							if (pageStore.activePage) {
 								pageStore.duplicatePage(pageStore.activePage);
 							}
+						},
+					},
+					{
+						name: "toggle-client-scripts",
+						title: `${canvasStore.activeCanvas?.canvasProps.scriptsRunning ? "Stop" : "Run"} Client Scripts`,
+						icon: canvasStore.activeCanvas?.canvasProps.scriptsRunning ? "lucide-square" : "lucide-play",
+						description: "Page",
+						group: "Page",
+						action: () => {
+							const canvasProps = canvasStore.activeCanvas?.canvasProps;
+							if (canvasProps) canvasProps.scriptsRunning = !canvasProps.scriptsRunning;
 						},
 					},
 				]

--- a/frontend/src/components/BuilderCommandPalette.vue
+++ b/frontend/src/components/BuilderCommandPalette.vue
@@ -58,36 +58,28 @@ function toggleClientScripts() {
 // key restores it instead of always landing on Stop.
 let scriptsRunningBeforeHold = false;
 
-useShortcut([
-	{
-		key: "p",
-		ctrl: true,
-		shift: true,
-		description: "Toggle Client Scripts",
-		group: "Page",
-		condition: () => isBuilderRoute.value,
-		handler: toggleClientScripts,
+// One combo, two outcomes: a tap toggles Run/Stop, a hold previews with
+// scripts on and restores the prior state on release.
+useShortcut({
+	key: "p",
+	ctrl: true,
+	shift: true,
+	description: "Toggle Client Scripts (hold to preview)",
+	group: "Page",
+	triggeredOn: "hold",
+	condition: () => isBuilderRoute.value,
+	handler: toggleClientScripts,
+	onHold: () => {
+		const canvasProps = canvasStore.activeCanvas?.canvasProps;
+		if (!canvasProps) return;
+		scriptsRunningBeforeHold = canvasProps.scriptsRunning;
+		canvasProps.scriptsRunning = true;
 	},
-	{
-		key: "p",
-		alt: true,
-		shift: true,
-		description: "Hold to Preview Client Scripts",
-		group: "Page",
-		triggeredOn: "hold",
-		condition: () => isBuilderRoute.value,
-		onHold: () => {
-			const canvasProps = canvasStore.activeCanvas?.canvasProps;
-			if (!canvasProps) return;
-			scriptsRunningBeforeHold = canvasProps.scriptsRunning;
-			canvasProps.scriptsRunning = true;
-		},
-		onRelease: () => {
-			const canvasProps = canvasStore.activeCanvas?.canvasProps;
-			if (canvasProps) canvasProps.scriptsRunning = scriptsRunningBeforeHold;
-		},
+	onRelease: () => {
+		const canvasProps = canvasStore.activeCanvas?.canvasProps;
+		if (canvasProps) canvasProps.scriptsRunning = scriptsRunningBeforeHold;
 	},
-]);
+});
 
 const isDark = useDark({ attribute: "data-theme" });
 const toggleDark = useToggle(isDark);

--- a/frontend/src/components/BuilderCommandPalette.vue
+++ b/frontend/src/components/BuilderCommandPalette.vue
@@ -49,6 +49,46 @@ useShortcut({
 	},
 });
 
+function toggleClientScripts() {
+	const canvasProps = canvasStore.activeCanvas?.canvasProps;
+	if (canvasProps) canvasProps.scriptsRunning = !canvasProps.scriptsRunning;
+}
+
+// Remembers the Run/Stop state from before a preview hold, so releasing the
+// key restores it instead of always landing on Stop.
+let scriptsRunningBeforeHold = false;
+
+useShortcut([
+	{
+		key: "p",
+		ctrl: true,
+		shift: true,
+		description: "Toggle Client Scripts",
+		group: "Page",
+		condition: () => isBuilderRoute.value,
+		handler: toggleClientScripts,
+	},
+	{
+		key: "p",
+		alt: true,
+		shift: true,
+		description: "Hold to Preview Client Scripts",
+		group: "Page",
+		triggeredOn: "hold",
+		condition: () => isBuilderRoute.value,
+		onHold: () => {
+			const canvasProps = canvasStore.activeCanvas?.canvasProps;
+			if (!canvasProps) return;
+			scriptsRunningBeforeHold = canvasProps.scriptsRunning;
+			canvasProps.scriptsRunning = true;
+		},
+		onRelease: () => {
+			const canvasProps = canvasStore.activeCanvas?.canvasProps;
+			if (canvasProps) canvasProps.scriptsRunning = scriptsRunningBeforeHold;
+		},
+	},
+]);
+
 const isDark = useDark({ attribute: "data-theme" });
 const toggleDark = useToggle(isDark);
 
@@ -147,10 +187,7 @@ const staticCommands = computed<Command[]>(() => {
 						icon: canvasStore.activeCanvas?.canvasProps.scriptsRunning ? "lucide-square" : "lucide-play",
 						description: "Page",
 						group: "Page",
-						action: () => {
-							const canvasProps = canvasStore.activeCanvas?.canvasProps;
-							if (canvasProps) canvasProps.scriptsRunning = !canvasProps.scriptsRunning;
-						},
+						action: toggleClientScripts,
 					},
 				]
 			: []),

--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -33,6 +33,7 @@ import type Block from "@/block";
 import TextBlockBubbleMenu from "@/components/TextBlockBubbleMenu.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import blockController from "@/utils/blockController";
+import { closestAcrossShadow, getEventTarget } from "@/utils/canvasShadowDom";
 import { BlockValueResolver } from "@/utils/blockValueResolver";
 import { setFontFromHTML } from "@/utils/fontManager";
 import type { PauseId } from "@/utils/useCanvasHistory";
@@ -318,7 +319,7 @@ const handleEscKey = () => {
 };
 
 const handleClickOutside = (e: MouseEvent) => {
-	if ((e.target as HTMLElement).closest(".canvas-container")) {
+	if (closestAcrossShadow(getEventTarget(e), ".canvas-container")) {
 		canvasStore.editableBlock = null;
 	}
 };

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -49,7 +49,6 @@ const useBuilderStore = defineStore("builderStore", {
 			attribute: "data-theme",
 		}),
 		canvasDarkMode: useStorage("canvasDarkMode", false),
-		highlightBlocksWithClientScripts: false,
 		showSettingsDialog: false,
 		settingsActiveTab: useStorage("settingsActiveTab", "page_general"),
 		openImageUpload: false,

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1,5 +1,6 @@
 import type Block from "@/block";
 import type BuilderCanvas from "@/components/BuilderCanvas.vue";
+import { queryCanvas } from "@/utils/canvasShadowDom";
 import type { IndicatorGeometry } from "@/utils/dropGeometry";
 import { getVersionedDoc } from "@/data/snapshot";
 import { confirm, getBlockCopy, getBlockInstance } from "@/utils/helpers";
@@ -271,7 +272,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			let element = document.createElement("div");
 			element.id = "placeholder";
 
-			const root = document.querySelector(".__builder_component__[data-block-id='root']");
+			const root = queryCanvas(".__builder_component__[data-block-id='root']");
 			if (root) {
 				this.dropTarget.placeholder = root.appendChild(element);
 			}
@@ -279,10 +280,7 @@ const useCanvasStore = defineStore("canvasStore", {
 		},
 
 		removeDropPlaceholder() {
-			const placeholder = document.getElementById("placeholder");
-			if (placeholder) {
-				placeholder.remove();
-			}
+			queryCanvas("#placeholder")?.remove();
 		},
 
 		clearReorderTarget() {

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -81,7 +81,13 @@ const usePageStore = defineStore("pageStore", {
 				});
 
 				await scriptsResource.list.promise;
-				this.activePageScripts = scriptsResource.data as BuilderClientScript[];
+				// the fetch does not keep attachment order, but execution order matters
+				const scriptsByName = new Map(
+					(scriptsResource.data as BuilderClientScript[]).map((script) => [script.name, script]),
+				);
+				this.activePageScripts = page.client_scripts
+					.map((attached) => scriptsByName.get(attached.builder_script))
+					.filter(Boolean) as BuilderClientScript[];
 			} else {
 				this.activePageScripts = [];
 			}

--- a/frontend/src/types/Builder/BuilderCanvas.ts
+++ b/frontend/src/types/Builder/BuilderCanvas.ts
@@ -20,6 +20,9 @@ export interface CanvasProps {
 	scaling: boolean;
 	panning: boolean;
 	breakpoints: BreakpointConfig[];
+	scriptsRunning: boolean;
+	// bumped by the canvas's Refresh control to force a clean re-run of already-running scripts
+	scriptsRefreshNonce: number;
 }
 
 export type CanvasHistory = Ref<ReturnType<typeof useCanvasHistory>>;

--- a/frontend/src/types/Builder/BuilderCanvas.ts
+++ b/frontend/src/types/Builder/BuilderCanvas.ts
@@ -21,8 +21,6 @@ export interface CanvasProps {
 	panning: boolean;
 	breakpoints: BreakpointConfig[];
 	scriptsRunning: boolean;
-	// bumped by the canvas's Refresh control to force a clean re-run of already-running scripts
-	scriptsRefreshNonce: number;
 }
 
 export type CanvasHistory = Ref<ReturnType<typeof useCanvasHistory>>;

--- a/frontend/src/utils/blockStateStyles.ts
+++ b/frontend/src/utils/blockStateStyles.ts
@@ -1,0 +1,53 @@
+/**
+ * Turns a block's state styles (hover:, focus:, active:) into canvas CSS.
+ *
+ * A published page puts every style in a stylesheet, so `.fb-x:hover` wins on
+ * specificity alone. The canvas renders a block's regular styles inline, and an
+ * inline declaration beats any rule, so each state declaration needs !important
+ * to apply while the state holds. Mirrors append_state_style in builder_page.py.
+ */
+import { splitStylePrefix, toKebabCase } from "@/utils/helpers";
+
+type BlockStateStyleRegistrar = (uid: string, breakpoint: string, css: string) => () => void;
+
+function escapeAttributeValue(value: string) {
+	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+/** Matches one block inside one breakpoint's canvas. */
+function blockSelector(uid: string, breakpoint: string) {
+	const block = escapeAttributeValue(uid);
+	const device = escapeAttributeValue(breakpoint);
+	return `[data-block-uid="${block}"][data-breakpoint="${device}"]`;
+}
+
+function toDeclaration(property: string, value: StyleValue) {
+	const text = property === "fontFamily" ? String(value).replace(/ /g, "\\ ") : String(value);
+	const priority = text.includes("!important") ? "" : " !important";
+	return `${toKebabCase(property)}: ${text}${priority};`;
+}
+
+function isRenderable(property: string, value: StyleValue) {
+	return !property.startsWith("__") && value !== null && value !== undefined && value !== "";
+}
+
+/** One rule per state, so `hover:color` and `hover:background` share a block. */
+function toStateStyleRules(styles: BlockStyleMap, selector: string) {
+	const declarationsByState = new Map<string, string[]>();
+	Object.entries(styles).forEach(([style, value]) => {
+		const { prefix, property } = splitStylePrefix(style);
+		if (!prefix || !isRenderable(property, value)) return;
+		const state = prefix.slice(0, -1);
+		declarationsByState.set(state, [
+			...(declarationsByState.get(state) ?? []),
+			toDeclaration(property, value),
+		]);
+	});
+	return Array.from(
+		declarationsByState,
+		([state, declarations]) => `${selector}:${state} { ${declarations.join(" ")} }`,
+	).join("\n");
+}
+
+export { blockSelector, toStateStyleRules };
+export type { BlockStateStyleRegistrar };

--- a/frontend/src/utils/canvasScriptFacade.ts
+++ b/frontend/src/utils/canvasScriptFacade.ts
@@ -1,0 +1,149 @@
+/**
+ * Document and window facades for client scripts in a shadow canvas.
+ *
+ * A published page gives a client script the real document. In the editor the
+ * page renders inside a shadow root, so `document.querySelector` would search
+ * the editor UI and find nothing. These facades route DOM lookups to the shadow
+ * root, report the breakpoint width, and record listeners and timers so the
+ * caller can undo them.
+ *
+ * These facades emulate. They do not sandbox. A page script still runs in the
+ * editor JavaScript realm and can reach the real window through any global it
+ * likes. Shadow DOM cannot prevent that. Use scriptSandbox.ts when you need the
+ * restricted mode.
+ */
+
+type Disposer = () => void;
+
+/** Events a page script waits for that already happened by the time it runs. */
+const READY_EVENTS = new Set(["DOMContentLoaded", "load", "readystatechange"]);
+
+const WIDTH_CONDITION = /\((min|max)-width:\s*(\d+(?:\.\d+)?)(px)?\)/gi;
+
+function createFacade<T extends object>(base: T, overrides: object): T {
+	return new Proxy(base, {
+		get(target, prop) {
+			if (prop in overrides) return Reflect.get(overrides, prop);
+			const value = Reflect.get(target, prop);
+			// native methods throw "Illegal invocation" when called on the proxy
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+		set(target, prop, value) {
+			if (prop in overrides) return Reflect.set(overrides, prop, value);
+			return Reflect.set(target, prop, value);
+		},
+	}) as T;
+}
+
+class CanvasScriptScope {
+	private disposers: Disposer[] = [];
+	readonly document: Document;
+	readonly window: Window;
+
+	constructor(
+		private root: ShadowRoot,
+		private breakpointWidth: number,
+		private pageData: Record<string, any> = {},
+	) {
+		this.document = this.createDocumentFacade();
+		this.window = this.createWindowFacade();
+	}
+
+	/** Undo every listener and timer the scripts registered. */
+	dispose() {
+		this.disposers.forEach((disposer) => disposer());
+		this.disposers = [];
+	}
+
+	private track(disposer: Disposer) {
+		this.disposers.push(disposer);
+	}
+
+	/** The rendered page body, which is the root block. */
+	private get pageBody() {
+		return this.root.querySelector<HTMLElement>("[data-block-id='root']") ?? this.root.firstElementChild;
+	}
+
+	private addRootListener(type: string, listener: EventListenerOrEventListenerObject, options?: any) {
+		if (READY_EVENTS.has(type)) {
+			const timer = setTimeout(() => (listener as EventListener)(new Event(type)));
+			this.track(() => clearTimeout(timer));
+			return;
+		}
+		this.root.addEventListener(type, listener, options);
+		this.track(() => this.root.removeEventListener(type, listener, options));
+	}
+
+	private createDocumentFacade() {
+		const root = this.root;
+		const getPageBody = () => this.pageBody;
+		const overrides = {
+			querySelector: (selector: string) => root.querySelector(selector),
+			querySelectorAll: (selector: string) => root.querySelectorAll(selector),
+			getElementById: (id: string) => root.getElementById(id),
+			getElementsByClassName: (name: string) => root.querySelectorAll(`.${CSS.escape(name)}`),
+			getElementsByTagName: (name: string) => root.querySelectorAll(name),
+			addEventListener: this.addRootListener.bind(this),
+			removeEventListener: (type: string, listener: any, options?: any) =>
+				root.removeEventListener(type, listener, options),
+			dispatchEvent: (event: Event) => root.dispatchEvent(event),
+			readyState: "complete",
+			currentScript: null,
+			get body() {
+				return getPageBody();
+			},
+			get documentElement() {
+				return getPageBody();
+			},
+		};
+		return createFacade(document, overrides);
+	}
+
+	/**
+	 * A shadow root resolves media queries against the editor viewport, so a
+	 * width query would give the same answer on every breakpoint. Answer width
+	 * queries from the breakpoint instead and pass everything else through.
+	 */
+	private matchBreakpointMedia(query: string) {
+		WIDTH_CONDITION.lastIndex = 0;
+		const conditions = Array.from(query.matchAll(WIDTH_CONDITION));
+		if (!conditions.length) return window.matchMedia(query);
+		const matches = conditions.every(([, bound, value]) =>
+			bound.toLowerCase() === "min" ? this.breakpointWidth >= Number(value) : this.breakpointWidth <= Number(value),
+		);
+		return { matches, media: query, addEventListener() {}, removeEventListener() {}, onchange: null };
+	}
+
+	private createWindowFacade() {
+		const overrides = {
+			document: this.document,
+			// the published page sets this in webpage_scripts.html
+			page_data: this.pageData,
+			innerWidth: this.breakpointWidth,
+			matchMedia: (query: string) => this.matchBreakpointMedia(query),
+			addEventListener: (type: string, listener: any, options?: any) => {
+				if (READY_EVENTS.has(type)) return this.addRootListener(type, listener, options);
+				window.addEventListener(type, listener, options);
+				this.track(() => window.removeEventListener(type, listener, options));
+			},
+			setTimeout: (handler: TimerHandler, delay?: number, ...args: any[]) => {
+				const timer = window.setTimeout(handler, delay, ...args);
+				this.track(() => window.clearTimeout(timer));
+				return timer;
+			},
+			setInterval: (handler: TimerHandler, delay?: number, ...args: any[]) => {
+				const timer = window.setInterval(handler, delay, ...args);
+				this.track(() => window.clearInterval(timer));
+				return timer;
+			},
+			requestAnimationFrame: (callback: FrameRequestCallback) => {
+				const frame = window.requestAnimationFrame(callback);
+				this.track(() => window.cancelAnimationFrame(frame));
+				return frame;
+			},
+		};
+		return createFacade(window, overrides);
+	}
+}
+
+export { CanvasScriptScope };

--- a/frontend/src/utils/canvasScriptFacade.ts
+++ b/frontend/src/utils/canvasScriptFacade.ts
@@ -59,9 +59,15 @@ class CanvasScriptScope {
 		this.disposers.push(disposer);
 	}
 
-	/** The rendered page body, which is the root block. */
+	/**
+	 * The rendered page body, which is the root block.
+	 *
+	 * No fallback here on purpose: the shadow root also holds an internal style
+	 * sync element unrelated to the page, so guessing at a substitute risks a
+	 * script mutating the wrong node instead of failing loudly.
+	 */
 	private get pageBody() {
-		return this.root.querySelector<HTMLElement>("[data-block-id='root']") ?? this.root.firstElementChild;
+		return this.root.querySelector<HTMLElement>("[data-block-id='root']");
 	}
 
 	private addRootListener(type: string, listener: EventListenerOrEventListenerObject, options?: any) {

--- a/frontend/src/utils/canvasScriptFacade.ts
+++ b/frontend/src/utils/canvasScriptFacade.ts
@@ -8,9 +8,8 @@
  * caller can undo them.
  *
  * These facades emulate. They do not sandbox. A page script still runs in the
- * editor JavaScript realm and can reach the real window through any global it
- * likes. Shadow DOM cannot prevent that. Use scriptSandbox.ts when you need the
- * restricted mode.
+ * editor's JavaScript realm and can reach the real window through any global.
+ * Shadow DOM does not prevent that. Use scriptSandbox.ts for the restricted mode.
  */
 
 type Disposer = () => void;
@@ -62,9 +61,9 @@ class CanvasScriptScope {
 	/**
 	 * The rendered page body, which is the root block.
 	 *
-	 * No fallback here on purpose: the shadow root also holds an internal style
-	 * sync element unrelated to the page, so guessing at a substitute risks a
-	 * script mutating the wrong node instead of failing loudly.
+	 * No fallback here on purpose. The shadow root also holds an internal
+	 * style-sync element unrelated to the page. Guessing at a substitute risks
+	 * a wrong mutation instead of a loud failure.
 	 */
 	private get pageBody() {
 		return this.root.querySelector<HTMLElement>("[data-block-id='root']");

--- a/frontend/src/utils/canvasShadowDom.ts
+++ b/frontend/src/utils/canvasShadowDom.ts
@@ -9,12 +9,7 @@
  * - `event.target` retargets to the host element. Use `getEventTarget`.
  * - `document.querySelector` does not descend into a shadow root. Use `queryCanvas`.
  *
- * These helpers also work when no shadow root exists, so the call sites stay
- * correct with the flag off.
  */
-
-/** Prototype switch. Set `localStorage.builderShadowCanvas = "1"` to turn it on. */
-const shadowCanvasEnabled = localStorage.getItem("builderShadowCanvas") === "1";
 
 type DelegatedListener = {
 	type: string;
@@ -141,5 +136,4 @@ export {
 	queryCanvas,
 	queryCanvasAll,
 	registerCanvasShadowRoot,
-	shadowCanvasEnabled,
 };

--- a/frontend/src/utils/canvasShadowDom.ts
+++ b/frontend/src/utils/canvasShadowDom.ts
@@ -1,0 +1,145 @@
+/**
+ * Shadow DOM support for canvas breakpoints.
+ *
+ * Each breakpoint renders its blocks inside a shadow root, so page CSS cannot
+ * reach the editor UI. A shadow root shares the viewport, the coordinate space
+ * and the event loop with the editor, so rects, listeners and drag events need
+ * no translation. Only two boundary rules need care:
+ *
+ * - `event.target` retargets to the host element. Use `getEventTarget`.
+ * - `document.querySelector` does not descend into a shadow root. Use `queryCanvas`.
+ *
+ * These helpers also work when no shadow root exists, so the call sites stay
+ * correct with the flag off.
+ */
+
+/** Prototype switch. Set `localStorage.builderShadowCanvas = "1"` to turn it on. */
+const shadowCanvasEnabled = localStorage.getItem("builderShadowCanvas") === "1";
+
+type DelegatedListener = {
+	type: string;
+	handler: EventListener;
+	options?: boolean | AddEventListenerOptions;
+};
+
+const canvasShadowRoots = new Set<ShadowRoot>();
+const delegatedListeners = new Set<DelegatedListener>();
+
+function registerCanvasShadowRoot(root: ShadowRoot) {
+	canvasShadowRoots.add(root);
+	delegatedListeners.forEach(({ type, handler, options }) =>
+		root.addEventListener(type, handler, options),
+	);
+	return () => {
+		delegatedListeners.forEach(({ type, handler, options }) =>
+			root.removeEventListener(type, handler, options),
+		);
+		canvasShadowRoots.delete(root);
+	};
+}
+
+/**
+ * Listen inside every canvas shadow root, now and for roots added later.
+ *
+ * Needed for events that carry a relatedTarget, such as mouseover and mouseout.
+ * Event dispatch skips any tree where the target and the relatedTarget retarget
+ * to the same node, so moving the pointer between two blocks in one canvas never
+ * reaches a listener above the host. Entering the canvas from outside still does,
+ * which makes the bug look like "the highlight works once".
+ */
+function addShadowRootListener(
+	type: string,
+	handler: EventListener,
+	options?: boolean | AddEventListenerOptions,
+) {
+	const listener = { type, handler, options };
+	delegatedListeners.add(listener);
+	canvasShadowRoots.forEach((root) => root.addEventListener(type, handler, options));
+	return () => {
+		delegatedListeners.delete(listener);
+		canvasShadowRoots.forEach((root) => root.removeEventListener(type, handler, options));
+	};
+}
+
+/** The element under the pointer, drilling into every shadow root on the way. */
+function elementFromPoint(x: number, y: number): HTMLElement | null {
+	let element = document.elementFromPoint(x, y);
+	while (element?.shadowRoot) {
+		const inner = element.shadowRoot.elementFromPoint(x, y);
+		if (!inner || inner === element) break;
+		element = inner;
+	}
+	return element as HTMLElement | null;
+}
+
+/** The element the user touched, before the shadow boundary retargets it. */
+function getEventTarget(event: Event): HTMLElement | null {
+	const path = event.composedPath();
+	return ((path[0] as HTMLElement) || (event.target as HTMLElement)) ?? null;
+}
+
+/** closest() that keeps walking up through shadow hosts. */
+function closestAcrossShadow(element: Element | null, selector: string): HTMLElement | null {
+	let current: Element | null = element;
+	while (current) {
+		const match = current.closest?.(selector);
+		if (match) return match as HTMLElement;
+		const root = current.getRootNode();
+		current = root instanceof ShadowRoot ? root.host : null;
+	}
+	return null;
+}
+
+/** The closest block element for an event, across the shadow boundary. */
+function getEventBlockElement(event: Event, selector = ".__builder_component__") {
+	return closestAcrossShadow(getEventTarget(event), selector);
+}
+
+function searchRoots(): (Document | ShadowRoot)[] {
+	return [document, ...canvasShadowRoots];
+}
+
+/** querySelector over the editor document and every canvas shadow root. */
+function queryCanvas(selector: string): HTMLElement | null {
+	for (const root of searchRoots()) {
+		const match = root.querySelector<HTMLElement>(selector);
+		if (match) return match;
+	}
+	return null;
+}
+
+/** querySelectorAll over the editor document and every canvas shadow root. */
+function queryCanvasAll(selector: string): HTMLElement[] {
+	return searchRoots().flatMap((root) => Array.from(root.querySelectorAll<HTMLElement>(selector)));
+}
+
+/** querySelectorAll below `root`, descending into the canvas shadow roots it contains. */
+function queryAllWithin(root: HTMLElement, selector: string): HTMLElement[] {
+	const matches = Array.from(root.querySelectorAll<HTMLElement>(selector));
+	for (const shadowRoot of canvasShadowRoots) {
+		if (root.contains(shadowRoot.host)) {
+			matches.push(...Array.from(shadowRoot.querySelectorAll<HTMLElement>(selector)));
+		}
+	}
+	return matches;
+}
+
+/** The shadow root a block renders in, or null when the block is in light DOM. */
+function getShadowRootOf(element: Node): ShadowRoot | null {
+	const root = element.getRootNode();
+	return root instanceof ShadowRoot ? root : null;
+}
+
+export {
+	addShadowRootListener,
+	closestAcrossShadow,
+	elementFromPoint,
+	getEventBlockElement,
+	getEventTarget,
+	getShadowRootOf,
+	queryAllWithin,
+	queryCanvas,
+	queryCanvasAll,
+	registerCanvasShadowRoot,
+	shadowCanvasEnabled,
+};

--- a/frontend/src/utils/canvasShadowDom.ts
+++ b/frontend/src/utils/canvasShadowDom.ts
@@ -2,13 +2,12 @@
  * Shadow DOM support for canvas breakpoints.
  *
  * Each breakpoint renders its blocks inside a shadow root, so page CSS cannot
- * reach the editor UI. A shadow root shares the viewport, the coordinate space
- * and the event loop with the editor, so rects, listeners and drag events need
+ * reach the editor UI. A shadow root shares the viewport, the coordinate space,
+ * and the event loop with the editor. Rects, listeners, and drag events need
  * no translation. Only two boundary rules need care:
  *
  * - `event.target` retargets to the host element. Use `getEventTarget`.
  * - `document.querySelector` does not descend into a shadow root. Use `queryCanvas`.
- *
  */
 
 type DelegatedListener = {
@@ -36,11 +35,11 @@ function registerCanvasShadowRoot(root: ShadowRoot) {
 /**
  * Listen inside every canvas shadow root, now and for roots added later.
  *
- * Needed for events that carry a relatedTarget, such as mouseover and mouseout.
- * Event dispatch skips any tree where the target and the relatedTarget retarget
- * to the same node, so moving the pointer between two blocks in one canvas never
- * reaches a listener above the host. Entering the canvas from outside still does,
- * which makes the bug look like "the highlight works once".
+ * Needed for events with a relatedTarget, such as mouseover and mouseout.
+ * Event dispatch skips a tree when the target and the relatedTarget retarget
+ * to the same node. So a pointer move between two blocks in one canvas never
+ * reaches a listener above the host, though entering the canvas from outside
+ * still does. That is why the bug looks like "the highlight works once".
  */
 function addShadowRootListener(
 	type: string,
@@ -108,7 +107,7 @@ function queryCanvasAll(selector: string): HTMLElement[] {
 	return searchRoots().flatMap((root) => Array.from(root.querySelectorAll<HTMLElement>(selector)));
 }
 
-/** querySelectorAll below `root`, descending into the canvas shadow roots it contains. */
+/** querySelectorAll under `root`, including any canvas shadow roots inside it. */
 function queryAllWithin(root: HTMLElement, selector: string): HTMLElement[] {
 	const matches = Array.from(root.querySelectorAll<HTMLElement>(selector));
 	for (const shadowRoot of canvasShadowRoots) {
@@ -119,7 +118,7 @@ function queryAllWithin(root: HTMLElement, selector: string): HTMLElement[] {
 	return matches;
 }
 
-/** The shadow root a block renders in, or null when the block is in light DOM. */
+/** The shadow root a block renders in, or null if the block is in the light DOM. */
 function getShadowRootOf(element: Node): ShadowRoot | null {
 	const root = element.getRootNode();
 	return root instanceof ShadowRoot ? root : null;

--- a/frontend/src/utils/canvasShadowStyles.ts
+++ b/frontend/src/utils/canvasShadowStyles.ts
@@ -1,50 +1,105 @@
 /**
- * Copies the editor stylesheets into a canvas shadow root.
+ * Shares the editor's stylesheets with every canvas shadow root.
  *
  * A shadow root does not inherit document styles, so the block tree renders
- * unstyled without this. Vite serves styles as <style> tags in development and
- * as <link> tags in a build, so this handles both. It also follows later
- * additions, which keeps hot reload working.
+ * unstyled without this. Each document <style>/<link> becomes one constructable
+ * CSSStyleSheet, adopted by every shadow root by reference: parsed once and
+ * shared, instead of cloned and reparsed per breakpoint. Mutating a sheet in
+ * place (replaceSync) updates every root that adopted it, so only a stylesheet
+ * entering or leaving the document needs adoptedStyleSheets reassigned.
  *
  * Fonts need no copy. `@font-face` is document scoped and already applies
- * inside every shadow tree.
+ * inside every shadow tree. A cross-origin font <link> (Google Fonts) has no
+ * readable cssRules, so its sheet ends up empty — harmless, since the font
+ * still applies without it.
  */
 
-const STYLE_SOURCES = 'style, link[rel="stylesheet"]';
+const STYLE_SOURCE_SELECTOR = 'style, link[rel="stylesheet"]';
 
-class ShadowStyleSync {
-	private container = document.createElement("div");
-	private observer: MutationObserver | null = null;
-	private pendingSync = 0;
+const roots = new Set<ShadowRoot>();
+const sheetsBySource = new Map<Element, CSSStyleSheet>();
+const unwatchBySource = new Map<Element, () => void>();
+let headObserver: MutationObserver | null = null;
 
-	constructor(private root: ShadowRoot) {
-		this.container.style.display = "contents";
-	}
-
-	start() {
-		this.root.prepend(this.container);
-		this.copyStyles();
-		this.observer = new MutationObserver(() => this.scheduleSync());
-		this.observer.observe(document.head, { childList: true, subtree: true, characterData: true });
-	}
-
-	stop() {
-		this.observer?.disconnect();
-		this.observer = null;
-		cancelAnimationFrame(this.pendingSync);
-		this.container.remove();
-	}
-
-	/** Batch the bursts of head mutations that hot reload produces. */
-	private scheduleSync() {
-		cancelAnimationFrame(this.pendingSync);
-		this.pendingSync = requestAnimationFrame(() => this.copyStyles());
-	}
-
-	private copyStyles() {
-		const sources = document.querySelectorAll<HTMLElement>(STYLE_SOURCES);
-		this.container.replaceChildren(...Array.from(sources, (source) => source.cloneNode(true)));
+function cssTextOf(source: Element): string {
+	if (source instanceof HTMLStyleElement) return source.textContent ?? "";
+	const sheet = (source as HTMLLinkElement).sheet;
+	if (!sheet) return "";
+	try {
+		return Array.from(sheet.cssRules, (rule) => rule.cssText).join("\n");
+	} catch {
+		return "";
 	}
 }
 
-export { ShadowStyleSync };
+function syncSheet(source: Element) {
+	const sheet = sheetsBySource.get(source) ?? new CSSStyleSheet();
+	try {
+		sheet.replaceSync(cssTextOf(source));
+	} catch {
+		return;
+	}
+	sheetsBySource.set(source, sheet);
+}
+
+/** Hot reload swaps a style tag's text in place, and a link has no rules until it loads. */
+function addSource(source: Element) {
+	syncSheet(source);
+	const resync = () => syncSheet(source);
+	const observer = new MutationObserver(resync);
+	observer.observe(source, { childList: true, characterData: true, subtree: true });
+	source.addEventListener("load", resync);
+	unwatchBySource.set(source, () => {
+		observer.disconnect();
+		source.removeEventListener("load", resync);
+	});
+}
+
+function removeSource(source: Element) {
+	unwatchBySource.get(source)?.();
+	unwatchBySource.delete(source);
+	sheetsBySource.delete(source);
+}
+
+function currentSources() {
+	return Array.from(document.querySelectorAll<Element>(STYLE_SOURCE_SELECTOR));
+}
+
+function scanDocument() {
+	const sources = currentSources();
+	const present = new Set(sources);
+	Array.from(sheetsBySource.keys())
+		.filter((source) => !present.has(source))
+		.forEach(removeSource);
+	sources.filter((source) => !sheetsBySource.has(source)).forEach(addSource);
+
+	const sheets = sources
+		.map((source) => sheetsBySource.get(source))
+		.filter((sheet): sheet is CSSStyleSheet => Boolean(sheet));
+	roots.forEach((root) => (root.adoptedStyleSheets = sheets));
+}
+
+/** Nothing to follow once the editor leaves the canvas, so drop it all together. */
+function stopWatching() {
+	headObserver?.disconnect();
+	headObserver = null;
+	unwatchBySource.forEach((unwatch) => unwatch());
+	unwatchBySource.clear();
+	sheetsBySource.clear();
+}
+
+/** Adopts the shared stylesheets into `root` and keeps it in sync from then on. */
+function registerShadowStyles(root: ShadowRoot) {
+	if (!headObserver) {
+		headObserver = new MutationObserver(scanDocument);
+		headObserver.observe(document.head, { childList: true });
+	}
+	roots.add(root);
+	scanDocument();
+	return () => {
+		roots.delete(root);
+		if (!roots.size) stopWatching();
+	};
+}
+
+export { registerShadowStyles };

--- a/frontend/src/utils/canvasShadowStyles.ts
+++ b/frontend/src/utils/canvasShadowStyles.ts
@@ -1,0 +1,50 @@
+/**
+ * Copies the editor stylesheets into a canvas shadow root.
+ *
+ * A shadow root does not inherit document styles, so the block tree renders
+ * unstyled without this. Vite serves styles as <style> tags in development and
+ * as <link> tags in a build, so this handles both. It also follows later
+ * additions, which keeps hot reload working.
+ *
+ * Fonts need no copy. `@font-face` is document scoped and already applies
+ * inside every shadow tree.
+ */
+
+const STYLE_SOURCES = 'style, link[rel="stylesheet"]';
+
+class ShadowStyleSync {
+	private container = document.createElement("div");
+	private observer: MutationObserver | null = null;
+	private pendingSync = 0;
+
+	constructor(private root: ShadowRoot) {
+		this.container.style.display = "contents";
+	}
+
+	start() {
+		this.root.prepend(this.container);
+		this.copyStyles();
+		this.observer = new MutationObserver(() => this.scheduleSync());
+		this.observer.observe(document.head, { childList: true, subtree: true, characterData: true });
+	}
+
+	stop() {
+		this.observer?.disconnect();
+		this.observer = null;
+		cancelAnimationFrame(this.pendingSync);
+		this.container.remove();
+	}
+
+	/** Batch the bursts of head mutations that hot reload produces. */
+	private scheduleSync() {
+		cancelAnimationFrame(this.pendingSync);
+		this.pendingSync = requestAnimationFrame(() => this.copyStyles());
+	}
+
+	private copyStyles() {
+		const sources = document.querySelectorAll<HTMLElement>(STYLE_SOURCES);
+		this.container.replaceChildren(...Array.from(sources, (source) => source.cloneNode(true)));
+	}
+}
+
+export { ShadowStyleSync };

--- a/frontend/src/utils/guidesTracker.ts
+++ b/frontend/src/utils/guidesTracker.ts
@@ -1,4 +1,5 @@
 import useCanvasStore from "@/stores/canvasStore";
+import { closestAcrossShadow } from "@/utils/canvasShadowDom";
 import { useElementBounding } from "@vueuse/core";
 import { reactive } from "vue";
 const canvasStore = useCanvasStore();
@@ -28,7 +29,7 @@ const tracks = [
 function setGuides(target: HTMLElement | SVGElement, canvasProps: CanvasProps) {
 	const threshold = 10;
 	// TODO: Remove canvas dependency
-	const canvasElement = target.closest(".canvas") as HTMLElement;
+	const canvasElement = closestAcrossShadow(target, ".canvas") as HTMLElement;
 	const canvasBounds = reactive(useElementBounding(canvasElement));
 	const targetBounds = reactive(useElementBounding(target));
 	const parentBounds = reactive(useElementBounding(target.parentElement as HTMLElement));

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -955,6 +955,7 @@ export {
 	setBoxSpacing,
 	shortenNumber,
 	showDialog,
+	splitStylePrefix,
 	stripStatePrefix,
 	toCSSProperty,
 	toKebabCase,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -4,6 +4,7 @@ import { BuilderPage } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { dialog, FileUploadHandler, toast } from "frappe-ui";
 import { reactive, toRaw } from "vue";
+import { closestAcrossShadow, getEventBlockElement, getEventTarget } from "./canvasShadowDom";
 import { getRGB, HexToHSV, HSVToHex } from "./colors";
 import {
 	addPxToNumber,
@@ -129,7 +130,7 @@ const INTERACTIVE_CONTROL_SELECTOR =
 // used to let control widgets keep their own click/contextmenu behaviour
 function isInteractiveControl(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
-	return Boolean(target.closest(INTERACTIVE_CONTROL_SELECTOR));
+	return Boolean(closestAcrossShadow(target, INTERACTIVE_CONTROL_SELECTOR));
 }
 
 // splits an optional state prefix (hover:color) from the property name
@@ -165,10 +166,10 @@ function isJSONString(str: string) {
 }
 
 function isTargetEditable(e: Event) {
-	const target = e.target as HTMLElement;
-	const isEditable = target.isContentEditable;
+	const target = getEventTarget(e);
+	if (!target) return false;
 	const isInput = target.tagName === "INPUT" || target.tagName === "TEXTAREA";
-	return isEditable || isInput;
+	return target.isContentEditable || isInput;
 }
 
 function getDataForKey(datum: Object, key: string) {
@@ -538,10 +539,7 @@ function generateId() {
 }
 
 function isBlock(e: MouseEvent) {
-	return (
-		(e.target instanceof HTMLElement || e.target instanceof SVGElement) &&
-		e.target.closest(".__builder_component__")
-	);
+	return Boolean(getEventBlockElement(e));
 }
 
 type BlockInfo = {
@@ -550,13 +548,13 @@ type BlockInfo = {
 };
 
 function getBlockInfo(e: MouseEvent) {
-	const target = (e.target as HTMLElement)?.closest(".__builder_component__") as HTMLElement;
-	return target.dataset as BlockInfo;
+	return (getEventBlockElement(e)?.dataset ?? {}) as BlockInfo;
 }
 
 function getBlock(e: MouseEvent) {
 	const canvasStore = useCanvasStore();
 	const blockInfo = getBlockInfo(e);
+	if (!blockInfo?.blockId) return null;
 	return canvasStore.activeCanvas?.findBlock(blockInfo.blockId);
 }
 

--- a/frontend/src/utils/pageScriptEmulation.ts
+++ b/frontend/src/utils/pageScriptEmulation.ts
@@ -11,6 +11,13 @@ import { CanvasScriptScope } from "@/utils/canvasScriptFacade";
 
 const WIDTH_ONLY_CONDITION = /^\(\s*(?:min|max)-width\s*:[^()]+\)(?:\s+and\s+\(\s*(?:min|max)-width\s*:[^()]+\))*$/i;
 
+// the rewrite only depends on the CSS text, not the breakpoint, so every
+// PageScriptRuntime instance can share one result instead of re-parsing it.
+// Each save of a script adds an entry, so evict the oldest rather than hold
+// every past revision for the session.
+const CACHE_LIMIT = 50;
+const containerQueryCache = new Map<string, string>();
+
 /**
  * A shadow root resolves @media against the editor viewport, so every
  * breakpoint would get the same answer. The canvas host is a size container,
@@ -18,13 +25,22 @@ const WIDTH_ONLY_CONDITION = /^\(\s*(?:min|max)-width\s*:[^()]+\)(?:\s+and\s+\(\
  * breakpoint. Anything else (print, orientation, hover) passes through.
  */
 function toContainerQueries(css: string) {
+	const cached = containerQueryCache.get(css);
+	if (cached !== undefined) return cached;
+
+	let result: string;
 	try {
 		const sheet = new CSSStyleSheet();
 		sheet.replaceSync(css);
-		return Array.from(sheet.cssRules, rewriteMediaRule).join("\n");
+		result = Array.from(sheet.cssRules, rewriteMediaRule).join("\n");
 	} catch {
-		return css;
+		result = css;
 	}
+	if (containerQueryCache.size >= CACHE_LIMIT) {
+		containerQueryCache.delete(containerQueryCache.keys().next().value as string);
+	}
+	containerQueryCache.set(css, result);
+	return result;
 }
 
 function rewriteMediaRule(rule: CSSRule) {

--- a/frontend/src/utils/pageScriptEmulation.ts
+++ b/frontend/src/utils/pageScriptEmulation.ts
@@ -50,11 +50,15 @@ class PageScriptRuntime {
 		this.root.appendChild(this.styleElement);
 	}
 
-	/** Replace the applied CSS and re-run the JavaScript. */
-	apply(scripts: BuilderClientScript[], runJavaScript: boolean, pageData: Record<string, any> = {}) {
+	/** Apply the CSS and run the JavaScript together. Neither applies when stopped. */
+	apply(scripts: BuilderClientScript[], runScripts: boolean, pageData: Record<string, any> = {}) {
 		this.stop();
+		if (!runScripts) {
+			this.styleElement.textContent = "";
+			this.setSizeContainer(false);
+			return;
+		}
 		this.applyStyles(scripts);
-		if (!runJavaScript) return;
 		this.scope = new CanvasScriptScope(this.root, this.breakpointWidth, pageData);
 		scripts.filter(isJavaScript).forEach((script) => this.runScript(script));
 	}

--- a/frontend/src/utils/pageScriptEmulation.ts
+++ b/frontend/src/utils/pageScriptEmulation.ts
@@ -1,0 +1,103 @@
+/**
+ * Runs page client scripts inside one breakpoint shadow root.
+ *
+ * A published page loads each attached script as a <script src> or a stylesheet
+ * link, in attachment order. This reproduces that in the canvas: CSS goes into
+ * the shadow root as one style element, JavaScript runs against the canvas
+ * facades. Re-applying replaces both, so an edit re-runs the scripts.
+ */
+import type { BuilderClientScript } from "@/types/doctypes";
+import { CanvasScriptScope } from "@/utils/canvasScriptFacade";
+
+const WIDTH_ONLY_CONDITION = /^\(\s*(?:min|max)-width\s*:[^()]+\)(?:\s+and\s+\(\s*(?:min|max)-width\s*:[^()]+\))*$/i;
+
+/**
+ * A shadow root resolves @media against the editor viewport, so every
+ * breakpoint would get the same answer. The canvas host is a size container,
+ * so width-only queries convert to container queries and resolve per
+ * breakpoint. Anything else (print, orientation, hover) passes through.
+ */
+function toContainerQueries(css: string) {
+	try {
+		const sheet = new CSSStyleSheet();
+		sheet.replaceSync(css);
+		return Array.from(sheet.cssRules, rewriteMediaRule).join("\n");
+	} catch {
+		return css;
+	}
+}
+
+function rewriteMediaRule(rule: CSSRule) {
+	if (!(rule instanceof CSSMediaRule)) return rule.cssText;
+	const condition = rule.conditionText.trim();
+	if (!WIDTH_ONLY_CONDITION.test(condition)) return rule.cssText;
+	const body = Array.from(rule.cssRules, (nested) => nested.cssText).join("\n");
+	return `@container ${condition} {\n${body}\n}`;
+}
+
+function isJavaScript(script: BuilderClientScript) {
+	return script.script_type === "JavaScript";
+}
+
+class PageScriptRuntime {
+	private styleElement = document.createElement("style");
+	private scope: CanvasScriptScope | null = null;
+
+	constructor(
+		private root: ShadowRoot,
+		private breakpointWidth: number,
+	) {
+		this.root.appendChild(this.styleElement);
+	}
+
+	/** Replace the applied CSS and re-run the JavaScript. */
+	apply(scripts: BuilderClientScript[], runJavaScript: boolean, pageData: Record<string, any> = {}) {
+		this.stop();
+		this.applyStyles(scripts);
+		if (!runJavaScript) return;
+		this.scope = new CanvasScriptScope(this.root, this.breakpointWidth, pageData);
+		scripts.filter(isJavaScript).forEach((script) => this.runScript(script));
+	}
+
+	/** Undo listeners and timers. DOM the scripts wrote is left to Vue to re-render. */
+	stop() {
+		this.scope?.dispose();
+		this.scope = null;
+	}
+
+	destroy() {
+		this.stop();
+		this.styleElement.remove();
+	}
+
+	private applyStyles(scripts: BuilderClientScript[]) {
+		const css = scripts
+			.filter((script) => script.script_type === "CSS")
+			.map((script) => toContainerQueries(script.script ?? ""))
+			.join("\n");
+		this.styleElement.textContent = css;
+		this.setSizeContainer(css.includes("@container"));
+	}
+
+	/**
+	 * container-type also applies layout containment, which makes the host a
+	 * containing block for absolutely positioned blocks. Only pay that cost on
+	 * pages whose CSS actually has width media queries to resolve.
+	 */
+	private setSizeContainer(needed: boolean) {
+		(this.root.host as HTMLElement).style.containerType = needed ? "inline-size" : "";
+	}
+
+	private runScript(script: BuilderClientScript) {
+		if (!script.script?.trim() || !this.scope) return;
+		try {
+			// parameters shadow the real globals, the way a published page sees them
+			const run = new Function("document", "window", "self", "globalThis", script.script);
+			run(this.scope.document, this.scope.window, this.scope.window, this.scope.window);
+		} catch (error) {
+			console.error(`Error in page client script "${script.name}":`, error);
+		}
+	}
+}
+
+export { PageScriptRuntime };

--- a/frontend/src/utils/pageScriptEmulation.ts
+++ b/frontend/src/utils/pageScriptEmulation.ts
@@ -2,8 +2,8 @@
  * Runs page client scripts inside one breakpoint shadow root.
  *
  * A published page loads each attached script as a <script src> or a stylesheet
- * link, in attachment order. This reproduces that in the canvas: CSS goes into
- * the shadow root as one style element, JavaScript runs against the canvas
+ * link, in attachment order. This reproduces that in the canvas. CSS goes into
+ * the shadow root as one style element. JavaScript runs against the canvas
  * facades. Re-applying replaces both, so an edit re-runs the scripts.
  */
 import type { BuilderClientScript } from "@/types/doctypes";
@@ -59,7 +59,7 @@ class PageScriptRuntime {
 		scripts.filter(isJavaScript).forEach((script) => this.runScript(script));
 	}
 
-	/** Undo listeners and timers. DOM the scripts wrote is left to Vue to re-render. */
+	/** Undo listeners and timers only. BuilderCanvas.vue remounts the block tree separately to undo any DOM change. */
 	stop() {
 		this.scope?.dispose();
 		this.scope = null;
@@ -82,7 +82,7 @@ class PageScriptRuntime {
 	/**
 	 * container-type also applies layout containment, which makes the host a
 	 * containing block for absolutely positioned blocks. Only pay that cost on
-	 * pages whose CSS actually has width media queries to resolve.
+	 * pages whose CSS has width media queries to resolve.
 	 */
 	private setSizeContainer(needed: boolean) {
 		(this.root.host as HTMLElement).style.containerType = needed ? "inline-size" : "";

--- a/frontend/src/utils/scriptSandbox.ts
+++ b/frontend/src/utils/scriptSandbox.ts
@@ -76,7 +76,7 @@ function executeClientScriptUnrestricted(
  */
 function executeClientScriptRestricted(
 	thisElement: HTMLElement | null,
-	sandboxRoot: HTMLElement | null,
+	sandboxRoot: HTMLElement | ShadowRoot | null,
 	userScript: string,
 	{ componentData = {}, props = {} }: ScriptContext = {},
 ): ScriptCleanup {

--- a/frontend/src/utils/trackTarget.ts
+++ b/frontend/src/utils/trackTarget.ts
@@ -1,5 +1,6 @@
 import { useElementBounding } from "@vueuse/core";
 import { nextTick, onScopeDispose, reactive, watch, watchEffect } from "vue";
+import { closestAcrossShadow } from "./canvasShadowDom";
 import { getElementRotation } from "./rotation";
 import { addPxToNumber } from "./helpers";
 
@@ -9,29 +10,46 @@ import { addPxToNumber } from "./helpers";
 // observer would die with whichever editor happened to create it) without leaking
 // stale updaters across the session.
 const updateList = new Set<() => void>();
+const observedRoots = new Set<Node>();
 let observer: MutationObserver | null = null;
 
-function startObserver(container: HTMLElement) {
-	observer = new MutationObserver(() => {
-		nextTick(() => updateList.forEach((fn) => fn()));
-	});
-	observer.observe(container, {
-		attributes: true,
-		childList: true,
-		subtree: true,
-		attributeFilter: ["style", "class"],
-		characterData: true,
-	});
+const OBSERVER_OPTIONS = {
+	attributes: true,
+	childList: true,
+	subtree: true,
+	attributeFilter: ["style", "class"],
+	characterData: true,
+};
+
+// One observer watches several roots. subtree does not reach into a shadow tree,
+// so each canvas shadow root has to be observed on its own.
+function observeRoot(root: Node) {
+	if (!observer) {
+		observer = new MutationObserver(() => {
+			nextTick(() => updateList.forEach((fn) => fn()));
+		});
+	}
+	if (observedRoots.has(root)) return;
+	observedRoots.add(root);
+	observer.observe(root, OBSERVER_OPTIONS);
+}
+
+function stopObserver() {
+	observer?.disconnect();
+	observer = null;
+	observedRoots.clear();
 }
 
 function trackTarget(target: HTMLElement | SVGElement, host: HTMLElement, canvasProps: CanvasProps) {
 	const targetBounds = reactive(useElementBounding(target));
-	const container = target.closest(".canvas-container") as HTMLElement | null;
+	// the target renders in a shadow root, so closest() alone stops at the boundary
+	// and the observer would never start
+	const container = closestAcrossShadow(target, ".canvas-container");
 
 	updateList.add(targetBounds.update);
-	if (container && !observer) {
-		startObserver(container);
-	}
+	if (container) observeRoot(container);
+	const targetRoot = target.getRootNode();
+	if (targetRoot instanceof ShadowRoot) observeRoot(targetRoot);
 
 	watch(canvasProps, () => nextTick(targetBounds.update), { deep: true });
 
@@ -62,10 +80,7 @@ function trackTarget(target: HTMLElement | SVGElement, host: HTMLElement, canvas
 
 	onScopeDispose(() => {
 		updateList.delete(targetBounds.update);
-		if (updateList.size === 0 && observer) {
-			observer.disconnect();
-			observer = null;
-		}
+		if (updateList.size === 0) stopObserver();
 	});
 
 	return targetBounds.update;

--- a/frontend/src/utils/trackTarget.ts
+++ b/frontend/src/utils/trackTarget.ts
@@ -22,7 +22,7 @@ const OBSERVER_OPTIONS = {
 };
 
 // One observer watches several roots. subtree does not reach into a shadow tree,
-// so each canvas shadow root has to be observed on its own.
+// so it must observe each canvas shadow root on its own.
 function observeRoot(root: Node) {
 	if (!observer) {
 		observer = new MutationObserver(() => {
@@ -43,7 +43,7 @@ function stopObserver() {
 function trackTarget(target: HTMLElement | SVGElement, host: HTMLElement, canvasProps: CanvasProps) {
 	const targetBounds = reactive(useElementBounding(target));
 	// the target renders in a shadow root, so closest() alone stops at the boundary
-	// and the observer would never start
+	// and the observer never starts
 	const container = closestAcrossShadow(target, ".canvas-container");
 
 	updateList.add(targetBounds.update);

--- a/frontend/src/utils/useBlockReorder.ts
+++ b/frontend/src/utils/useBlockReorder.ts
@@ -1,6 +1,12 @@
 import type Block from "@/block";
 import useCanvasStore from "@/stores/canvasStore";
 import {
+	closestAcrossShadow,
+	elementFromPoint,
+	getEventBlockElement,
+	queryCanvas,
+} from "@/utils/canvasShadowDom";
+import {
 	clusterLines,
 	collectChildRects,
 	computeDropIndicator,
@@ -39,16 +45,15 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 	// measure the wrong layout when dragging on, e.g., the mobile canvas.
 	const dragBreakpoint =
 		breakpoint ||
-		((event.target as HTMLElement)?.closest?.(".__builder_component__") as HTMLElement | null)?.dataset
-			.breakpoint ||
+		getEventBlockElement(event)?.dataset.breakpoint ||
 		canvasStore.activeCanvas?.activeBreakpoint ||
 		canvasStore.activeCanvas?.hoveredBreakpoint ||
 		"desktop";
 
 	const getContainerEl = (target: Block): HTMLElement | null =>
-		document.querySelector(
+		queryCanvas(
 			`.__builder_component__[data-block-id="${target.blockId}"][data-breakpoint="${dragBreakpoint}"]`,
-		) as HTMLElement | null;
+		);
 
 	const sourceEl = getContainerEl(block);
 	if (!sourceEl) return;
@@ -163,8 +168,8 @@ export function startBlockReorder(event: MouseEvent, block: Block, breakpoint?: 
 	//  - a gap between items → elementFromPoint already returns the parent
 	// Returns the resolved block AND its element so the caller doesn't re-query.
 	const resolveTargetContainer = (clientX: number, clientY: number) => {
-		const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
-		const hovered = el?.closest(".__builder_component__") as HTMLElement | null;
+		const el = elementFromPoint(clientX, clientY);
+		const hovered = closestAcrossShadow(el, ".__builder_component__");
 		let raw: Block | null = (hovered?.dataset.blockId && findBlock(hovered.dataset.blockId)) || null;
 
 		while (raw && isSelfOrInsideDragged(raw)) raw = raw.getParentBlock();

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -8,6 +8,7 @@ import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import blockController from "@/utils/blockController";
 import getBlockTemplate from "@/utils/blockTemplate";
+import { closestAcrossShadow, getEventTarget } from "@/utils/canvasShadowDom";
 
 import { copyBuilderBlocks, pasteBuilderBlocks } from "@/utils/builderBlockCopyPaste";
 import {
@@ -554,9 +555,10 @@ export function useBuilderEvents(
 	// context menu
 	useEventListener(document, "contextmenu", async (e) => {
 		if (isTargetEditable(e)) return;
+		const eventTarget = getEventTarget(e);
 		const target =
-			<HTMLElement | null>(e.target as HTMLElement)?.closest("[data-block-layer-id]") ||
-			(e.target as HTMLElement)?.closest("[data-block-id]");
+			closestAcrossShadow(eventTarget, "[data-block-layer-id]") ||
+			closestAcrossShadow(eventTarget, "[data-block-id]");
 		if (target) {
 			const blockId = target.dataset.blockLayerId || target.dataset.blockId;
 			const block = canvasStore.activeCanvas?.findBlock(blockId as string);

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -520,21 +520,7 @@ export function useBuilderEvents(
 			handler: () => {
 				builderStore.mode = "move";
 			},
-		},
-		{
-			key: "l",
-			ctrl: true,
-			shift: true,
-			triggeredOn: "hold",
-			description: "Highlight Blocks with Client Scripts",
-			group: "View",
-			onHold: () => {
-				builderStore.highlightBlocksWithClientScripts = true;
-			},
-			onRelease: () => {
-				builderStore.highlightBlocksWithClientScripts = false;
-			},
-		},
+		}
 	]);
 
 	// on tab activation, reload for latest data

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -3,6 +3,7 @@ import useBlockTemplateStore from "@/stores/blockTemplateStore";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
+import { closestAcrossShadow, elementFromPoint, queryCanvas } from "@/utils/canvasShadowDom";
 import { getLayoutDirection, type LayoutDirection } from "@/utils/dropGeometry";
 import {
 	getBlockCopy,
@@ -68,8 +69,8 @@ export function useCanvasDropZone(
 	});
 
 	const getInitialParentBlock = (ev: DragEvent) => {
-		const element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
-		const targetElement = element.closest(".__builder_component__") as HTMLElement;
+		const element = elementFromPoint(ev.x, ev.y) as HTMLElement;
+		const targetElement = closestAcrossShadow(element, ".__builder_component__") as HTMLElement;
 
 		// set the hoveredBreakpoint from the target element to show placeholder at the correct breakpoint canvas
 		const breakpoint =
@@ -96,7 +97,7 @@ export function useCanvasDropZone(
 	const getBlockElement = (block: Block) => {
 		const breakpoint =
 			canvasStore.activeCanvas?.hoveredBreakpoint || canvasStore.activeCanvas?.activeBreakpoint;
-		return document.querySelector(
+		return queryCanvas(
 			`.__builder_component__[data-block-id="${block.blockId}"][data-breakpoint="${breakpoint}"]`,
 		) as HTMLElement;
 	};

--- a/frontend/src/utils/useCanvasEvents.ts
+++ b/frontend/src/utils/useCanvasEvents.ts
@@ -3,6 +3,7 @@ import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import { CanvasHistory } from "@/types/Builder/BuilderCanvas";
 import getBlockTemplate from "@/utils/blockTemplate";
+import { addShadowRootListener, elementFromPoint, queryCanvas } from "@/utils/canvasShadowDom";
 import {
 	addPxToNumber,
 	getBlock,
@@ -38,7 +39,7 @@ export function useCanvasEvents(
 			if (builderStore.readOnlyMode) return;
 			const pauseId = canvasHistory.value?.pause();
 			ev.stopPropagation();
-			let element = document.elementFromPoint(ev.x, ev.y) as HTMLElement;
+			let element = elementFromPoint(ev.x, ev.y) as HTMLElement;
 			let block = getRootBlock();
 			if (element) {
 				if (element.dataset.blockId) {
@@ -53,8 +54,8 @@ export function useCanvasEvents(
 				}
 			}
 			const child = getBlockTemplate(builderStore.mode);
-			const parentElement = document.body.querySelector(
-				`.canvas [data-block-id="${parentBlock.blockId}"]`,
+			const parentElement = queryCanvas(
+				`.__builder_component__[data-block-id="${parentBlock.blockId}"]`,
 			) as HTMLElement;
 			const parentOldPosition = parentBlock.getStyle("position");
 			if (parentOldPosition === "static" || parentOldPosition === "inherit" || !parentOldPosition) {
@@ -233,6 +234,9 @@ export function useCanvasEvents(
 	});
 
 	useEventListener(container, "mouseover", handleMouseOver);
+	// a container listener only sees the pointer entering the canvas, never a move
+	// between two blocks inside it
+	return addShadowRootListener("mouseover", handleMouseOver as EventListener);
 }
 
 function handleMouseOver(e: MouseEvent) {

--- a/frontend/src/utils/useCanvasEvents.ts
+++ b/frontend/src/utils/useCanvasEvents.ts
@@ -234,7 +234,7 @@ export function useCanvasEvents(
 	});
 
 	useEventListener(container, "mouseover", handleMouseOver);
-	// a container listener only sees the pointer entering the canvas, never a move
+	// a container listener only sees the pointer enter the canvas, never a move
 	// between two blocks inside it
 	return addShadowRootListener("mouseover", handleMouseOver as EventListener);
 }

--- a/frontend/src/utils/useCanvasMarqueeSelection.ts
+++ b/frontend/src/utils/useCanvasMarqueeSelection.ts
@@ -2,6 +2,7 @@ import type Block from "@/block";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import type { CanvasProps } from "@/types/Builder/BuilderCanvas";
+import { closestAcrossShadow, getEventTarget, queryAllWithin } from "@/utils/canvasShadowDom";
 import { computed, reactive, ref, type Ref } from "vue";
 
 const MIN_MARQUEE_DRAG = 5;
@@ -128,7 +129,8 @@ export function useCanvasMarqueeSelection(options: UseCanvasMarqueeSelectionOpti
 		const container = canvasContainer.value;
 		if (!container) return [];
 		const target = marqueeBreakpoint.value || activeBreakpoint.value;
-		const elements = container.querySelectorAll<HTMLElement>(
+		const elements = queryAllWithin(
+			container,
 			".__builder_component__[data-block-id][data-breakpoint]",
 		);
 		const result: BlockRectSnapshot[] = [];
@@ -231,17 +233,17 @@ export function useCanvasMarqueeSelection(options: UseCanvasMarqueeSelectionOpti
 		if (builderStore.readOnlyMode) return false;
 		if (canvasStore.isDragging || canvasProps.panning || canvasProps.scaling) return false;
 
-		const target = ev.target as HTMLElement | null;
+		const target = getEventTarget(ev);
 		if (!target) return false;
 
-		if (target.closest("input, textarea, select, button, a, [contenteditable='true']")) {
+		if (closestAcrossShadow(target, "input, textarea, select, button, a, [contenteditable='true']")) {
 			return false;
 		}
 
 		// Pressing on an actual block starts a block drag/selection (see
 		// useBlockEventHandlers), not a marquee. The root block (page background)
 		// and truly empty canvas still start a marquee.
-		const blockEl = target.closest(".__builder_component__") as HTMLElement | null;
+		const blockEl = closestAcrossShadow(target, ".__builder_component__");
 		if (blockEl && blockEl.dataset.blockId && blockEl.dataset.blockId !== "root") {
 			return false;
 		}


### PR DESCRIPTION
Renders each canvas breakpoint inside a shadow root, so page CSS cannot reach the editor UI.

This is an alternative to the iframe approach on https://github.com/frappe/builder/pull/656

## Why a shadow root

A shadow root shares the viewport, the coordinate space, and the event loop with the editor. Rects, listeners, and drag events therefore need no translation across a frame boundary. Fonts need no extra handling, because `@font-face` is document scoped.

Two boundary rules need care, and `canvasShadowDom.ts` holds the helpers for both:

- `event.target` retargets to the host element. Use `getEventTarget`.
- `document.querySelector` does not descend into a shadow root. Use `queryCanvas`.

## Client scripts

A shadow root gives no JavaScript isolation, so page and block scripts run against a facade in `canvasScriptFacade.ts`. The facade points `document` and `window` at the breakpoint's root.

Run and Stop gate the scripts, from the command palette or `Ctrl+Shift+P`. A tap toggles the state. A hold previews and restores the earlier state on release. Stopping remounts the block tree, because a script can mutate the DOM in ways Vue cannot undo.

A shadow root resolves `@media` against the editor viewport, so every breakpoint would get the same answer. `pageScriptEmulation.ts` rewrites width-only queries to container queries, and the canvas host becomes a size container only when the CSS needs one.

## Styles

Each breakpoint adopts the editor stylesheets by reference, as constructable `CSSStyleSheet` objects. The document parses each sheet once, and every root shares it. A change to a sheet updates all adopters, so only a stylesheet that enters or leaves the document reassigns `adoptedStyleSheets`.

Block client script CSS goes to the breakpoint that registered it, not to every root.

## State styles

Hover, active and focus styles now render during preview. Before this branch the canvas dropped them. A block renders its regular styles inline, and an inline style cannot carry a pseudo class, so `BuilderBlock` deleted every `hover:` key.

`blockStateStyles.ts` emits them as real rules instead, which mirrors `append_state_style` in `builder_page.py`. An inline declaration outranks any rule, so each state declaration carries `!important`.

The rules apply during preview only. To select a block the user hovers it, and a block that restyles itself under the pointer is unusable.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
