### PR TITLE
fix: Design Tokens naming and escaping a pending token row

### DIFF
--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -142,7 +142,7 @@ const leftPanelOptions = [
 		icon: "lucide-code",
 	},
 	{
-		label: "Design System",
+		label: "Design Tokens",
 		value: "variables",
 		icon: "lucide-aperture",
 	},

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -35,7 +35,7 @@
 								:actionButton="
 									modelValue && !isCssVariable && props.showColorVariableOptions
 										? {
-												label: 'Save as Variable',
+												label: 'Save as Token',
 												icon: 'lucide-plus',
 												handler: openVariableDialog,
 											}

--- a/frontend/src/components/Modals/TokenManager.vue
+++ b/frontend/src/components/Modals/TokenManager.vue
@@ -15,7 +15,7 @@
 		action-label="Add Token"
 		:action-handler="addNewVariable"
 		placement="top-left">
-		<template #header><h2 class="text-lg-semibold py-2">Design System</h2></template>
+		<template #header><h2 class="text-lg-semibold py-2">Design Tokens</h2></template>
 		<template #content>
 			<div @keydown.esc="clearSelection">
 				<div class="mb-2">
@@ -65,6 +65,7 @@
 									data-row
 									class="rounded py-2"
 									:class="rowGridClass"
+									@keydown.esc.stop.prevent="() => (newVariable = null)"
 									@focusout="(e) => handleNewRowFocusOut(e, row)"
 									@contextmenu="handleNewRowContextMenu">
 									<input
@@ -75,8 +76,7 @@
 										data-new-name
 										@mousedown.stop
 										@input="(e) => (row.token_name = inputValue(e))"
-										@keydown.enter.prevent="() => createVariable(row)"
-										@keydown.esc.stop.prevent="() => (newVariable = null)" />
+										@keydown.enter.prevent="() => createVariable(row)" />
 									<div
 										v-if="isColorType"
 										:class="[

--- a/frontend/src/components/Modals/TokenManager.vue
+++ b/frontend/src/components/Modals/TokenManager.vue
@@ -35,7 +35,8 @@
 						icon-left="search" />
 				</div>
 
-				<div class="max-h-[60vh] overflow-y-auto">
+				<!-- a floor under the list so a short tab does not shrink the whole panel -->
+				<div class="max-h-[60vh] min-h-64 overflow-y-auto">
 					<!-- Header row -->
 					<div
 						class="sticky top-0 z-10 border-b border-outline-gray-1 bg-surface-base pb-2 pt-1 text-sm text-ink-gray-5"


### PR DESCRIPTION
Follow-ups on #676.

- The colour field's action button still read **Save as Variable** → now **Save as Token**.
- The panel is called **Design Tokens** (header and the left sidebar tooltip), not Design System.
- **Escape** only discarded a pending new row while the name cell had focus, so pressing it from the value cells left an empty row behind. It is handled on the row now, from any cell.
