### PR TITLE
feat: add dev-setup script for submodule init

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ bench --site builder.localhost set-config ignore_csrf 1 # prevents CSRFToken err
 1. Open a new terminal session and run the following commands:
 ```bash
 cd frappe-bench/apps/builder
-yarn install
+yarn dev-setup
 yarn dev --host
 ```
 1. Now, you can access the site on vite dev server at `http://builder.localhost:8080`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "scripts": {
         "postinstall": "cd frontend && yarn install",
         "dev": "cd frontend && yarn dev",
-        "build": "cd frontend && yarn build"
+        "build": "cd frontend && yarn build",
+        "dev-setup": "git submodule update --init --recursive --verbose --depth 1 && yarn install"
     },
     "version": "0.0.0",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Add a `dev-setup` yarn script that initializes the `frappe-ui` submodule and runs `yarn install` in one step
- Update the README to point new contributors at `yarn dev-setup` instead of a bare `yarn install