### PR TITLE
fix: analytics empty states, side-by-side site lists, filter spacing

### DIFF
--- a/frontend/src/components/Settings/AnalyticsEmptyState.vue
+++ b/frontend/src/components/Settings/AnalyticsEmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex h-full min-h-[200px] flex-col items-center justify-center gap-1 px-4 text-center">
+	<div class="flex flex-col items-center justify-center gap-1 px-4 py-12 text-center">
 		<p class="text-p-sm text-ink-gray-6">{{ title }}</p>
 		<p v-if="hint" class="text-p-xs text-ink-gray-4">{{ hint }}</p>
 	</div>

--- a/frontend/src/components/Settings/AnalyticsFilters.vue
+++ b/frontend/src/components/Settings/AnalyticsFilters.vue
@@ -8,9 +8,7 @@
 			:allowArbitraryValue="true"
 			:showInputAsOption="true"
 			class="w-44" />
-		<div class="w-32">
-			<Select size="sm" v-model="modelRange" :options="rangeOptions" />
-		</div>
+		<Select size="sm" v-model="modelRange" :options="rangeOptions" />
 		<DateRangePicker
 			v-if="modelRange === 'custom'"
 			v-model="customDateRangeValue"

--- a/frontend/src/components/Settings/AnalyticsOverview.vue
+++ b/frontend/src/components/Settings/AnalyticsOverview.vue
@@ -21,11 +21,15 @@
 			</div>
 		</div>
 	</div>
-	<div class="mx-[-16px] [&>div]:h-[250px] [&>div]:!min-h-[200px]">
+	<div class="mx-[-16px]">
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			Loading...
 		</div>
-		<AxisChart v-else-if="data.data && data.data.length" :config="chartConfigData" :events="chartEvents" />
+		<AxisChart
+			v-else-if="data.data && data.data.length"
+			class="!h-[250px] !min-h-[200px]"
+			:config="chartConfigData"
+			:events="chartEvents" />
 		<AnalyticsEmptyState
 			v-else
 			title="No views in this period"

--- a/frontend/src/components/Settings/GlobalAnalytics.vue
+++ b/frontend/src/components/Settings/GlobalAnalytics.vue
@@ -16,39 +16,40 @@
 						@update:customDateRange="(val) => (customDateRange = val)" />
 				</template>
 			</AnalyticsOverview>
-			<div class="mt-8">
-				<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Pages</h3>
-				<div
-					v-if="analytics.loading"
-					class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
-					Loading...
+			<div class="mt-8 flex flex-col gap-5 md:flex-row md:items-start">
+				<div v-if="analytics.loading || processedAnalyticsData.top_pages?.length" class="flex-1">
+					<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Pages</h3>
+					<div
+						v-if="analytics.loading"
+						class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
+						Loading...
+					</div>
+					<ListView
+						class="!w-auto"
+						v-else
+						:columns="[
+							{ label: 'Route', key: 'route', width: '60%' },
+							{ label: 'Views', key: 'view_count', align: 'right' },
+						]"
+						:options="{
+							selectable: false,
+							emptyState: {},
+							showTooltip: false,
+							onRowClick: onPageRowClick,
+						}"
+						:rows="processedAnalyticsData.top_pages"
+						row-key="route" />
 				</div>
-				<ListView
-					class="!w-auto"
-					v-else-if="processedAnalyticsData.top_pages?.length"
-					:columns="[
-						{ label: 'Route', key: 'route', width: '60%' },
-						{ label: 'Views', key: 'view_count', align: 'right' },
-					]"
-					:options="{
-						selectable: false,
-						emptyState: {},
-						showTooltip: false,
-						onRowClick: onPageRowClick,
-					}"
-					:rows="processedAnalyticsData.top_pages"
-					row-key="route" />
-				<AnalyticsEmptyState v-else title="No page views yet" />
-			</div>
-			<div class="mt-8">
-				<TopReferrersList :rows="processedAnalyticsData.top_referrers" :loading="analytics.loading" />
+				<TopReferrersList
+					class="flex-1"
+					:rows="processedAnalyticsData.top_referrers"
+					:loading="analytics.loading" />
 			</div>
 		</template>
 	</div>
 </template>
 
 <script setup lang="ts">
-import AnalyticsEmptyState from "@/components/Settings/AnalyticsEmptyState.vue";
 import AnalyticsFilters from "@/components/Settings/AnalyticsFilters.vue";
 import AnalyticsOverview from "@/components/Settings/AnalyticsOverview.vue";
 import TopReferrersList from "@/components/Settings/TopReferrersList.vue";

--- a/frontend/src/components/Settings/TopClicksList.vue
+++ b/frontend/src/components/Settings/TopClicksList.vue
@@ -1,11 +1,11 @@
 <template>
-	<div>
+	<div v-if="loading || rows.length">
 		<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Clicks</h3>
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			Loading...
 		</div>
 		<ListView
-			v-else-if="rows.length"
+			v-else
 			class="!w-auto"
 			:columns="[
 				{ label: 'Target', key: 'label', width: '50%' },
@@ -15,16 +15,11 @@
 			:options="{ selectable: false, emptyState: {}, showTooltip: false, onRowClick: highlightBlock }"
 			:rows="rows"
 			row-key="blockId" />
-		<AnalyticsEmptyState
-			v-else
-			title="No clicks tracked yet"
-			hint="Enable click tracking on a block, then clicks on it will appear here." />
 	</div>
 </template>
 
 <script setup lang="ts">
 import { findBlockInTree } from "@/utils/block/tree";
-import AnalyticsEmptyState from "@/components/Settings/AnalyticsEmptyState.vue";
 import type { CTRElement } from "@/composables/useAnalytics";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";

--- a/frontend/src/components/Settings/TopReferrersList.vue
+++ b/frontend/src/components/Settings/TopReferrersList.vue
@@ -1,11 +1,11 @@
 <template>
-	<div>
+	<div v-if="loading || rows?.length">
 		<h3 class="text-lg-medium mb-4 text-ink-gray-7">Top Referrers</h3>
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			Loading...
 		</div>
 		<ListView
-			v-else-if="rows?.length"
+			v-else
 			class="!w-auto"
 			:columns="[
 				{
@@ -31,12 +31,10 @@
 			:options="{ selectable: false, emptyState: {} }"
 			:rows="rows"
 			row-key="domain" />
-		<AnalyticsEmptyState v-else title="No referrers yet" />
 	</div>
 </template>
 
 <script setup lang="ts">
-import AnalyticsEmptyState from "@/components/Settings/AnalyticsEmptyState.vue";
 import { ListView } from "frappe-ui";
 import { h } from "vue";
 


### PR DESCRIPTION
Four fixes to the Analytics screens.

**Empty sections are dropped, not filled.** With no data, each section rendered its heading above a 200px placeholder and the chart's *no views* note was stretched to 250px — screens that were mostly reserved space. Top Pages, Top Referrers and Top Clicks now render only when they have rows, and the chart note is sized to its text. The chart keeps its 250px when there *is* a chart.

**Top Pages and Top Referrers sit side by side** on Site Analytics, matching what the page screen already did with referrers and clicks. Either one on its own still takes the full width.

**Filter spacing.** The range select sat in a fixed `w-32` box while its button renders at 93px, so 35px of dead space read as an oversized gap before the date picker. The wrapper is gone; the row's `gap-2` now does the spacing.

Measured in the editor: filter gaps a uniform 8px with no slack inside any control (176 / 93 / 224px), Top Pages and Top Referrers at the same y and 340px each, and an empty Site Analytics renders the overview and note with no section scaffolding at all. Typecheck and ESLint on the touched files are unchanged from develop.