### PR TITLE
fix(i18n): wrap the remaining user-facing strings

### DIFF
--- a/builder/builder/doctype/builder_settings/builder_settings.js
+++ b/builder/builder/doctype/builder_settings/builder_settings.js
@@ -17,8 +17,8 @@ frappe.ui.form.on("Builder Settings", {
               {
                 fieldtype: "HTML",
                 fieldname: "filter_area",
-                label: "Builder Page Filter",
-                description: "Limits the pages where the component is replaced",
+                label: __("Builder Page Filter"),
+                description: __("Limits the pages where the component is replaced"),
               },
               {
                 fieldname: "target_component",
@@ -64,9 +64,7 @@ frappe.ui.form.on("Builder Settings", {
               doctype: "Builder Page",
               on_change: () => {},
             });
-            filter_group.wrapper.prepend(
-              "<h5>Filter Builder Pages</h5><p>Limits the pages where the component is replaced</p><br>",
-            );
+            filter_group.wrapper.prepend("<h5>" + __("Filter Builder Pages") + "</h5><p>" + __("Limits the pages where the component is replaced") + "</p><br>");
             filter_group.wrapper.append("<br><br>");
           });
           d.set_primary_action(__("Replace"), (values) => {

--- a/builder/domain.py
+++ b/builder/domain.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.integrations.frappe_providers.frappecloud_billing import get_base_url, get_headers
 from frappe.utils.telemetry import capture
 
@@ -31,7 +32,7 @@ def fc_call(method: str, **params):
 				error = None
 		else:
 			error = body.get("exception") or body.get("message")
-		frappe.throw(error or f"FC API returned {response.status_code}")
+		frappe.throw(error or _("FC API returned {0}").format(response.status_code))
 
 	return response.json().get("message")
 

--- a/builder/public/js/builder.js
+++ b/builder/public/js/builder.js
@@ -1,4 +1,4 @@
 frappe.search.utils.make_function_searchable(
   () => window.open("/builder"),
-  "Open Builder",
+  __("Open Builder"),
 );

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,6 +12,7 @@
 <script setup lang="ts">
 import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
+import { __ } from "@/translation";
 import { UseDark } from "@vueuse/components";
 import { useTitle } from "@vueuse/core";
 import { useSiteReadOnlyNotice } from "@/utils/useSiteReadOnlyNotice";
@@ -29,7 +30,7 @@ provide("sessionUser", sessionUser);
 
 const title = computed(() => {
 	return pageStore.activePage && route.name !== "home"
-		? `${pageStore.activePage.page_title || "Untitled"} | Builder`
+		? `${pageStore.activePage.page_title || __("Untitled")} | Builder`
 		: "Frappe Builder";
 });
 

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -221,11 +221,11 @@ const getDisplayValue = (state: string | null) => {
 	const bg = blockController.getStyle(getStyleKey("backgroundImage", state)) as string;
 	const color = blockController.getStyle(getStyleKey("backgroundColor", state)) as string;
 
-	if (bg?.includes("gradient")) return "Gradient";
+	if (bg?.includes("gradient")) return __("Gradient");
 	if (bg) {
 		const url = bg.replace(/^url\(['"]?|['"]?\)$/g, "");
 		const parts = url.split("/");
-		return parts[parts.length - 1] || "Image";
+		return parts[parts.length - 1] || __("Image");
 	}
 	// show the variable's name instead of its raw value e.g. var(--uuid)
 	if (color) return getVariableName(color) ?? color;

--- a/frontend/src/components/BlockPropertySections/InputOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/InputOptionsSection.ts
@@ -53,8 +53,7 @@ const inputOptionsSectionProperties = [
 			return {
 				label: __("Name"),
 				modelValue: blockController.getAttribute("name") || "",
-				description:
-					"Group name for this radio button. Radio buttons with the same name are grouped together.",
+				description: __("Group name for this radio button. Radio buttons with the same name are grouped together."),
 			};
 		},
 		searchKeyWords: "Radio, Name, Group, RadioName, Radio Name, Group Name, input, radio button",

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -126,6 +126,7 @@ import { builderSettings } from "@/data/builderSettings";
 import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
+import { __ } from "@/translation";
 import { BreakpointConfig, CanvasHistory } from "@/types/Builder/BuilderCanvas";
 import { getBlockObject, isCtrlOrCmd } from "@/utils/helpers";
 import {
@@ -228,7 +229,7 @@ const canvasProps = reactive({
 		{
 			icon: "lucide-monitor",
 			device: "desktop",
-			displayName: "Desktop",
+			displayName: __("Desktop"),
 			width: 1400,
 			visible: true,
 			renderedOnce: true,
@@ -236,14 +237,14 @@ const canvasProps = reactive({
 		{
 			icon: "lucide-tablet",
 			device: "tablet",
-			displayName: "Tablet",
+			displayName: __("Tablet"),
 			width: 800,
 			visible: false,
 		},
 		{
 			icon: "lucide-smartphone",
 			device: "mobile",
-			displayName: "Mobile",
+			displayName: __("Mobile"),
 			width: 420,
 			visible: false,
 		},

--- a/frontend/src/components/BuilderSettings.vue
+++ b/frontend/src/components/BuilderSettings.vue
@@ -32,7 +32,7 @@
 				<component :is="selectedItemDoc?.component" class="pb-16" />
 			</KeepAlive>
 			<div v-else class="flex items-center justify-center">
-				<span class="text-ink-gray-5">Loading...</span>
+				<span class="text-ink-gray-5">{{ __("Loading...") }}</span>
 			</div>
 		</div>
 	</div>
@@ -43,6 +43,7 @@ import builderProjectFolder from "@/data/builderProjectFolder";
 import { builderSettings } from "@/data/builderSettings";
 import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
+import { __ } from "@/translation";
 import { computed, onActivated, onMounted, provide, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -23,7 +23,7 @@
 					<input
 						ref="inputRef"
 						v-model="localQuery"
-						:placeholder="placeholder || (stepLabel ? 'Search...' : 'Search commands...')"
+						:placeholder="placeholder || (stepLabel ? __('Search...') : __('Search commands...'))"
 						class="w-full border-none bg-transparent py-3.5 pl-3 pr-4 text-base text-ink-gray-8 placeholder-ink-gray-4 outline-none ring-0 focus:outline-none focus:ring-0"
 						autocomplete="off"
 						spellcheck="false"
@@ -72,8 +72,8 @@
 							aria-hidden="true" />
 						<span class="text-base">
 							<template v-if="loading">{{ __("Searching...") }}</template>
-							<template v-else-if="localQuery">No results for "{{ localQuery }}"</template>
-							<template v-else>{{ hint || "No commands found" }}</template>
+							<template v-else-if="localQuery">{{ __('No results for "{0}"', [localQuery]) }}</template>
+							<template v-else>{{ hint || __("No commands found") }}</template>
 						</span>
 					</div>
 				</div>
@@ -104,6 +104,7 @@
 </template>
 
 <script setup lang="ts">
+import { __ } from "@/translation";
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from "reka-ui";
 import { computed, nextTick, ref, watch } from "vue";
 

--- a/frontend/src/components/ComponentUpdates.vue
+++ b/frontend/src/components/ComponentUpdates.vue
@@ -37,7 +37,7 @@
 						<div class="flex min-w-0 flex-col">
 							<span class="truncate text-sm text-ink-gray-8">{{ item.component_name }}</span>
 							<span class="text-xs text-ink-gray-5">
-								{{ item.count }} instance{{ item.count === 1 ? "" : "s" }}
+								{{ item.count === 1 ? __("{0} instance", [item.count]) : __("{0} instances", [item.count]) }}
 							</span>
 						</div>
 						<Button
@@ -57,6 +57,7 @@
 import useCanvasStore from "@/stores/canvasStore";
 import useComponentStore from "@/stores/componentStore";
 import usePageStore from "@/stores/pageStore";
+import { __ } from "@/translation";
 import { Button, Popover, Tooltip } from "frappe-ui";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 

--- a/frontend/src/components/Controls/CodeMirror/CustomSearchPanel.vue
+++ b/frontend/src/components/Controls/CodeMirror/CustomSearchPanel.vue
@@ -7,7 +7,7 @@
 				variant="ghost"
 				size="sm"
 				class="h-full rounded-r-none"
-				:tooltip="showReplace ? 'Hide Replace' : 'Show Replace'"
+				:tooltip="showReplace ? __('Hide Replace') : __('Show Replace')"
 				@click="toggleReplace">
 				<span
 					:class="[showReplace ? 'lucide-chevron-down' : 'lucide-chevron-right', 'h-4 w-4']"
@@ -111,6 +111,7 @@ import {
 	setSearchQuery,
 } from "@codemirror/search";
 import type { EditorView } from "@codemirror/view";
+import { __ } from "@/translation";
 import { Button, TextInput } from "frappe-ui";
 import { inject, nextTick, onMounted, ref } from "vue";
 

--- a/frontend/src/components/Controls/Dialog.vue
+++ b/frontend/src/components/Controls/Dialog.vue
@@ -46,7 +46,7 @@ const toggleDialog = (value: boolean) => {
 useEventListener("beforeunload", (e) => {
 	if (attrs?.isDirty) {
 		e.preventDefault();
-		e.returnValue = "You have unsaved changes. Please save before leaving.";
+		e.returnValue = __("You have unsaved changes. Please save before leaving.");
 	}
 });
 

--- a/frontend/src/components/Controls/SearchBlock.vue
+++ b/frontend/src/components/Controls/SearchBlock.vue
@@ -14,7 +14,7 @@
 				ref="searchInput"
 				class="flex-1"
 				type="text"
-				:placeholder="searchMode === 'replace' ? 'Find...' : 'Search blocks...'"
+				:placeholder="searchMode === 'replace' ? __('Find...') : __('Search blocks...')"
 				v-model="query"
 				@input="setQuery"
 				@keydown.enter="handlePrimaryAction" />
@@ -89,10 +89,10 @@
 				variant="solid"
 				class="w-full"
 				:disabled="!replaceQuery">
-				Replace All ({{ results.length }} matches)
+				{{ __("Replace All ({0} matches)", [results.length]) }}
 			</Button>
 			<div v-if="searchMode === 'replace' && replacedCount > 0" class="mt-2 text-xs text-ink-gray-5">
-				{{ replacedCount }} replacements made
+				{{ __("{0} replacements made", [replacedCount]) }}
 			</div>
 		</div>
 
@@ -164,14 +164,14 @@ const searchInSelectedBlock = ref(false);
 const propertyHandlers = [
 	{
 		key: "element",
-		name: "Tag",
+		name: __("Tag"),
 		matches: (block: Block, term: string) => block.getElement()?.toLowerCase().includes(term),
 		replace: () => false,
 	},
 	{
 		// dynamicValues and dataKey
 		key: "data",
-		name: "Data",
+		name: __("Data"),
 		matches: (block: Block, term: string) => {
 			if (block.getDynamicValues()) {
 				block.getDynamicValues().forEach((dv: BlockDataKey) => {
@@ -191,7 +191,7 @@ const propertyHandlers = [
 	},
 	{
 		key: "content",
-		name: "Content",
+		name: __("Content"),
 		matches: (block: Block, term: string) => block.getInnerHTML()?.toLowerCase().includes(term),
 		replace: (block: Block, searchTerm: string, replaceTerm: string) => {
 			const innerHTML = block.getInnerHTML();
@@ -207,7 +207,7 @@ const propertyHandlers = [
 	},
 	{
 		key: "styles",
-		name: "Style",
+		name: __("Style"),
 		matches: (block: Block, term: string) => {
 			const styles = { ...block.baseStyles, ...block.mobileStyles, ...block.tabletStyles };
 			return Object.values(styles).some((val) => String(val).toLowerCase().includes(term));
@@ -222,7 +222,7 @@ const propertyHandlers = [
 	},
 	{
 		key: "attributes",
-		name: "Attributes",
+		name: __("Attributes"),
 		matches: (block: Block, term: string) => {
 			const attrs = { ...block.attributes, ...block.customAttributes };
 			return Object.values(attrs).some((val) => String(val).toLowerCase().includes(term));
@@ -236,7 +236,7 @@ const propertyHandlers = [
 	},
 	{
 		key: "classes",
-		name: "CSS Classes",
+		name: __("CSS Classes"),
 		matches: (block: Block, term: string) => {
 			return block.classes?.some((c) => c.toLowerCase().includes(term));
 		},
@@ -315,7 +315,7 @@ const getMatchDetails = (block: Block) => {
 	const lowerSearchTerm = query.value.toLowerCase();
 	const details = propertyHandlers.filter((h) => h.matches(block, lowerSearchTerm)).map((h) => h.name);
 
-	return details.length > 0 ? `Found in: ${details.join(", ")}` : "";
+	return details.length > 0 ? __("Found in: {0}", [details.join(", ")]) : "";
 };
 
 const replaceInProperty = (obj: any, searchTerm: string, replaceTerm: string): boolean => {
@@ -367,7 +367,7 @@ const replaceInBlock = (block: Block, index: number) => {
 	if (hasReplacement) {
 		replacedCount.value++;
 		results.value.splice(index, 1);
-		toast.success(`Replaced in ${block.getBlockDescription()}`);
+		toast.success(__("Replaced in {0}", [block.getBlockDescription()]));
 	} else {
 		toast.error(__("No replacements made"));
 	}
@@ -388,7 +388,7 @@ const replaceAll = () => {
 	});
 
 	if (totalReplacements > 0) {
-		toast.success(`Made ${totalReplacements} replacements across ${totalReplacements} blocks`);
+		toast.success(__("Made {0} replacements across {0} blocks", [totalReplacements]));
 		performSearch();
 	} else {
 		toast.error(__("No replacements made"));

--- a/frontend/src/components/Controls/SplitModeInput.vue
+++ b/frontend/src/components/Controls/SplitModeInput.vue
@@ -33,6 +33,7 @@
 <script lang="ts" setup>
 import Input from "@/components/Controls/Input.vue";
 import SplitInput from "@/components/Controls/SplitInput.vue";
+import { __ } from "@/translation";
 import blockController from "@/utils/blockController";
 import { expandBoxShorthand } from "@/utils/cssUtils";
 import { TabButtons, type TabButton } from "frappe-ui";
@@ -66,8 +67,8 @@ const props = withDefaults(
 	{
 		modelValue: "",
 		placeholder: "",
-		uniformTitle: "Use for all",
-		splitTitle: "Set separately",
+		uniformTitle: __("Use for all"),
+		splitTitle: __("Set separately"),
 		splitIcon: "lucide-scan",
 		splits: 0,
 		toControlValues: (value: unknown) => (Array.isArray(value) ? value : [value as InputValue]),

--- a/frontend/src/components/Controls/StylePropertyControl.vue
+++ b/frontend/src/components/Controls/StylePropertyControl.vue
@@ -12,6 +12,7 @@
 
 <script lang="ts" setup>
 import BasePropertyControl from "@/components/Controls/BasePropertyControl.vue";
+import { __ } from "@/translation";
 import blockController from "@/utils/blockController";
 import type { Component } from "vue";
 import { computed } from "vue";
@@ -51,9 +52,9 @@ const props = withDefaults(
 );
 
 const stateLabels: Record<string, string> = {
-	hover: "On Hover",
-	active: "On Active",
-	focus: "On Focus",
+	hover: __("On Hover"),
+	active: __("On Active"),
+	focus: __("On Focus"),
 };
 
 const stateVariants = computed(() =>

--- a/frontend/src/components/EditableSpan.vue
+++ b/frontend/src/components/EditableSpan.vue
@@ -58,7 +58,7 @@ function handleBlur() {
 		props.onChange(text).catch((e) => {
 			let error_message = e.exc.split("\n").slice(-2)[0];
 			if (error_message.includes("Duplicate") || error_message.includes("select another name")) {
-				error_message = "Name already exists";
+				error_message = __("Name already exists");
 			}
 			toast.error(__("Failed to rename"), {
 				description: error_message,

--- a/frontend/src/components/Modals/NewBuilderToken.vue
+++ b/frontend/src/components/Modals/NewBuilderToken.vue
@@ -2,11 +2,11 @@
 	<Dialog
 		:modelValue="modelValue"
 		@update:modelValue="$emit('update:modelValue', $event)"
-		:title="dialogMode === 'edit' ? 'Edit Token' : 'New Token'"
+		:title="dialogMode === 'edit' ? __('Edit Token') : __('New Token')"
 		size="sm"
 		:actions="[
 			{
-				label: dialogMode === 'edit' ? 'Update' : 'Create',
+				label: dialogMode === 'edit' ? __('Update') : __('Create'),
 				variant: 'solid',
 				onClick: handleSave,
 			},
@@ -20,7 +20,7 @@
 					:label="__('Token Name')"
 					required
 					:autofocus="true"
-					placeholder="e.g., primary, accent, background"
+					:placeholder="__('e.g., primary, accent, background')"
 					:hideClearButton="true" />
 				<div v-if="activeBuilderToken.type === 'Color'" class="flex flex-col gap-3">
 					<div class="flex flex-col gap-1.5">
@@ -96,7 +96,8 @@ const handleSave = async () => {
 		emit("update:modelValue", false);
 	} catch (error) {
 		console.error("Failed to save variable:", error);
-		toast.error((error as Error).message || `Failed to ${dialogMode.value} token`);
+		const fallbackMessage = dialogMode.value === "edit" ? __("Failed to update token") : __("Failed to create token");
+		toast.error((error as Error).message || fallbackMessage);
 	}
 };
 </script>

--- a/frontend/src/components/Modals/TokenManager.vue
+++ b/frontend/src/components/Modals/TokenManager.vue
@@ -12,7 +12,7 @@
 		v-if="modelValue"
 		:placement-offset-top="8"
 		:placement-offset-left="65"
-		action-label="Add Token"
+		:action-label="__('Add Token')"
 		:action-handler="addNewVariable"
 		placement="top-left">
 		<template #header>
@@ -199,10 +199,10 @@
 											v-else
 											:class="[cellBoxClass, cellTextClass(row), row.token_name ? '' : 'text-ink-gray-4']"
 											@dblclick="startEdit(row, 'token_name')">
-											{{ row.token_name || "unnamed" }}
+											{{ row.token_name || __("unnamed") }}
 										</div>
 										<!-- Copy the token's CSS handle: var(--<id>) — paste it into any style -->
-										<Tooltip v-if="row.name" :text="`Copy var(--${row.name})`" placement="top">
+										<Tooltip v-if="row.name" :text="__('Copy var(--{0})', [row.name])" placement="top">
 											<div
 												class="invisible ml-auto mr-1 shrink-0 group-hover/row:visible"
 												:class="{ '!visible': copiedId === row.id }">
@@ -346,12 +346,12 @@
 					</template>
 					<div v-if="!hasRows" class="py-10 text-center">
 						<div class="text-base-medium text-ink-gray-7">
-							{{ searchQuery.trim() ? __("No tokens found") : `No ${activeType.toLowerCase()} tokens yet` }}
+							{{ searchQuery.trim() ? __("No tokens found") : emptyTypeMessage }}
 						</div>
 						<div class="mt-1 text-sm text-ink-gray-5">
 							{{
 								searchQuery.trim()
-									? `No tokens match "${searchQuery}". Try a different search term.`
+									? __('No tokens match "{0}". Try a different search term.', [searchQuery])
 									: __("Click 'Add Token' to create your first one.")
 							}}
 						</div>
@@ -424,6 +424,11 @@ const {
 const csvFileInput = ref<HTMLInputElement>();
 const activeType = ref<"Color" | "Font" | "Dimension">("Color");
 const isColorType = computed(() => activeType.value === "Color");
+const emptyTypeMessage = computed(() => {
+	if (activeType.value === "Color") return __("No color tokens yet");
+	if (activeType.value === "Font") return __("No font tokens yet");
+	return __("No dimension tokens yet");
+});
 
 // Copy a token's CSS handle — var(--<doc-id>) — for pasting into any style field.
 const copiedId = ref<string | null>(null);
@@ -718,7 +723,11 @@ const moveSelectedToGroup = async (group: string) => {
 		row.group = group;
 		await saveVariable(row);
 	}
-	toast.success(group ? `Moved ${rows.length} token(s) to "${group}"` : `Ungrouped ${rows.length} token(s)`);
+	if (group) {
+		toast.success(rows.length === 1 ? __('Moved {0} token to "{1}"', [rows.length, group]) : __('Moved {0} tokens to "{1}"', [rows.length, group]));
+	} else {
+		toast.success(rows.length === 1 ? __("Ungrouped {0} token", [rows.length]) : __("Ungrouped {0} tokens", [rows.length]));
+	}
 };
 
 const uniqueCopyName = (name: string) => {
@@ -732,7 +741,8 @@ const uniqueCopyName = (name: string) => {
 const deleteSelected = async () => {
 	const rows = selectedRows();
 	if (!rows.length) return;
-	const confirmed = await confirm(`Are you sure you want to delete ${rows.length} token(s)?`);
+	const deleteMessage = rows.length === 1 ? __("Are you sure you want to delete {0} token?", [rows.length]) : __("Are you sure you want to delete {0} tokens?", [rows.length]);
+	const confirmed = await confirm(deleteMessage);
 	if (!confirmed) return;
 
 	let deleted = 0;
@@ -742,10 +752,10 @@ const deleteSelected = async () => {
 			rowObjects.delete(row.name!);
 			deleted++;
 		} catch (error) {
-			toast.error(`Failed to delete "${row.token_name}"`);
+			toast.error(__('Failed to delete "{0}"', [row.token_name]));
 		}
 	}
-	if (deleted) toast.success(`Deleted ${deleted} token(s)`);
+	if (deleted) toast.success(deleted === 1 ? __("Deleted {0} token", [deleted]) : __("Deleted {0} tokens", [deleted]));
 	clearSelection();
 };
 
@@ -754,7 +764,7 @@ const contextMenuOptions = computed(() => {
 		return [{ label: __("Remove"), action: () => (newVariable.value = null) }];
 	}
 	const count = selectedIds.value.size;
-	const suffix = count > 1 ? ` ${count} variables` : " variable";
+	const deleteLabel = count > 1 ? __("Delete {0} variables", [count]) : __("Delete variable");
 	return [
 		{ label: __("Move to group"), action: openGroupDialog },
 		{
@@ -762,7 +772,7 @@ const contextMenuOptions = computed(() => {
 			action: () => moveSelectedToGroup(""),
 			condition: () => selectedRows().some((row) => row.group),
 		},
-		{ label: `Delete${suffix}`, action: deleteSelected },
+		{ label: deleteLabel, action: deleteSelected },
 	];
 });
 
@@ -938,23 +948,24 @@ const parseCSVAndAddVariables = async (csvText: string) => {
 	}
 
 	if (newVariables.length === 0 && updateVariables.length === 0) {
-		if (invalidCount > 0) toast.error(`${invalidCount} entries were invalid`);
+		if (invalidCount > 0) toast.error(invalidCount === 1 ? __("{0} entry was invalid", [invalidCount]) : __("{0} entries were invalid", [invalidCount]));
 		if (csvFileInput.value) csvFileInput.value.value = "";
 		return;
 	}
 
 	// Warn user that existing variables will be updated
-	const skippedNotes = [
-		invalidCount > 0 ? `${invalidCount} invalid entries skipped` : "",
-		standardCount > 0 ? `${standardCount} standard token(s) skipped` : "",
-	]
-		.filter(Boolean)
-		.join(", ");
-	const confirmed = await confirm(
-		`Create ${newVariables.length} new token(s) and update ${updateVariables.length} existing token(s)?${
-			skippedNotes ? ` (${skippedNotes})` : ""
-		}\n\nWARNING: Updating will overwrite the existing values for the listed variables.`,
-	);
+	const createAndUpdateMessage = newVariables.length === 1
+		? updateVariables.length === 1
+			? __("Create {0} new token and update {1} existing token?", [newVariables.length, updateVariables.length])
+			: __("Create {0} new token and update {1} existing tokens?", [newVariables.length, updateVariables.length])
+		: updateVariables.length === 1
+			? __("Create {0} new tokens and update {1} existing token?", [newVariables.length, updateVariables.length])
+			: __("Create {0} new tokens and update {1} existing tokens?", [newVariables.length, updateVariables.length]);
+	const confirmationLines = [createAndUpdateMessage];
+	if (invalidCount > 0) confirmationLines.push(invalidCount === 1 ? __("({0} invalid entry skipped)", [invalidCount]) : __("({0} invalid entries skipped)", [invalidCount]));
+	if (standardCount > 0) confirmationLines.push(standardCount === 1 ? __("({0} standard token skipped)", [standardCount]) : __("({0} standard tokens skipped)", [standardCount]));
+	confirmationLines.push("", __("WARNING: Updating will overwrite the existing values for the listed variables."));
+	const confirmed = await confirm(confirmationLines.join("\n"));
 
 	if (!confirmed) {
 		if (csvFileInput.value) csvFileInput.value.value = "";
@@ -1002,12 +1013,12 @@ const parseCSVAndAddVariables = async (csvText: string) => {
 	// CSV import mutates variables outside the table; rebuild rows from fresh store data
 	resetRowObjects();
 
-	if (createdCount > 0) toast.success(`Created ${createdCount} token(s)`);
-	if (updatedCount > 0) toast.success(`Updated ${updatedCount} token(s)`);
-	if (createErrors > 0) toast.error(`Failed to create ${createErrors} token(s)`);
-	if (updateErrors > 0) toast.error(`Failed to update ${updateErrors} token(s)`);
-	if (invalidCount > 0) toast.warning(`Skipped ${invalidCount} invalid entries`);
-	if (standardCount > 0) toast.warning(`Skipped ${standardCount} standard token(s) (read-only)`);
+	if (createdCount > 0) toast.success(createdCount === 1 ? __("Created {0} token", [createdCount]) : __("Created {0} tokens", [createdCount]));
+	if (updatedCount > 0) toast.success(updatedCount === 1 ? __("Updated {0} token", [updatedCount]) : __("Updated {0} tokens", [updatedCount]));
+	if (createErrors > 0) toast.error(createErrors === 1 ? __("Failed to create {0} token", [createErrors]) : __("Failed to create {0} tokens", [createErrors]));
+	if (updateErrors > 0) toast.error(updateErrors === 1 ? __("Failed to update {0} token", [updateErrors]) : __("Failed to update {0} tokens", [updateErrors]));
+	if (invalidCount > 0) toast.warning(invalidCount === 1 ? __("Skipped {0} invalid entry", [invalidCount]) : __("Skipped {0} invalid entries", [invalidCount]));
+	if (standardCount > 0) toast.warning(standardCount === 1 ? __("Skipped {0} standard token (read-only)", [standardCount]) : __("Skipped {0} standard tokens (read-only)", [standardCount]));
 
 	if (csvFileInput.value) csvFileInput.value.value = "";
 };

--- a/frontend/src/components/PageOptions.vue
+++ b/frontend/src/components/PageOptions.vue
@@ -19,7 +19,7 @@
 				@update:modelValue="(val: string) => updateActivePage('route', val)" />
 			<!-- Dynamic Route Variables -->
 			<CollapsibleSection
-				sectionName="URL Variables"
+				:sectionName="__('URL Variables')"
 				v-if="dynamicVariables.length"
 				class="w-full [&>div>h3]:!text-xs [&>div>h3]:!text-ink-gray-5">
 				<BuilderInput
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import useBuilderStore from "@/stores/builderStore";
 import usepageStore from "@/stores/pageStore";
+import { __ } from "@/translation";
 import { BuilderPage } from "@/types/doctypes";
 import { getRouteVariables } from "@/utils/helpers";
 import { useDebounceFn } from "@vueuse/core";

--- a/frontend/src/components/RouteTreeNode.vue
+++ b/frontend/src/components/RouteTreeNode.vue
@@ -89,8 +89,8 @@
 					class="flex items-center gap-1 text-xs text-ink-gray-4 hover:text-ink-gray-7"
 					@click="onLoadMore(node.id, node.loadedCount)">
 					<span class="lucide-more-horizontal size-3" aria-hidden="true" />
-					Load {{ Math.min(PAGE_LIMIT_PER_NODE, node.totalCount - node.loadedCount) }} more
-					<span class="ml-0.5 text-ink-gray-3">({{ node.totalCount - node.loadedCount }} remaining)</span>
+					{{ __("Load {0} more", [Math.min(PAGE_LIMIT_PER_NODE, node.totalCount - node.loadedCount)]) }}
+					<span class="ml-0.5 text-ink-gray-3">{{ __("({0} remaining)", [node.totalCount - node.loadedCount]) }}</span>
 				</button>
 			</div>
 		</section>
@@ -99,6 +99,7 @@
 
 <script setup lang="ts">
 import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
+import { __ } from "@/translation";
 import { BuilderPage } from "@/types/doctypes";
 import { Tooltip } from "frappe-ui";
 import HomeIcon from "~icons/lucide/house";

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="isolate">
 		<div v-if="pagesResource.loading && !pages.length" class="px-3 py-6 text-center text-sm text-ink-gray-4">
-			Loading pages…
+			{{ __("Loading pages…") }}
 		</div>
 		<div
 			v-else-if="!pagesResource.loading && !pages.length"
@@ -36,9 +36,9 @@
 					class="flex items-center gap-1 text-xs text-ink-gray-4 hover:text-ink-gray-7"
 					@click="loadMore('__root__', rootLoadMore.loadedCount)">
 					<span class="lucide-more-horizontal size-3" aria-hidden="true" />
-					Load {{ Math.min(PAGE_LIMIT_PER_NODE, rootLoadMore.totalCount - rootLoadMore.loadedCount) }} more
+					{{ __("Load {0} more", [Math.min(PAGE_LIMIT_PER_NODE, rootLoadMore.totalCount - rootLoadMore.loadedCount)]) }}
 					<span class="ml-0.5 text-ink-gray-3">
-						({{ rootLoadMore.totalCount - rootLoadMore.loadedCount }} remaining)
+						{{ __("({0} remaining)", [rootLoadMore.totalCount - rootLoadMore.loadedCount]) }}
 					</span>
 				</button>
 			</div>

--- a/frontend/src/components/Settings/GlobalDomains.vue
+++ b/frontend/src/components/Settings/GlobalDomains.vue
@@ -40,7 +40,7 @@
 		<form @submit.prevent="handleAdd" class="flex flex-col gap-3">
 			<FormControl
 				:label="__('Enter your domain')"
-				placeholder="e.g. yourdomain.com"
+				:placeholder="__('e.g. yourdomain.com')"
 				v-model="newDomain"
 				autocomplete="off" />
 
@@ -49,13 +49,13 @@
 				<template v-for="(rec, i) in dnsRecords" :key="rec.type">
 					<div v-if="i > 0" class="flex items-center gap-3 px-3">
 						<div class="bg-outline-gray-2 h-px flex-1"></div>
-						<span class="text-p-xs text-ink-gray-4">or</span>
+						<span class="text-p-xs text-ink-gray-4">{{ __("or") }}</span>
 						<div class="bg-outline-gray-2 h-px flex-1"></div>
 					</div>
 					<div class="flex items-center gap-2 px-3 py-2.5">
 						<div class="min-w-0 flex-1">
 							<div class="flex items-baseline gap-1.5">
-								<span class="text-p-sm-semibold leading-6 text-ink-gray-8">{{ rec.type }} record</span>
+								<span class="text-p-sm-semibold leading-6 text-ink-gray-8">{{ __("{0} record", [rec.type]) }}</span>
 								<span class="font-mono text-p-xs">
 									<span :class="newDomain ? 'text-ink-gray-5' : 'text-ink-gray-3'">{{ rec.host }}</span>
 									<span class="px-1 text-ink-gray-4">→</span>
@@ -157,7 +157,7 @@ const dnsRecords = computed(() => {
 			value: currentSite,
 			copyValue: currentSite,
 			recommended: true,
-			hint: "Automatically follows server IP changes. Best choice for subdomains.",
+			hint: __("Automatically follows server IP changes. Best choice for subdomains."),
 		});
 	}
 	records.push({
@@ -174,22 +174,22 @@ const dnsRecords = computed(() => {
 });
 
 function brokenReason(d: any): string {
-	if (!d.dns_response) return "Domain setup failed. Please retry or contact support.";
+	if (!d.dns_response) return __("Domain setup failed. Please retry or contact support.");
 	try {
 		const parsed = JSON.parse(d.dns_response);
 		if (parsed.exc_message) return parsed.exc_message.replace(/<[^>]*>/g, "").trim();
 		const cname = parsed.CNAME;
 		const a = parsed.A;
 		if (cname?.exists && !cname?.matched)
-			return `CNAME record points to wrong destination: ${cname.answer?.trim() || "unknown"}`;
-		if (a?.exists && !a?.matched) return `A record points to wrong IP: ${a.answer?.trim() || "unknown"}`;
-		if (!cname?.exists && !a?.exists) return "No DNS record found for this domain.";
+			return __("CNAME record points to wrong destination: {0}", [cname.answer?.trim() || __("unknown")]);
+		if (a?.exists && !a?.matched) return __("A record points to wrong IP: {0}", [a.answer?.trim() || __("unknown")]);
+		if (!cname?.exists && !a?.exists) return __("No DNS record found for this domain.");
 		if (parsed.matched || parsed.valid)
-			return "DNS is verified but SSL certificate provisioning failed. Please retry.";
+			return __("DNS is verified but SSL certificate provisioning failed. Please retry.");
 	} catch {
 		// ignore parse errors
 	}
-	return "Domain setup failed. Please retry or contact support.";
+	return __("Domain setup failed. Please retry or contact support.");
 }
 
 function statusTheme(status: string) {

--- a/frontend/src/components/Settings/GlobalRedirects.vue
+++ b/frontend/src/components/Settings/GlobalRedirects.vue
@@ -45,7 +45,7 @@
 					<span
 						v-if="field === 'to' && (row.status !== '301' || row.forward)"
 						class="flex shrink-0 items-center gap-1 rounded bg-surface-gray-3 px-1.5 py-0.5 text-xs text-ink-gray-5"
-						:title="`HTTP ${row.status}${row.forward ? ' · forwards query parameters' : ''}`">
+						:title="row.forward ? __('HTTP {0} · forwards query parameters', [row.status]) : __('HTTP {0}', [row.status])">
 						<span v-if="row.status !== '301'" class="tabular-nums">{{ row.status }}</span>
 						<span v-if="row.forward" class="lucide-arrow-right-left size-3" aria-hidden="true" />
 					</span>
@@ -59,14 +59,14 @@
 			</div>
 
 			<div v-if="searchQuery.trim() && !rows.length" class="px-2 py-6 text-center text-sm text-ink-gray-5">
-				No redirects match "{{ searchQuery }}"
+				{{ __('No redirects match "{0}"', [searchQuery]) }}
 			</div>
 		</div>
 
 		<Dialog
 			v-model="showDialog"
-			:title="editingId ? 'Edit Redirect' : 'Add Redirect'"
-			:actions="[{ label: editingId ? 'Save' : 'Add Redirect', variant: 'solid', onClick: commit }]">
+			:title="editingId ? __('Edit Redirect') : __('Add Redirect')"
+			:actions="[{ label: editingId ? __('Save') : __('Add Redirect'), variant: 'solid', onClick: commit }]">
 			<template #default>
 				<div class="flex flex-col gap-3">
 					<BuilderInput
@@ -75,7 +75,7 @@
 						required
 						:ref="(el) => field === 'from' && (fromRef = el)"
 						:modelValue="draft[field]"
-						:label="field === 'from' ? 'Source' : 'Target'"
+						:label="field === 'from' ? __('Source') : __('Target')"
 						type="text"
 						:hideClearButton="true"
 						:placeholder="placeholders[field]"
@@ -141,10 +141,10 @@ const cellDividerClass = "border-l border-outline-gray-1 pl-2";
 const fields = ["from", "to"] as const;
 const placeholders: Record<Field, string> = { from: "/old-path", to: "/new-path" };
 const statusOptions = [
-	{ label: "301 - Moved Permanently", value: "301" },
-	{ label: "302 - Found (Temporary)", value: "302" },
-	{ label: "307 - Temporary Redirect", value: "307" },
-	{ label: "308 - Permanent Redirect", value: "308" },
+	{ label: __("301 - Moved Permanently"), value: "301" },
+	{ label: __("302 - Found (Temporary)"), value: "302" },
+	{ label: __("307 - Temporary Redirect"), value: "307" },
+	{ label: __("308 - Permanent Redirect"), value: "308" },
 ];
 
 const highlight = (field: Field, value: string) =>
@@ -250,7 +250,7 @@ const insertNew = (d: Draft) => {
 			const i = findIndex(tempId);
 			if (i !== -1) routeRedirects.data?.splice(i, 1);
 		},
-		{ loading: "Adding redirect...", success: "Redirect added", error: "Error adding redirect" },
+		{ loading: __("Adding redirect..."), success: __("Redirect added"), error: __("Error adding redirect") },
 	);
 };
 
@@ -261,14 +261,14 @@ const saveExisting = (id: string, d: Draft) => {
 		() => routeRedirects.setValue.submit({ name: id, ...docFields(d) }),
 		() => index !== -1 && Object.assign(routeRedirects.data![index], docFields(d)),
 		() => backup && Object.assign(routeRedirects.data![index], backup),
-		{ loading: "Updating redirect...", success: "Redirect updated", error: "Error updating redirect" },
+		{ loading: __("Updating redirect..."), success: __("Redirect updated"), error: __("Error updating redirect") },
 	);
 };
 
 const deleteRedirect = async (id: string) => {
 	const row = rows.value.find((r) => r.id === id);
 	const message = row
-		? `Are you sure you want to delete the redirect from "${row.from}" to "${row.to}"?`
+		? __('Are you sure you want to delete the redirect from "{0}" to "{1}"?', [row.from, row.to])
 		: __("Are you sure you want to delete this redirect?");
 	if (!(await confirm(message))) return;
 
@@ -278,7 +278,7 @@ const deleteRedirect = async (id: string) => {
 		() => routeRedirects.delete.submit(id),
 		() => index !== -1 && routeRedirects.data!.splice(index, 1),
 		() => backup && routeRedirects.data!.splice(index, 0, backup),
-		{ loading: "Deleting redirect...", success: "Redirect deleted", error: "Error deleting redirect" },
+		{ loading: __("Deleting redirect..."), success: __("Redirect deleted"), error: __("Error deleting redirect") },
 	);
 };
 </script>

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -14,7 +14,7 @@
 		<div class="min-h-0 flex-1 overflow-y-auto">
 			<div v-if="filteredInvites.length" class="mb-6 flex flex-col">
 				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-p-sm text-ink-gray-5">
-					Pending Invites ({{ filteredInvites.length }})
+					{{ __("Pending Invites ({0})", [filteredInvites.length]) }}
 				</span>
 				<div
 					v-for="invite in filteredInvites"
@@ -26,7 +26,7 @@
 							<span class="truncate text-p-sm text-ink-gray-8">{{ invite.email }}</span>
 							<UseTimeAgo v-slot="{ timeAgo }" :time="invite.creation">
 								<span class="truncate text-p-xs text-ink-gray-5">
-									Invited {{ timeAgo }}{{ invite.invited_by_name ? ` by ${invite.invited_by_name}` : "" }}
+									{{ invite.invited_by_name ? __("Invited {0} by {1}", [timeAgo, invite.invited_by_name]) : __("Invited {0}", [timeAgo]) }}
 								</span>
 							</UseTimeAgo>
 						</div>
@@ -45,7 +45,7 @@
 
 			<div class="flex flex-col">
 				<span class="sticky top-0 z-10 bg-surface-base pb-1 text-p-sm text-ink-gray-5">
-					Members ({{ filteredMembers.length }})
+					{{ __("Members ({0})", [filteredMembers.length]) }}
 				</span>
 				<div
 					v-for="user in filteredMembers"
@@ -55,14 +55,14 @@
 					<div class="flex min-w-0 flex-col">
 						<span class="truncate text-p-sm text-ink-gray-8">
 							{{ user.full_name }}
-							<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">You</Badge>
+							<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">{{ __("You") }}</Badge>
 						</span>
 						<span class="truncate text-p-xs text-ink-gray-5">{{ user.name }}</span>
 					</div>
 					<Badge v-if="user.is_admin" theme="gray" class="ml-auto shrink-0">{{ __("Admin") }}</Badge>
 				</div>
 				<div v-if="!filteredMembers.length" class="py-6 text-center text-p-sm text-ink-gray-5">
-					<template v-if="searchQuery.trim()">No members match "{{ searchQuery }}"</template>
+					<template v-if="searchQuery.trim()">{{ __('No members match "{0}"', [searchQuery]) }}</template>
 					<template v-else>
 						{{ __("No members yet. Invite someone to give them access to Builder.") }}
 					</template>
@@ -175,16 +175,16 @@ const sendInvites = async () => {
 			app_name: "builder",
 		});
 		if (res.invited_emails.length) {
-			toast.success(`Invitation sent to ${res.invited_emails.join(", ")}`);
+			toast.success(__("Invitation sent to {0}", [res.invited_emails.join(", ")]));
 		}
 		if (res.pending_invite_emails.length) {
-			toast.info(`Already invited: ${res.pending_invite_emails.join(", ")}`);
+			toast.info(__("Already invited: {0}", [res.pending_invite_emails.join(", ")]));
 		}
 		if (res.accepted_invite_emails.length) {
-			toast.info(`Already a member: ${res.accepted_invite_emails.join(", ")}`);
+			toast.info(__("Already a member: {0}", [res.accepted_invite_emails.join(", ")]));
 		}
 		if (res.disabled_user_emails.length) {
-			toast.error(`User is disabled: ${res.disabled_user_emails.join(", ")}`);
+			toast.error(__("User is disabled: {0}", [res.disabled_user_emails.join(", ")]));
 		}
 		showInviteDialog.value = false;
 		inviteEmails.value = "";
@@ -197,14 +197,14 @@ const sendInvites = async () => {
 const resendInvite = async (invite: PendingInvite) => {
 	try {
 		await resendResource.submit({ name: invite.name, app_name: "builder" });
-		toast.success(`Invitation resent to ${invite.email}`);
+		toast.success(__("Invitation resent to {0}", [invite.email]));
 	} catch (error) {
 		toast.error(errorMessage(error));
 	}
 };
 
 const cancelInvite = async (invite: PendingInvite) => {
-	if (!(await confirm(`Are you sure you want to cancel the invitation to ${invite.email}?`))) return;
+	if (!(await confirm(__("Are you sure you want to cancel the invitation to {0}?", [invite.email])))) return;
 	try {
 		await cancelResource.submit({ name: invite.name, app_name: "builder" });
 		toast.success(__("Invitation cancelled"));

--- a/frontend/src/components/Settings/PageGeneral.vue
+++ b/frontend/src/components/Settings/PageGeneral.vue
@@ -19,7 +19,7 @@
 				</div>
 				<div class="flex flex-col gap-3 text-base">
 					<div class="flex">
-						<span class="w-20 text-ink-gray-6">URL</span>
+						<span class="w-20 text-ink-gray-6">{{ __("URL") }}</span>
 						<a class="font-medium text-ink-gray-8 hover:underline" target="_blank" :href="fullURL">
 							{{ fullURL }}
 						</a>
@@ -83,11 +83,7 @@
 								@upload="(url: string) => pageStore.updateActivePage('favicon', url)"
 								@remove="() => pageStore.updateActivePage('favicon', '')" />
 							<span class="text-p-sm text-ink-gray-6">
-								{{
-									__(
-										"Appears next to the title in your browser tab. Recommended size is 32x32 px in PNG or ICO",
-									)
-								}}
+								{{ __("Appears next to the title in your browser tab. Recommended size is 32x32 px in PNG or ICO") }}
 							</span>
 						</div>
 					</div>
@@ -141,7 +137,7 @@
 						<hr v-if="pageStore.activePage?.is_standard" class="w-full border-outline-gray-2" />
 						<div v-if="pageStore.activePage?.is_standard" class="flex items-center justify-between">
 							<div class="flex flex-col gap-2">
-								<span class="text-base-medium text-ink-gray-9">App</span>
+								<span class="text-base-medium text-ink-gray-9">{{ __("App") }}</span>
 								<p class="max-w-xs text-p-sm text-ink-gray-7">
 									{{ __("Select the app for this standard page") }}
 								</p>
@@ -261,7 +257,7 @@ const notifyStandardPageExport = () => {
 
 	if (activePage?.is_standard) {
 		const appName = toTitleCase(activePage?.app || "");
-		toast.success(`This page will be exported to ${appName} app as standard page`);
+		toast.success(__("This page will be exported to {0} app as standard page", [appName]));
 	}
 };
 </script>

--- a/frontend/src/components/ShadowHandler.vue
+++ b/frontend/src/components/ShadowHandler.vue
@@ -61,7 +61,7 @@
 					<div v-for="(shadow, index) in shadowConfigs" :key="index" class="space-y-2 rounded-md">
 						<div class="flex items-center justify-between">
 							<span class="text-[10px] font-bold uppercase tracking-wider text-ink-gray-4">
-								Layer {{ index + 1 }}
+								{{ __("Layer {0}", [index + 1]) }}
 							</span>
 							<Button
 								icon="lucide-x"
@@ -110,7 +110,7 @@
 							</div>
 						</div>
 						<div class="flex items-center gap-2">
-							<Tooltip :text="shadow.inset ? 'Inset Shadow' : 'Outset Shadow'">
+							<Tooltip :text="shadow.inset ? __('Inset Shadow') : __('Outset Shadow')">
 								<OptionToggle
 									class="!w-auto [&>div]:!h-7 [&>div]:min-w-[40px]"
 									:modelValue="shadow.inset"
@@ -131,7 +131,7 @@
 					</div>
 				</div>
 				<div class="mt-3">
-					<Button class="w-full" variant="subtle" @click="addShadow">+ Add Shadow Layer</Button>
+					<Button class="w-full" variant="subtle" @click="addShadow">{{ __("+ Add Shadow Layer") }}</Button>
 				</div>
 			</div>
 		</template>

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -237,9 +237,9 @@ const importAll = () => {
 			router.push({ name: "home" });
 		});
 	toast.promise(promise, {
-		loading: "Adding all pages...",
-		success: () => "All pages added",
-		error: () => "Could not add pages",
+		loading: __("Adding all pages..."),
+		success: () => __("All pages added"),
+		error: () => __("Could not add pages"),
 	});
 	promise.finally(() => {
 		importingAll.value = false;

--- a/frontend/src/components/Templates/TemplateGroupCard.vue
+++ b/frontend/src/components/Templates/TemplateGroupCard.vue
@@ -22,7 +22,7 @@
 				{{ group.title }}
 			</p>
 			<span class="shrink-0 text-xs text-ink-gray-4">
-				{{ group.pages.length }} {{ group.pages.length === 1 ? "page" : "pages" }}
+				{{ group.pages.length === 1 ? __("{0} page", [group.pages.length]) : __("{0} pages", [group.pages.length]) }}
 			</span>
 		</div>
 	</div>

--- a/frontend/src/components/TextBlockBubbleMenu.vue
+++ b/frontend/src/components/TextBlockBubbleMenu.vue
@@ -36,7 +36,7 @@
 			</div>
 			<Input
 				type="checkbox"
-				:label="'Open in New Tab'"
+				:label="__('Open in New Tab')"
 				class="text-xs"
 				v-model="openInNewTab"
 				@change="() => setLink(textLink, false)"></Input>
@@ -142,6 +142,7 @@
 import type Block from "@/block";
 import ColorPicker from "@/components/Controls/ColorPicker.vue";
 import Input from "@/components/Controls/Input.vue";
+import { __ } from "@/translation";
 import type { Editor } from "@tiptap/vue-3";
 import { BubbleMenu } from "@tiptap/vue-3/menus";
 import { vOnClickOutside } from "@vueuse/components";
@@ -263,9 +264,9 @@ const handleKeydown = (e: KeyboardEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
 		const blockWarnings = {
-			isHeader: "You cannot make heading a link",
-			isLink: "You cannot add link inside a link block",
-			isButton: "You cannot add link inside a button block",
+			isHeader: __("You cannot make heading a link"),
+			isLink: __("You cannot add link inside a link block"),
+			isButton: __("You cannot add link inside a button block"),
 		};
 
 		const blockType = Object.entries(blockWarnings).find(([type]) => (props.block as any)[type]());

--- a/frontend/src/components/ToolbarItems/ViewerAvatars.vue
+++ b/frontend/src/components/ToolbarItems/ViewerAvatars.vue
@@ -21,6 +21,7 @@
 </template>
 <script setup lang="ts">
 import useBuilderStore from "@/stores/builderStore";
+import { __ } from "@/translation";
 import { Tooltip } from "frappe-ui";
 import { computed } from "vue";
 
@@ -36,7 +37,7 @@ const currentlyViewedByText = computed(() => {
 	} else if (count === 2) {
 		return `${names.join(" & ")}`;
 	} else {
-		return `${names.slice(0, 2).join(", ")} & ${count - 2} others`;
+		return __("{0} & {1} others", [names.slice(0, 2).join(", "), count - 2]);
 	}
 });
 </script>

--- a/frontend/src/data/domains.ts
+++ b/frontend/src/data/domains.ts
@@ -8,7 +8,7 @@ const API = "builder.domain";
 function getErrorMessage(e: any): string {
 	const msg = Array.isArray(e?.messages) && e.messages[0];
 	if (msg && typeof msg === "string") return msg.replace(/<[^>]*>/g, "").trim();
-	return e?.message || "Something went wrong";
+	return e?.message || __("Something went wrong");
 }
 
 export function useDomains() {
@@ -41,13 +41,13 @@ export function useDomains() {
 			return { matched: result?.matched ?? false, error: "" };
 		} catch (e: any) {
 			const msg = Array.isArray(e?.messages) && e.messages[0];
-			const error = (msg && typeof msg === "string" ? msg : e?.message) || "Something went wrong";
+			const error = (msg && typeof msg === "string" ? msg : e?.message) || __("Something went wrong");
 			return { matched: false, error };
 		}
 	}
 
 	async function addDomain(domain: string): Promise<{ ok: boolean; error?: string }> {
-		const id = toast.loading(`Verifying DNS for ${domain}…`);
+		const id = toast.loading(__("Verifying DNS for {0}…", [domain]));
 		try {
 			const { matched, error } = await checkDNS(domain);
 			if (!matched) {
@@ -57,9 +57,9 @@ export function useDomains() {
 					error: error || "DNS not yet propagated. Make sure the record is set correctly and try again.",
 				};
 			}
-			toast.loading(`Adding ${domain}…`, { id });
+			toast.loading(__("Adding {0}…", [domain]), { id });
 			await createResource({ url: `${API}.add_domain` }).submit({ domain });
-			toast.success(`${domain} added successfully`, { id });
+			toast.success(__("{0} added successfully", [domain]), { id });
 			await fetchDomains();
 			return { ok: true };
 		} catch (e: any) {
@@ -69,23 +69,23 @@ export function useDomains() {
 	}
 
 	async function removeDomain(domain: string) {
-		await callAPI("remove_domain", domain, `${domain} removed`, `Removing ${domain}…`);
+		await callAPI("remove_domain", domain, __("{0} removed", [domain]), __("Removing {0}…", [domain]));
 	}
 
 	async function retryDomain(domain: string) {
-		await callAPI("retry_add_domain", domain, `Retrying ${domain}`, `Retrying ${domain}…`);
+		await callAPI("retry_add_domain", domain, __("Retrying {0}", [domain]), __("Retrying {0}…", [domain]));
 	}
 
 	async function setHostName(domain: string) {
-		await callAPI("set_host_name", domain, `${domain} set as primary`, `Updating primary domain…`);
+		await callAPI("set_host_name", domain, __("{0} set as primary", [domain]), __("Updating primary domain…"));
 	}
 
 	async function setRedirect(domain: string) {
-		await callAPI("set_redirect", domain, `Redirect enabled for ${domain}`, `Enabling redirect…`);
+		await callAPI("set_redirect", domain, __("Redirect enabled for {0}", [domain]), __("Enabling redirect…"));
 	}
 
 	async function unsetRedirect(domain: string) {
-		await callAPI("unset_redirect", domain, `Redirect disabled for ${domain}`, `Disabling redirect…`);
+		await callAPI("unset_redirect", domain, __("Redirect disabled for {0}", [domain]), __("Disabling redirect…"));
 	}
 
 	async function callAPI(method: string, domain: string, successMsg: string, loadingMsg?: string) {

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -2,8 +2,8 @@
 	<div v-show="isSmallScreen" class="grid h-screen w-screen place-content-center gap-4 text-ink-gray-9">
 		<img src="/builder_logo.png" alt="logo" class="h-10" />
 		<div class="flex flex-col">
-			<h1 class="text-p-3xl-semibold">Screen too small</h1>
-			<p class="text-p-base">Please switch to a larger screen to edit</p>
+			<h1 class="text-p-3xl-semibold">{{ __("Screen too small") }}</h1>
+			<p class="text-p-base">{{ __("Please switch to a larger screen to edit") }}</p>
 		</div>
 	</div>
 	<div v-show="!isSmallScreen" class="page-builder relative h-screen overflow-hidden bg-surface-gray-1">
@@ -30,7 +30,7 @@
 			<template v-slot:header>
 				<div class="flex items-center justify-between bg-surface-base p-2 text-sm text-ink-gray-8 shadow-sm">
 					<div class="flex items-center gap-1 pl-2 text-xs">
-						<a @click="canvasStore.exitFragmentMode" class="cursor-pointer">Page</a>
+						<a @click="canvasStore.exitFragmentMode" class="cursor-pointer">{{ __("Page") }}</a>
 						<span class="lucide-chevron-right h-3 w-3" aria-hidden="true" />
 						<span class="flex items-center gap-2">
 							{{ canvasStore.fragmentData.fragmentName }}

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -108,9 +108,9 @@ const questions: {
 }[] = [
 	{
 		key: "source",
-		heading: "How did you hear about Builder?",
-		subtitle: "Just curious, it helps us know what's working.",
-		otherPlaceholder: "I heard from the community",
+		heading: __("How did you hear about Builder?"),
+		subtitle: __("Just curious, it helps us know what's working."),
+		otherPlaceholder: __("I heard from the community"),
 		options: [
 			{ value: "search", label: __("Search (Google)") },
 			{ value: "youtube", label: __("YouTube") },
@@ -122,9 +122,9 @@ const questions: {
 	},
 	{
 		key: "role",
-		heading: "Which one best describes you?",
-		subtitle: "This helps us personalise your Builder experience",
-		otherPlaceholder: "I'm a student building my first site",
+		heading: __("Which one best describes you?"),
+		subtitle: __("This helps us personalise your Builder experience"),
+		otherPlaceholder: __("I'm a student building my first site"),
 		options: [
 			{ value: "designer", label: __("Designer") },
 			{ value: "developer", label: __("Developer") },
@@ -136,9 +136,9 @@ const questions: {
 	},
 	{
 		key: "use_case",
-		heading: "What do you want to build first?",
-		subtitle: "We'll point you to the right starting templates",
-		otherPlaceholder: "A booking site for my clinic",
+		heading: __("What do you want to build first?"),
+		subtitle: __("We'll point you to the right starting templates"),
+		otherPlaceholder: __("A booking site for my clinic"),
 		options: [
 			{ value: "marketing_site", label: __("Marketing / landing site") },
 			{ value: "ecommerce", label: __("Online store / E-commerce") },

--- a/frontend/src/stores/blockTemplateStore.ts
+++ b/frontend/src/stores/blockTemplateStore.ts
@@ -41,7 +41,7 @@ const useBlockTemplateStore = defineStore("blockTemplateStore", {
 				(block: Block) => {
 					this.saveBlockTemplate(block, blockTemplateName);
 				},
-				"Save Template",
+				__("Save Template"),
 				blockTemplate.template_name,
 			);
 			builderStore.leftPanelActiveTab = "Layers";

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -169,7 +169,7 @@ const useCanvasStore = defineStore("canvasStore", {
 			block: Block,
 			fragmentType: "component" | "blockTemplate",
 			saveAction: (block: Block) => void,
-			saveActionLabel: string = "Save",
+			saveActionLabel: string = __("Save"),
 			fragmentName?: string,
 			fragmentId?: string,
 			showUsageCount?: boolean,

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -85,7 +85,7 @@ const useComponentStore = defineStore("componentStore", {
 				componentBlock,
 				"component",
 				(block: Block) => this.saveComponent(block, componentName),
-				"Save Component",
+				__("Save Component"),
 				component.component_name,
 				component.name,
 				true,
@@ -122,14 +122,14 @@ const useComponentStore = defineStore("componentStore", {
 									auto: true,
 								});
 								await toast.promise(componentResource.promise!, {
-									loading: "Syncing component in all the pages...",
+									loading: __("Syncing component in all the pages..."),
 									success: () => {
 										pageStore.fetchActivePage().then(() => {
 											pageStore.setPage(pageStore.activePage?.name as string);
 										});
-										return "Component synced in all the pages!";
+										return __("Component synced in all the pages!");
 									},
-									error: () => "Error syncing component in all the pages!",
+									error: () => __("Error syncing component in all the pages!"),
 								});
 							},
 						},
@@ -438,9 +438,7 @@ const useComponentStore = defineStore("componentStore", {
 			if (this.isComponentUsed(component.name)) {
 				alert(__("Component is used in current page. You cannot delete it."));
 			} else {
-				const confirmed = await confirm(
-					`Are you sure you want to delete component: ${component.component_name}?`,
-				);
+				const confirmed = await confirm(__("Are you sure you want to delete component: {0}?", [component.component_name]));
 				if (confirmed) {
 					webComponent.delete.submit(component.name).then(() => {
 						this.componentMap.delete(component.name);

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -182,8 +182,7 @@ async function handlePagePaste(
 
 	await showDialog({
 		title: __("Pasting a page!"),
-		message:
-			"You are about to paste a page with settings and scripts. Do you want to update the current page or create a new one?",
+		message: __("You are about to paste a page with settings and scripts. Do you want to update the current page or create a new one?"),
 		actions: [
 			{
 				label: __("Create New Page"),

--- a/frontend/src/utils/colorOptions.ts
+++ b/frontend/src/utils/colorOptions.ts
@@ -1,3 +1,4 @@
+import { __ } from "@/translation";
 import { BuilderToken } from "@/types/doctypes";
 import { filterOptions } from "@/utils/autocompleteOptions";
 import { tokenType } from "@/utils/useBuilderToken";
@@ -76,7 +77,7 @@ export function getColorVariableOptions(
 													onEdit(builderToken);
 												},
 											},
-											"Edit",
+											__("Edit"),
 										);
 								},
 							}),

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -15,15 +15,15 @@ interface WeightOption {
 }
 
 const WEIGHT_LABELS: Record<FontWeight, string> = {
-	"100": "Thin",
-	"200": "Extra Light",
-	"300": "Light",
-	"400": "Regular",
-	"500": "Medium",
-	"600": "Semi Bold",
-	"700": "Bold",
-	"800": "Extra Bold",
-	"900": "Black",
+	"100": __("Thin"),
+	"200": __("Extra Light"),
+	"300": __("Light"),
+	"400": __("Regular"),
+	"500": __("Medium"),
+	"600": __("Semi Bold"),
+	"700": __("Bold"),
+	"800": __("Extra Bold"),
+	"900": __("Black"),
 };
 
 const GF_CSS = "https://fonts.googleapis.com/css2";

--- a/frontend/src/utils/imageUtils.ts
+++ b/frontend/src/utils/imageUtils.ts
@@ -1,3 +1,4 @@
+import { __ } from "@/translation";
 import { createResource } from "frappe-ui";
 import { toast } from "frappe-ui";
 
@@ -27,9 +28,9 @@ export const getOptimizeButtonText = (imageUrl: string | null): string => {
 	}
 
 	if (isExternalImage(imageUrl)) {
-		return "Serve Locally";
+		return __("Serve Locally");
 	} else if (isConvertibleToWebP(imageUrl)) {
-		return "Convert to WebP";
+		return __("Convert to WebP");
 	}
 	return "";
 };
@@ -53,9 +54,9 @@ export const optimizeImage = ({ imageUrl, onSuccess }: ImageOptimizationOptions)
 			onSuccess(res);
 		}),
 		{
-			loading: isExternal ? "Pulling..." : "Converting...",
-			success: () => (isExternal ? "Image pulled to local" : "Image converted to WebP"),
-			error: () => (isExternal ? "Failed to pull image to local" : "Failed to convert image to WebP"),
+			loading: isExternal ? __("Pulling...") : __("Converting..."),
+			success: () => (isExternal ? __("Image pulled to local") : __("Image converted to WebP")),
+			error: () => (isExternal ? __("Failed to pull image to local") : __("Failed to convert image to WebP")),
 		},
 	);
 };


### PR DESCRIPTION
Follow-up to #721. That sweep covered most of the editor, so after it merged I walked the rest of the app to see what still renders in English regardless of the user's language.

### What this covers

- **Dashboard and page lifecycle** — route tree loading and pagination, template gallery import toasts, template group page counts
- **Editor shell** — the small-screen notice, the fragment breadcrumb, the settings loading state, the URL Variables section, the viewer summary
- **Command palette** — search placeholders and both empty states
- **Settings** — domains, redirects and users were untouched by earlier sweeps and were almost entirely English
- **Controls and modals** — block search and replace, split-mode input, state variants, shadow layers, the design token manager
- **Stores, utils and data** — component save and sync, font weight labels, image optimisation, domain toasts
- **Desk and backend** — the Builder Settings component filter dialog, the Open Builder command, and the FC API error

### Translator-facing changes

Every interpolated message became a stable placeholder source. Counted messages now select a singular or plural string instead of rendering `token(s)`, and the CSV import confirmation no longer joins translated fragments into another translated sentence. German and other inflected languages cannot express those forms.

### Deliberately not included

- The permission messages passed to `has_page_write` / `has_page_read`. A decorator argument is evaluated at import time, so `_()` there would resolve the translation before a user session exists. Translating inside the decorator would work, but it changes the decorator's contract, so it seemed better to raise it than to slip it in here.
- The visibility-condition description, which carries markup.
- Gradient and page preset names. They read as proper nouns, and the whole preset object is emitted to callers, so translating `name` would change what consumers receive.
- The AI surfaces, since #671 is rewriting them.

Lookup keys and sentinels stay raw: `Mixed`, `UNGROUPED_LABEL`, the breakpoint `device` values, the numeric font weights, and the command palette `group` keys.

### Overlap with open PRs

Some of these files are also touched by open drafts: #733, #671 and #702. Everything here is a one-line wrap, so conflicts should be mechanical, but flagging it since #715 and #721 collided the same way. Happy to rebase whenever it suits.

### Checks

Vue templates and TypeScript compile clean locally for all 37 changed frontend files, and `domain.py` parses. POT extraction and the suites run in CI.
