### PR TITLE
feat(font-picker): preview each font in its own typeface

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -84,7 +84,7 @@
 								@mousedown.prevent
 								class="group flex cursor-default select-none items-center gap-2 rounded px-2 py-1.5 text-sm text-ink-gray-9 transition-colors data-[disabled]:pointer-events-none data-[highlighted]:bg-surface-gray-1 data-[disabled]:opacity-50">
 								<component v-if="option.prefix" :is="option.prefix" class="h-4 w-4 flex-shrink-0" />
-								<MiddleTruncate :text="option.label" />
+								<MiddleTruncate :text="option.label" :style="resolveLabelStyle(option)" />
 								<component
 									v-if="option.suffix"
 									:is="option.suffix"
@@ -123,7 +123,7 @@ import {
 	ComboboxRoot,
 	ComboboxSeparator,
 } from "reka-ui";
-import type { Component, ComponentPublicInstance } from "vue";
+import type { Component, ComponentPublicInstance, StyleValue } from "vue";
 import { computed, nextTick, onMounted, ref, useAttrs, watch } from "vue";
 import MiddleTruncate from "../MiddleTruncate.vue";
 
@@ -137,6 +137,9 @@ interface Option {
 	prefix?: Component;
 	suffix?: Component;
 	disabled?: boolean;
+	// a getter is resolved during render, so styles backed by a reactive source (such as
+	// a font preview that is still loading) reapply once that source settles
+	labelStyle?: StyleValue | (() => StyleValue | undefined);
 }
 
 interface ActionButton {
@@ -248,6 +251,9 @@ const refreshOptions = async (query = "") => {
 		console.error("Failed to load options:", error);
 	}
 };
+
+const resolveLabelStyle = (option: Option): StyleValue | undefined =>
+	typeof option.labelStyle === "function" ? option.labelStyle() : option.labelStyle;
 
 const clearSelection = () => emit("update:modelValue", null);
 

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -31,7 +31,7 @@ import FontUploader from "@/components/Controls/FontUploader.vue";
 import userFonts from "@/data/userFonts";
 import { BuilderToken, UserFont } from "@/types/doctypes";
 import { filterOptions } from "@/utils/autocompleteOptions";
-import { fontListItems, loadFontList, previewFontStyle, schedulePreviewLoad } from "@/utils/fontManager";
+import { enqueuePreviewLoad, fontListItems, loadFontList, previewFontStyle } from "@/utils/fontManager";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { Tooltip } from "frappe-ui";
 import { computed, ref, watch } from "vue";
@@ -136,7 +136,7 @@ const getOptions = async (filterString: string) => {
 
 	// separators and design tokens are the only entries without a preview: a token's
 	// label carries its name too, which the family's own subset cannot render
-	schedulePreviewLoad(options.filter((o) => o.labelStyle).map((o) => o.value));
+	enqueuePreviewLoad(options.filter((o) => o.labelStyle).map((o) => o.value));
 	return options;
 };
 

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -31,7 +31,7 @@ import FontUploader from "@/components/Controls/FontUploader.vue";
 import userFonts from "@/data/userFonts";
 import { BuilderToken, UserFont } from "@/types/doctypes";
 import { filterOptions } from "@/utils/autocompleteOptions";
-import { fontListItems, loadFontList } from "@/utils/fontManager";
+import { fontListItems, loadFontList, previewFontStyle, schedulePreviewLoad } from "@/utils/fontManager";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { Tooltip } from "frappe-ui";
 import { computed, ref, watch } from "vue";
@@ -48,6 +48,12 @@ const props = withDefaults(
 );
 
 const emit = defineEmits(["update:modelValue"]);
+
+type FontOption = {
+	label: string;
+	value: string;
+	labelStyle?: () => { fontFamily: string } | undefined;
+};
 
 const { fontTokens, resolveVariableValue, getVariableName } = useBuilderToken();
 const fontInput = ref<typeof Autocomplete | null>(null);
@@ -85,7 +91,13 @@ const handleUpdate = (val: string | null) => emit("update:modelValue", val);
 
 const getOptions = async (filterString: string) => {
 	await loadFontList();
-	const toOption = (family: string) => ({ label: family, value: family });
+	// each row renders in its own typeface; previewFontStyle stays undefined until that
+	// face is usable, so labels never flash a fallback
+	const toOption = (family: string) => ({
+		label: family,
+		value: family,
+		labelStyle: () => previewFontStyle(family),
+	});
 	// a token's name is what the field shows when one is picked, and it matches no
 	// family: filtering the font lists by it would leave only the token to choose from
 	const fontQuery = isCssVariable.value && filterString === displayValue.value ? "" : filterString;
@@ -109,7 +121,7 @@ const getOptions = async (filterString: string) => {
 		fontQuery,
 	);
 
-	const options = [] as { label: string; value: string }[];
+	const options: FontOption[] = [];
 	if (tokenOptions.length) {
 		options.push({ label: "Design tokens", value: "_separator_0" }, ...tokenOptions);
 	}
@@ -121,6 +133,10 @@ const getOptions = async (filterString: string) => {
 		if (options.length) options.push({ label: "Default", value: "_separator_2" });
 		options.push(...defaultFontOptions);
 	}
+
+	// separators and design tokens are the only entries without a preview: a token's
+	// label carries its name too, which the family's own subset cannot render
+	schedulePreviewLoad(options.filter((o) => o.labelStyle).map((o) => o.value));
 	return options;
 };
 

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -28,6 +28,18 @@ const WEIGHT_LABELS: Record<FontWeight, string> = {
 const GF_CSS = "https://fonts.googleapis.com/css2";
 const fontCache = new Map<string, Promise<string>>();
 
+// A preview only ever renders the family's own name, so it loads a subset holding just
+// those glyphs (~1KB instead of the full face). That face must NOT be registered under
+// the real family name: a block that later applies the same font would otherwise race
+// against a face carrying a handful of glyphs. Alias it instead.
+const PREVIEW_PREFIX = "__builder_preview_";
+// the picker re-queries on every keystroke, so batch the resulting loads
+const PREVIEW_DEBOUNCE = 120;
+
+const previewRequests = new Map<string, Promise<void>>();
+// family -> the family its preview renders with; reactive so pickers restyle on arrival
+const previewFamilies = shallowRef(new Map<string, string>());
+
 // the Google Fonts catalog is ~110KB, so it stays out of the main bundle
 // and loads on first use (font pickers read the reactive ref)
 const fontListItems = shallowRef<FontListItem[]>([]);
@@ -101,24 +113,95 @@ function resolveFontToken(font: string): string {
 
 export function setFont(font: string | null, weight?: string): Promise<string> {
 	if (!font) return Promise.resolve("");
-	if (font.includes("var(")) {
-		const resolved = resolveFontToken(font);
-		if (!resolved) return Promise.resolve(font);
-		font = resolved;
-	}
-	const cacheKey = weight ? `${font}:${weight}` : font;
+
+	// a token stands in for its family; an unknown one leaves nothing to load
+	const family = font.includes("var(") ? resolveFontToken(font) : font;
+	if (!family) return Promise.resolve(font);
+
+	const cacheKey = weight ? `${family}:${weight}` : family;
 	if (fontCache.has(cacheKey)) return fontCache.get(cacheKey)!;
 
 	// userFont list resource may not have loaded yet (e.g. a page rendered right
 	// after navigation); fall back to treating it as a Google font until it does.
 	const customFont = (userFont.data || []).find(
-		(f: { font_name: string; font_file: string }) => f.font_name === font,
+		(f: { font_name: string; font_file: string }) => f.font_name === family,
 	);
 
-	const promise = customFont ? loadCustomFont(font, customFont.font_file) : loadGoogleFont(font, weight);
+	const promise = customFont
+		? loadCustomFont(family, customFont.font_file)
+		: loadGoogleFont(family, weight);
 
 	fontCache.set(cacheKey, promise);
 	return promise;
+}
+
+const isCustomFont = (font: string) =>
+	(userFont.data || []).some((f: { font_name: string }) => f.font_name === font);
+
+// Google's text= parameter returns a face carrying only the requested characters, which
+// for a preview is the family's own name — roughly 1KB rather than the full file.
+async function loadSubsetFace(font: string): Promise<string> {
+	const glyphs = [...new Set(font)].join("");
+	const res = await fetch(`${GF_CSS}?family=${encodeURIComponent(font)}&text=${encodeURIComponent(glyphs)}`);
+	if (!res.ok) throw new Error(`No Google font named ${font}`);
+	const url = (await res.text()).match(/url\((https:\/\/[^)]+)\)/)?.[1];
+	if (!url) throw new Error(`No font file in the stylesheet for ${font}`);
+
+	const previewFamily = `${PREVIEW_PREFIX}${font}`;
+	document.fonts.add(await new FontFace(previewFamily, `url("${url}")`).load());
+	return previewFamily;
+}
+
+function resolvePreviewFace(font: string): Promise<string> {
+	// a font already applied on the canvas has its full face on the way, and uploaded
+	// fonts are served whole from the site itself — either way there is nothing to
+	// subset, and setFont already caches both under the real family name
+	return isCustomFont(font) || fontCache.has(font) ? setFont(font) : loadSubsetFace(font);
+}
+
+/** Loads just enough of a font to render its own name. Failures leave it unpreviewed. */
+export function loadFontPreview(font: string): Promise<void> {
+	const pending = previewRequests.get(font);
+	if (pending) return pending;
+
+	const request = resolvePreviewFace(font)
+		.then((family) => {
+			// swap the map so the pickers restyle once the face is actually usable
+			previewFamilies.value = new Map(previewFamilies.value).set(font, family);
+		})
+		.catch(() => console.warn(`Failed to load font preview: ${font}`));
+
+	previewRequests.set(font, request);
+	return request;
+}
+
+const queuedPreviews = new Set<string>();
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+
+function flushPreviewQueue() {
+	flushTimer = undefined;
+	queuedPreviews.forEach(loadFontPreview);
+	queuedPreviews.clear();
+}
+
+/** Queues previews for the currently visible options, coalescing bursts of keystrokes. */
+export function schedulePreviewLoad(fonts: string[]): void {
+	fonts.forEach((font) => {
+		if (!previewRequests.has(font)) queuedPreviews.add(font);
+	});
+	// the window runs from the first queued font rather than the last, so previews still
+	// arrive while someone is typing
+	if (queuedPreviews.size && !flushTimer) flushTimer = setTimeout(flushPreviewQueue, PREVIEW_DEBOUNCE);
+}
+
+/**
+ * Style for rendering a label in its own typeface. Returns undefined until the preview
+ * has loaded, so the label stays in the UI font instead of flashing a fallback serif.
+ */
+export function previewFontStyle(font: string): { fontFamily: string } | undefined {
+	const family = previewFamilies.value.get(font);
+	// JSON.stringify quotes the family, which matters for names containing spaces
+	return family ? { fontFamily: JSON.stringify(family) } : undefined;
 }
 
 export function setFontFromHTML(html: string): void {

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -208,9 +208,9 @@ function flushPreviewQueue() {
 }
 
 /** Queues previews for the currently visible options, coalescing bursts of keystrokes. */
-export function schedulePreviewLoad(fonts: string[]): void {
+export function enqueuePreviewLoad(fonts: string[]): void {
 	// every keystroke supersedes the last, so the pending set is replaced rather than
-	// accumulated: typing "rob" must not leave the matches for "r" in flight
+	// accumulated: pausing on "rob" should not also fetch what matched "r"
 	queuedPreviews = fonts.filter((font) => !previewRequests.has(font));
 	if (flushTimer) clearTimeout(flushTimer);
 	if (queuedPreviews.length) flushTimer = setTimeout(flushPreviewQueue, PREVIEW_DEBOUNCE);

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -35,10 +35,15 @@ const fontCache = new Map<string, Promise<string>>();
 const PREVIEW_PREFIX = "__builder_preview_";
 // the picker re-queries on every keystroke, so batch the resulting loads
 const PREVIEW_DEBOUNCE = 120;
+// a builder session runs for hours: without a ceiling, browsing the picker would leave
+// the whole catalog resident. Well above the ~20 rows on screen, so nothing visible goes.
+const PREVIEW_FACE_LIMIT = 150;
 
 const previewRequests = new Map<string, Promise<void>>();
 // family -> the family its preview renders with; reactive so pickers restyle on arrival
 const previewFamilies = shallowRef(new Map<string, string>());
+// only subset faces, in insertion order — real faces belong to blocks and are never evicted
+const previewFaces = new Map<string, FontFace>();
 
 // the Google Fonts catalog is ~110KB, so it stays out of the main bundle
 // and loads on first use (font pickers read the reactive ref)
@@ -148,8 +153,26 @@ async function loadSubsetFace(font: string): Promise<string> {
 	if (!url) throw new Error(`No font file in the stylesheet for ${font}`);
 
 	const previewFamily = `${PREVIEW_PREFIX}${font}`;
-	document.fonts.add(await new FontFace(previewFamily, `url("${url}")`).load());
+	const face = await new FontFace(previewFamily, `url("${url}")`).load();
+	document.fonts.add(face);
+	previewFaces.set(font, face);
+	evictOldestPreviews();
 	return previewFamily;
+}
+
+function evictOldestPreviews() {
+	if (previewFaces.size <= PREVIEW_FACE_LIMIT) return;
+
+	const families = new Map(previewFamilies.value);
+	while (previewFaces.size > PREVIEW_FACE_LIMIT) {
+		const [oldest, face] = previewFaces.entries().next().value!;
+		document.fonts.delete(face);
+		previewFaces.delete(oldest);
+		// drop the request too, so the font can be previewed again if it comes back
+		previewRequests.delete(oldest);
+		families.delete(oldest);
+	}
+	previewFamilies.value = families;
 }
 
 function resolvePreviewFace(font: string): Promise<string> {
@@ -175,23 +198,22 @@ export function loadFontPreview(font: string): Promise<void> {
 	return request;
 }
 
-const queuedPreviews = new Set<string>();
+let queuedPreviews: string[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | undefined;
 
 function flushPreviewQueue() {
 	flushTimer = undefined;
 	queuedPreviews.forEach(loadFontPreview);
-	queuedPreviews.clear();
+	queuedPreviews = [];
 }
 
 /** Queues previews for the currently visible options, coalescing bursts of keystrokes. */
 export function schedulePreviewLoad(fonts: string[]): void {
-	fonts.forEach((font) => {
-		if (!previewRequests.has(font)) queuedPreviews.add(font);
-	});
-	// the window runs from the first queued font rather than the last, so previews still
-	// arrive while someone is typing
-	if (queuedPreviews.size && !flushTimer) flushTimer = setTimeout(flushPreviewQueue, PREVIEW_DEBOUNCE);
+	// every keystroke supersedes the last, so the pending set is replaced rather than
+	// accumulated: typing "rob" must not leave the matches for "r" in flight
+	queuedPreviews = fonts.filter((font) => !previewRequests.has(font));
+	if (flushTimer) clearTimeout(flushTimer);
+	if (queuedPreviews.length) flushTimer = setTimeout(flushPreviewQueue, PREVIEW_DEBOUNCE);
 }
 
 /**


### PR DESCRIPTION
## What

The family dropdown listed every font in the UI font. Each row now renders in
the face it names.

## How

Previews use the Google Fonts `text=` parameter, which returns a face carrying
only the requested characters for a preview, the family's own name. 