### PR TITLE
fix(page-data-script): make translation actually callable as `_(...)`

### DIFF
--- a/builder/builder/tests/test_utils.py
+++ b/builder/builder/tests/test_utils.py
@@ -139,6 +139,18 @@ class TestBuilderUtils(FrappeTestCase):
 		execute_script("data.sum = a + b", {"data": data, "a": 2, "b": 2}, "test.py")
 		self.assertEqual(data.sum, 4)
 
+	def test_execute_script_can_translate(self):
+		# frappe._(...) can't work in a Page Data Script: it's an attribute
+		# read, and the sandbox's _getattr_ guard rejects any name starting
+		# with "_" before ever getting to what "_" resolves to. "_" has to be
+		# called bare - see get_safer_globals(), and #626.
+		data = frappe._dict({})
+		execute_script('data.text = _("Supplier")', {"data": data}, "test.py")
+		self.assertEqual(data.text, "Supplier")
+
+		with self.assertRaises(Exception):
+			execute_script('data.text = frappe._("Supplier")', {"data": data}, "test.py")
+
 	@patch("builder.utils.is_safe_exec_enabled", return_value=False)
 	@patch("frappe.utils.safe_exec.is_safe_exec_enabled", return_value=False)
 	def test_execute_script_with_enabled_server_script(self, *args):

--- a/builder/builder/tests/test_utils.py
+++ b/builder/builder/tests/test_utils.py
@@ -140,14 +140,11 @@ class TestBuilderUtils(FrappeTestCase):
 		self.assertEqual(data.sum, 4)
 
 	def test_execute_script_can_translate(self):
-		# frappe._(...) can't work in a Page Data Script: it's an attribute
-		# read, and the sandbox's _getattr_ guard rejects any name starting
-		# with "_" before ever getting to what "_" resolves to. "_" has to be
-		# called bare - see get_safer_globals(), and #626.
 		data = frappe._dict({})
 		execute_script('data.text = _("Supplier")', {"data": data}, "test.py")
 		self.assertEqual(data.text, "Supplier")
 
+		# the sandbox rejects `frappe._`, only the bare name works (#626)
 		with self.assertRaises(Exception):
 			execute_script('data.text = frappe._("Supplier")', {"data": data}, "test.py")
 

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -282,13 +282,7 @@ def get_safer_globals():
 		as_json=frappe.as_json,
 		dict=safe_globals["dict"],
 		args=form_dict,
-		# Top-level, not just frappe.NamespaceDict below: `frappe._(...)` is an
-		# attribute read, and safe_exec's _getattr_ guard rejects any attribute
-		# name starting with "_" outright (frappe/utils/safe_exec.py,
-		# _validate_attribute_read) - it never reaches whatever "_" resolves to,
-		# regardless of where it's defined. A bare name lookup isn't attribute
-		# access, so `_(...)` at the top level is what actually works; this is
-		# also where frappe.utils.safe_exec's own render_safe_globals() puts it.
+		# must stay top-level: safe_exec's _getattr_ guard rejects `frappe._`
 		_=frappe._,
 		frappe=NamespaceDict(
 			db=NamespaceDict(

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -282,6 +282,14 @@ def get_safer_globals():
 		as_json=frappe.as_json,
 		dict=safe_globals["dict"],
 		args=form_dict,
+		# Top-level, not just frappe.NamespaceDict below: `frappe._(...)` is an
+		# attribute read, and safe_exec's _getattr_ guard rejects any attribute
+		# name starting with "_" outright (frappe/utils/safe_exec.py,
+		# _validate_attribute_read) - it never reaches whatever "_" resolves to,
+		# regardless of where it's defined. A bare name lookup isn't attribute
+		# access, so `_(...)` at the top level is what actually works; this is
+		# also where frappe.utils.safe_exec's own render_safe_globals() puts it.
+		_=frappe._,
 		frappe=NamespaceDict(
 			db=NamespaceDict(
 				count=frappe.db.count,


### PR DESCRIPTION
Fixes #626.

The issue's diagnosis is right and I ran it down the same way to be sure before touching anything: `frappe._("Supplier")` in a Page Data Script never gets anywhere near `frappe._`. `frappe._` is an attribute read, and RestrictedPython compiles that to `_getattr_(frappe, "_")`. That guard function is `_getattr_for_safe_exec` in `frappe/utils/safe_exec.py`, and it calls `_validate_attribute_read`, which rejects any attribute name starting with `"_"` unconditionally, before it even looks at what the attribute would resolve to:

```python
def _validate_attribute_read(object, name):
    ...
    if name.startswith("_"):
        raise AttributeError(f'"{name}" is an invalid attribute name because it starts with "_"')
```

So nesting `_=frappe._` differently inside the `frappe` namespace wouldn't have changed anything - `frappe._(...)` can't work regardless of where `_` is defined, because it's the attribute access itself that's rejected, not a lookup failure.

A bare name reference (`_("Supplier")`, no dot) compiles to a plain global lookup, which doesn't go through `_getattr_` at all - RestrictedPython only wraps attribute access, not name resolution. That's exactly what frappe's own `render_safe_globals()` (the base sandbox builder's `get_safer_globals()` extends) already relies on: it puts `_=frappe._` at the top level of `out`, not under `out.frappe`. Builder's version has it nested one level down, which is the actual gap. Moved it to match.

Added a test in `test_utils.py` alongside the existing `execute_script` ones: runs `data.text = _("Supplier")` through `execute_script()` and checks it resolves to `"Supplier"` (no translation is loaded for that string in a test run, so it comes back unchanged, which is expected), and separately asserts that `frappe._("Supplier")` still raises - want that locked in so nobody "fixes" this again later by moving `_` back under `frappe`, which would look reasonable but doesn't actually work.

Ran `ruff check` and `ruff format --check` against both changed files - clean. Didn't have a live site to run the actual test against; the reasoning above is what I'm relying on instead, traced against current `frappe/utils/safe_exec.py` and `render_safe_globals()` rather than assumed.
