### PR TITLE
fix: deep block trees fail to save due to stale json_valid checks

### DIFF
--- a/builder/builder/doctype/block_template/block_template.json
+++ b/builder/builder/doctype/block_template/block_template.json
@@ -25,7 +25,7 @@
   },
   {
    "fieldname": "block",
-   "fieldtype": "JSON",
+   "fieldtype": "Long Text",
    "label": "Block",
    "reqd": 1
   },
@@ -66,7 +66,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-19 13:07:00.935349",
+ "modified": "2026-08-10 15:30:00.000000",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Block Template",

--- a/builder/builder/doctype/builder_component/builder_component.json
+++ b/builder/builder/doctype/builder_component/builder_component.json
@@ -22,7 +22,7 @@
   },
   {
    "fieldname": "block",
-   "fieldtype": "JSON",
+   "fieldtype": "Long Text",
    "label": "Block",
    "read_only": 1
   },
@@ -33,25 +33,25 @@
    "options": "Builder Page",
    "read_only": 1
   },
-   {
-    "fieldname": "component_id",
-    "fieldtype": "Data",
-    "label": "Component ID",
-    "no_copy": 1,
-    "read_only": 1,
-    "unique": 1
-   },
-   {
-    "fieldname": "component_data_script",
-    "fieldtype": "Code",
-    "label": "Component Data Script",
-    "options": "Python",
-    "description": "Server-side Python script that populates component data. Receives props as input. Use: data.events = frappe.get_list('Event')"
-   }
-  ],
+  {
+   "fieldname": "component_id",
+   "fieldtype": "Data",
+   "label": "Component ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "component_data_script",
+   "fieldtype": "Code",
+   "label": "Component Data Script",
+   "options": "Python",
+   "description": "Server-side Python script that populates component data. Receives props as input. Use: data.events = frappe.get_list('Event')"
+  }
+ ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-29 09:30:34.896956",
+ "modified": "2026-08-10 15:30:00.000000",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Component",

--- a/builder/builder/patches/drop_json_checks_from_block_columns.py
+++ b/builder/builder/patches/drop_json_checks_from_block_columns.py
@@ -1,0 +1,31 @@
+import frappe
+
+# Block fields moved from JSON to Long Text because MariaDB's json_valid
+# rejects trees nested deeper than 32 levels, but both fieldtypes map to
+# longtext so schema sync never drops the old inline CHECK constraints.
+# The checks are column-level, so DROP CONSTRAINT won't remove them;
+# redefining the column via MODIFY does.
+COLUMNS = (
+	("Builder Page", "blocks"),
+	("Builder Page", "draft_blocks"),
+	("Builder Component", "block"),
+	("Block Template", "block"),
+)
+
+
+def execute():
+	if frappe.db.db_type != "mariadb":
+		return
+	for doctype, column in COLUMNS:
+		if has_json_check(doctype, column):
+			frappe.db.change_column_type(doctype, column, "longtext", nullable=True)
+
+
+def has_json_check(doctype: str, column: str) -> bool:
+	return bool(
+		frappe.db.sql(
+			"""SELECT 1 FROM information_schema.CHECK_CONSTRAINTS
+			WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = %s AND CONSTRAINT_NAME = %s""",
+			(f"tab{doctype}", column),
+		)
+	)

--- a/builder/patches.txt
+++ b/builder/patches.txt
@@ -14,5 +14,6 @@ builder.builder.doctype.builder_client_script.patches.trigger_asset_compression
 builder.builder.patches.add_composite_index_to_web_page_view
 builder.builder.patches.refactor_builder_variables
 builder.builder.patches.reset_builder_page_clicks
+builder.builder.patches.drop_json_checks_from_block_columns
 execute:frappe.call("builder.builder_analytics.enqueue_web_page_view_ingesion")
 execute:frappe.call("builder.builder_analytics.setup_duckdb_table")

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -8,7 +8,7 @@ import usePageStore from "@/stores/pageStore";
 import { BuilderComponent } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { alert, confirm, getBlockInstance, getBlockObject } from "@/utils/helpers";
-import { createDocumentResource, createResource, toast } from "frappe-ui";
+import { createDocumentResource, createListResource, createResource, toast } from "frappe-ui";
 import { defineStore } from "pinia";
 import { markRaw } from "vue";
 import { ComponentDocDraft } from "@/utils/componentController";
@@ -190,6 +190,21 @@ const useComponentStore = defineStore("componentStore", {
 						this.fetchingComponent.delete(componentName);
 					});
 			}
+		},
+		// seed the doc map for many components with one request, so callers like
+		// paste can tell which components already exist without probing inserts
+		async loadComponentDocs(componentNames: string[]) {
+			const missing = componentNames.filter((name) => !this.componentDocMap.has(name));
+			if (!missing.length) return;
+			const components = createListResource({
+				doctype: "Builder Component",
+				fields: ["name", "component_name", "component_id", "block", "component_data_script"],
+				filters: [["name", "in", missing]],
+				pageLength: missing.length,
+				auto: true,
+			});
+			await components.list.promise;
+			(components.data || []).forEach((doc: BuilderComponent) => this.setComponentMap(doc));
 		},
 		setComponentMap(componentDoc: BuilderComponent) {
 			this.componentDocMap.set(componentDoc.name, componentDoc);

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -314,10 +314,14 @@ async function handleComponents(clipboardData: BuilderClipboardData, crossSitePa
 			componentIdMap.set(originalId, newId);
 			component.name = newId;
 			component.component_id = newId;
-			await componentStore.createComponent(component, true);
-		} else {
-			await componentStore.createComponent(component, false);
 		}
+	}
+
+	// one lookup upfront so a re-paste skips or updates existing components
+	// instead of firing inserts that fail with 409
+	await componentStore.loadComponentDocs(clipboardData.components.map((component) => component.name));
+	for (const component of clipboardData.components) {
+		await componentStore.createComponent(component, crossSitePaste);
 	}
 
 	if (crossSitePaste) {
@@ -351,29 +355,33 @@ async function handlePageScripts(clipboardData: BuilderClipboardData, currentSit
 		return;
 	}
 
-	const pageScriptIdMap = new Map<string, string>();
-	for (const script of clipboardData.pageScripts || []) {
-		const newScriptId = generateHash(script.name, clipboardData.sourceURL, true);
-		pageScriptIdMap.set(script.name, newScriptId);
+	const scripts = clipboardData.pageScripts || [];
+	if (!scripts.length) {
+		return;
+	}
 
+	const clientScriptResource = createListResource({
+		doctype: "Builder Client Script",
+	});
+	const existingScriptIds = await fetchExistingScriptIds(
+		scripts.map((script) => generateHash(script.name, clipboardData.sourceURL as string, true)),
+	);
+
+	for (const script of scripts) {
+		const newScriptId = generateHash(script.name, clipboardData.sourceURL, true);
 		const scriptDoc: BuilderClientScriptDocument = {
 			...script,
 			name: newScriptId,
 		};
 
-		const clientScriptResource = createListResource({
-			doctype: "Builder Client Script",
-		});
 		try {
-			await clientScriptResource.insert.submit(scriptDoc);
-		} catch (error: { response?: { status: number } } | any) {
-			if (error?.response?.status === 409) {
-				// If script already exists, update it
+			if (existingScriptIds.has(newScriptId)) {
 				await clientScriptResource.setValue.submit(scriptDoc);
 			} else {
-				console.error("Error inserting client script:", error);
+				await clientScriptResource.insert.submit(scriptDoc);
 			}
-			// pass
+		} catch (error) {
+			console.error("Error saving client script:", error);
 		}
 
 		const clientScript = clipboardData.pageDoc.client_scripts?.find((s) => s.builder_script === script.name);
@@ -381,6 +389,18 @@ async function handlePageScripts(clipboardData: BuilderClipboardData, currentSit
 			clientScript.builder_script = newScriptId;
 		}
 	}
+}
+
+async function fetchExistingScriptIds(scriptIds: string[]): Promise<Set<string>> {
+	const existingScripts = createListResource({
+		doctype: "Builder Client Script",
+		fields: ["name"],
+		filters: [["name", "in", scriptIds]],
+		pageLength: scriptIds.length,
+		auto: true,
+	});
+	await existingScripts.list.promise;
+	return new Set((existingScripts.data || []).map((script: BuilderClientScript) => script.name));
 }
 
 function updateBlockComponentReferences(block: BlockOptions, componentIdMap: Map<string, string>): void {


### PR DESCRIPTION
Pasting a copied website with a deeply nested DOM failed every draft save with `CONSTRAINT tabbuilder page.draft_blocks failed`.

`blocks`/`draft_blocks` moved from JSON to Long Text in 90b2c2b7 because MariaDB's `json_valid` rejects JSON nested deeper than 32 levels, but MariaDB's JSON type is just an alias for `longtext CHECK (json_valid(...))`, so schema sync saw no type change and the old CHECK constraints survived on existing sites.

- Patch drops the stale checks. They are column-level, so `DROP CONSTRAINT` is a silent no-op; the patch redefines the columns via `MODIFY` instead.
- `Builder Component.block` and `Block Template.block` were still JSON and hit the same depth limit on insert, so they move to Long Text too.
- Pasting now checks which components/client scripts already exist with one list request instead of firing inserts that 409 on every re-paste.

Verified on a site with the stale constraints: a 60-level-deep tree saves on both Builder Page and Builder Component after migrate, and re-pasting produces no failed requests.