### PR TITLE
ci: bump codecov-action to v7, stop failing CI on upload errors

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -121,9 +121,9 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           name: Server
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
The Coverage Wrap Up job [failed on develop](https://github.com/frappe/builder/actions/runs/30812731778/job/91683838479) while every server test passed.

`codecov-action@v4` fetches its CLI from `cli.codecov.io`, which returned a Cloudflare 502. The action saved that HTML as `codecov.SHA256SUM`, gpg verification of it reported `BAD signature`, and `fail_ci_if_error: true` turned an upstream outage into a red build.

- **v4 to v7** — v4 is deprecated (also the source of the Node 20 annotation on that job). v7 is what `frappe/frappe` runs, and all four inputs used here still exist in its `action.yml`.
- **`fail_ci_if_error: false`** — v7 still downloads from `cli.codecov.io`, so the same 502 can recur. Coverage reporting being down should not fail a run whose tests passed. Note `frappe/frappe` keeps this `true`, so this one is a judgment call.

`actions/checkout@v3` and `download-artifact@v4` raise Node 20 deprecation warnings too, but those are warnings rather than failures and unrelated to this run, so I left them for a separate bump.