### PR TITLE
chore: bump litellm to 1.95.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "csscompressor>=0.9.5",
     "pandas (>=2.3.2,<3.0.0)",
     "duckdb==1.4.3",
-    "litellm==1.83.7",
+    "litellm==1.95.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Clears the open litellm security advisories flagged by Dependabot.

## Advisories cleared

| Advisory | Severity | Fixed in |
| --- | --- | --- |
| GHSA-4xpc-pv4p-pm3w (auth bypass via Host header injection) | critical | 1.84.0 |
| GHSA-7488-6r32-c95q (MCP auth bypass via OAuth2 passthrough fallback) | high | 1.84.0 |
| GHSA-qrc4-49gv-mv9m (internal_user can create over-privileged API keys) | high | 1.83.14 |
| GHSA-wpfp-gwwc-vwq6 (user can modify own user_role via /user/update) | high | 1.83.10 |

`gh api /advisories?ecosystem=pip&affects=litellm@1.95.0` returns nothing, so 1.95.0 is clean.

## Why this was blocked until now

Every release from 1.84.0 through 1.92.x caps `requires-python` at `<3.14`, so none of them install on a Python 3.14 bench. [BerriAI/litellm#33438](https://github.com/BerriAI/litellm/pull/33438) raised the cap to `<3.15` and first shipped in 1.93.0, which is what unblocks this.

| version | requires-python |
| --- | --- |
| 1.83.7 (current pin) | `>=3.9,<4.0` |
| 1.84.0 to 1.92.x | `>=3.10,<3.14` |
| 1.93.0 to 1.95.0 | `>=3.10,<3.15` |

## Click conflict, also fixed

1.83.7 hard-pinned `click==8.1.8`, while frappe requires `Click~=8.4.1`. That conflict was already present on develop:

```
$ pip check
frappe 17.0.0.dev0 has requirement Click~=8.3.1, but you have click 8.1.8.
```

1.95.0 relaxes to `click>=8.0.0,<9.0`, so click can move to 8.4.x and satisfy frappe.