### PR TITLE
feat: Show how many pages a client script is used in

### DIFF
--- a/frontend/src/components/Controls/CodeEditor.vue
+++ b/frontend/src/components/Controls/CodeEditor.vue
@@ -3,6 +3,7 @@
 		<span class="text-p-sm-medium text-ink-gray-8" v-show="label">
 			{{ label }}
 			<span v-if="isDirty" class="text-[10px] text-gray-600">●</span>
+			<slot name="label-suffix"></slot>
 		</span>
 		<div
 			:style="{

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -210,14 +210,19 @@ const clientScriptResource = createListResource({
 
 const pageListDialog = ref(false);
 
+const usagePageLimit = 100;
+
 const scriptUsageResource = createListResource({
 	doctype: "Builder Page",
 	fields: ["name", "page_title", "route", "preview"],
-	pageLength: 10000,
+	pageLength: usagePageLimit,
 });
 
 const scriptUsedInPages = computed<BuilderPage[]>(() => scriptUsageResource.data ?? []);
-const usageMessage = computed(() => getPageUsageMessage(scriptUsedInPages.value.length));
+const usageMessage = computed(() => {
+	const count = scriptUsedInPages.value.length;
+	return count === usagePageLimit ? `used in ${usagePageLimit - 1}+ pages` : getPageUsageMessage(count);
+});
 
 const selectScript = (script: attachedScript) => {
 	activeScript.value = script;

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -124,7 +124,10 @@
 				@save="updateScript"
 				:show-line-numbers="true">
 				<template #label-suffix>
-					<a @click="pageListDialog = true" class="ml-1 cursor-pointer text-p-sm text-ink-gray-4 underline">
+					<a
+						v-if="!scriptUsageResource.loading"
+						@click="pageListDialog = true"
+						class="ml-1 cursor-pointer text-p-sm text-ink-gray-4 underline">
 						{{ usageMessage }}
 					</a>
 				</template>
@@ -210,7 +213,7 @@ const pageListDialog = ref(false);
 const scriptUsageResource = createListResource({
 	doctype: "Builder Page",
 	fields: ["name", "page_title", "route", "preview"],
-	pageLength: 1000,
+	pageLength: 10000,
 });
 
 const scriptUsedInPages = computed<BuilderPage[]>(() => scriptUsageResource.data ?? []);

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -122,16 +122,25 @@
 				:autofocus="false"
 				:show-save-button="true"
 				@save="updateScript"
-				:show-line-numbers="true"></CodeEditor>
+				:show-line-numbers="true">
+				<template #label-suffix>
+					<a @click="pageListDialog = true" class="ml-1 cursor-pointer text-p-sm text-ink-gray-4 underline">
+						{{ usageMessage }}
+					</a>
+				</template>
+			</CodeEditor>
 		</div>
+		<PageListModal v-model="pageListDialog" :pages="scriptUsedInPages"></PageListModal>
 	</div>
 </template>
 
 <script setup lang="ts">
 import EditableSpan from "@/components/EditableSpan.vue";
+import PageListModal from "@/components/Modals/PageListModal.vue";
 import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderClientScript, BuilderPage } from "@/types/doctypes";
+import { getPageUsageMessage } from "@/utils/helpers";
 import { Combobox, createListResource, createResource, Dropdown } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
 import { computed, nextTick, ref, watch } from "vue";
@@ -196,8 +205,21 @@ const clientScriptResource = createListResource({
 	auto: true,
 });
 
+const pageListDialog = ref(false);
+
+const scriptUsageResource = createListResource({
+	doctype: "Builder Page",
+	fields: ["name", "page_title", "route", "preview"],
+	pageLength: 1000,
+});
+
+const scriptUsedInPages = computed<BuilderPage[]>(() => scriptUsageResource.data ?? []);
+const usageMessage = computed(() => getPageUsageMessage(scriptUsedInPages.value.length));
+
 const selectScript = (script: attachedScript) => {
 	activeScript.value = script;
+	scriptUsageResource.filters = [["Builder Page Client Script", "builder_script", "=", script.script_name]];
+	scriptUsageResource.reload();
 	nextTick(() => {
 		scriptEditor.value?.resetEditor(true);
 	});

--- a/frontend/src/components/VersionHistory.vue
+++ b/frontend/src/components/VersionHistory.vue
@@ -68,7 +68,7 @@
 								:time="pageStore.activePage.published_at">
 								{{ timeAgo }}
 							</UseTimeAgo>
-							<template v-else>Live on your site</template>
+							<template v-else>Currently live</template>
 						</span>
 					</div>
 					<Button

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -137,7 +137,7 @@ import { BuilderPage } from "@/types/doctypes";
 import { getUsersInfo } from "@/usersInfo";
 import blockController from "@/utils/blockController";
 import componentController from "@/utils/componentController.js";
-import { getBlockInstance, getBlockObject, getRootBlockTemplate } from "@/utils/helpers";
+import { getBlockInstance, getBlockObject, getPageUsageMessage, getRootBlockTemplate } from "@/utils/helpers";
 import { useBuilderEvents } from "@/utils/useBuilderEvents";
 import { breakpointsTailwind, useBreakpoints, useDebounceFn, useEventListener } from "@vueuse/core";
 import { createResource, KeyboardShortcutsModal, useShortcut } from "frappe-ui";
@@ -459,15 +459,7 @@ watchEffect(() => {
 
 const debouncedPageSave = useDebounceFn(pageStore.savePage, 300);
 
-const usageMessage = computed(() => {
-	if (usageCount.value === 0) {
-		return "not used in any pages";
-	}
-	if (usageCount.value === 1) {
-		return "used in 1 page";
-	}
-	return `used in ${usageCount.value} pages`;
-});
+const usageMessage = computed(() => getPageUsageMessage(usageCount.value));
 
 watch(
 	() => pageCanvas.value?.block,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -888,6 +888,13 @@ function isDialogOpen() {
 	return !!document.querySelector("[role='dialog']");
 }
 
+function getPageUsageMessage(count: number) {
+	if (!count) {
+		return "not used in any pages";
+	}
+	return count === 1 ? "used in 1 page" : `used in ${count} pages`;
+}
+
 function parseJSONWithFallback<T>(value: T | string | undefined, fallback: T): T {
 	if (value === undefined || value === null || value === "") {
 		return fallback;
@@ -926,6 +933,7 @@ export {
 	getDefaultPropsList,
 	getImageBlock,
 	getNumberFromPx,
+	getPageUsageMessage,
 	getParentProps,
 	getPropValue,
 	getRepeaterScopedData,


### PR DESCRIPTION
Shows the page usage count next to the client script name, same as components. Clicking it opens the list of pages.

![client script usage](https://raw.githubusercontent.com/surajshetty3416/builder/pr-screenshots/client-script-usage.png)