### PR TITLE
feat: recently used colors in the color picker palette

### DIFF
--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -1,5 +1,5 @@
 <template>
-	<Popover placement="left" class="!block w-full" :offset="25">
+	<Popover placement="left" class="!block w-full" :offset="25" @update:open="handlePopoverToggle">
 		<template #target="{ togglePopover }">
 			<div class="flex w-full items-center justify-between" @focusin="updateActiveState">
 				<StylePropertyControl
@@ -47,6 +47,7 @@
 				<!-- Color Tab -->
 				<div v-if="activeTab === 'color'" class="w-full space-y-4">
 					<ColorPicker
+						ref="colorPickerRef"
 						renderMode="inline"
 						:modelValue="backgroundColor"
 						:showInput="true"
@@ -178,6 +179,12 @@ const BackgroundInput = defineComponent({
 });
 
 const activeState = ref<string | null>(null);
+const colorPickerRef = ref<InstanceType<typeof ColorPicker> | null>(null);
+
+// the picker renders inline here, so this popover owns the "closed" moment
+const handlePopoverToggle = (open: boolean) => {
+	if (!open) colorPickerRef.value?.commitRecentColor();
+};
 
 const updateActiveState = (e: FocusEvent) => {
 	const target = e.target as HTMLElement;

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -34,7 +34,7 @@
 		</template>
 		<template #body>
 			<div
-				class="background-popover-body w-64 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
+				class="background-popover-body w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
 				<TabButtons
 					:options="[
 						{ label: '', value: 'color', icon: 'lucide-droplet' },

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -5,7 +5,7 @@
 		:placement="placement"
 		:offset="offset"
 		:portal-to="portalTo"
-		@update:open="isOpen = $event"
+		@update:open="handleOpenChange"
 		class="!block w-full">
 		<template #target>
 			<slot name="target" :togglePopover="togglePopover" :isOpen="isOpen"></slot>
@@ -63,6 +63,12 @@ const colorPickerPopover = ref<InstanceType<typeof Popover> | null>(null);
 const contentRef = ref<InstanceType<typeof ColorPickerContent> | null>(null);
 const isOpen = ref(false);
 
+// bank the color the picker closed on into the recently used swatches
+function handleOpenChange(open: boolean) {
+	if (!open) contentRef.value?.commitRecentColor();
+	isOpen.value = open;
+}
+
 // event handlers bind this directly, so drop the event they pass
 function togglePopover(open?: boolean | Event) {
 	if (open instanceof Event) open = undefined;
@@ -79,5 +85,6 @@ defineExpose({
 	togglePopover,
 	isOpen,
 	hideOptions: () => contentRef.value?.hideOptions(),
+	commitRecentColor: () => contentRef.value?.commitRecentColor(),
 });
 </script>

--- a/frontend/src/components/Controls/ColorPickerContent.vue
+++ b/frontend/src/components/Controls/ColorPickerContent.vue
@@ -160,8 +160,12 @@ const defaultColors: HashString[] = [
 // the eyedropper occupies the last slot when the browser supports it
 const swatchCount = computed(() => (isSupported.value ? 8 : 9));
 
-// persisted and shared across every picker instance in the tab
-const recentColors = useStorage<HashString[]>("builderRecentColors", []);
+// persisted and shared across every picker instance in the tab.
+// flush must be "sync": the default "pre" write runs in a scope-bound watcher, so
+// a value set while the picker is unmounting never reaches localStorage
+const recentColors = useStorage<HashString[]>("builderRecentColors", [], localStorage, {
+	flush: "sync",
+});
 
 // hex casing varies by source, so compare swatches on a common form
 const normalizeColor = (color: HashString) => color.trim().toLowerCase();
@@ -180,10 +184,15 @@ const colors = computed(() => {
 	return palette;
 });
 
-// only the color the picker closes on is banked, not every drag frame
+// dismissing the popover also deselects the block, so modelValue is already null
+// by the time the commit runs — keep hold of the last real color instead
+let lastColor: HashString | null = null;
+watch(modelColor, (color) => color && (lastColor = color), { immediate: true });
+
+// only the color the picker closed on is banked, not every drag frame
 const commitRecentColor = () => {
-	if (!modelColor.value) return;
-	const color = normalizeColor(modelColor.value) as HashString;
+	if (!lastColor) return;
+	const color = normalizeColor(lastColor) as HashString;
 	recentColors.value = [color, ...recentColors.value.filter((c) => normalizeColor(c) !== color)].slice(
 		0,
 		swatchCount.value,

--- a/frontend/src/components/Controls/ColorPickerContent.vue
+++ b/frontend/src/components/Controls/ColorPickerContent.vue
@@ -2,7 +2,9 @@
 	<div
 		:class="[
 			'color-picker-container flex flex-col gap-2',
-			renderMode === 'inline' ? 'w-full' : 'rounded-lg bg-surface-base p-3 shadow-lg',
+			renderMode === 'inline'
+				? 'w-full'
+				: 'w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl',
 		]">
 		<div
 			ref="colorMap"

--- a/frontend/src/components/Controls/ColorPickerContent.vue
+++ b/frontend/src/components/Controls/ColorPickerContent.vue
@@ -61,8 +61,8 @@ import useCanvasStore from "@/stores/canvasStore";
 import { getColorVariableOptions } from "@/utils/colorOptions";
 import { HSVToHex, HexToHSV, getRGB } from "@/utils/helpers";
 import { useBuilderToken } from "@/utils/useBuilderToken";
-import { clamp, useElementBounding, useEyeDropper } from "@vueuse/core";
-import { Ref, StyleValue, computed, nextTick, ref, watch } from "vue";
+import { clamp, useElementBounding, useEyeDropper, useStorage } from "@vueuse/core";
+import { Ref, StyleValue, computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 
 type CSSColorValue = HashString | RGBString | `var(--${string})`;
 
@@ -143,17 +143,54 @@ const getOptions = async (query: string) =>
 
 const emit = defineEmits(["update:modelValue"]);
 
-const colors: HashString[] = [
-	"#FFB3E6",
-	"#00B3E6",
-	"#E6B333",
-	"#3366E6",
+// seed palette, shown until enough colors have actually been used
+// kept lowercase to match what HSVToHex and getRGB emit, so no case conversion is needed
+const defaultColors: HashString[] = [
+	"#ffb3e6",
+	"#00b3e6",
+	"#e6b333",
+	"#3366e6",
 	"#999966",
-	"#99FF99",
-	"#B34D4D",
-	"#80B300",
+	"#99ff99",
+	"#b34d4d",
+	"#80b300",
+	"#808080",
 ];
-if (!isSupported.value) colors.push("#B34D4D");
+
+// the eyedropper occupies the last slot when the browser supports it
+const swatchCount = computed(() => (isSupported.value ? 8 : 9));
+
+// persisted and shared across every picker instance in the tab
+const recentColors = useStorage<HashString[]>("builderRecentColors", []);
+
+// hex casing varies by source, so compare swatches on a common form
+const normalizeColor = (color: HashString) => color.trim().toLowerCase();
+
+// recents fill the row first, defaults seed whatever space is left over
+const colors = computed(() => {
+	const seen = new Set<string>();
+	const palette: HashString[] = [];
+	for (const color of [...recentColors.value, ...defaultColors]) {
+		const key = normalizeColor(color);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		palette.push(color);
+		if (palette.length === swatchCount.value) break;
+	}
+	return palette;
+});
+
+// only the color the picker closes on is banked, not every drag frame
+const commitRecentColor = () => {
+	if (!modelColor.value) return;
+	const color = normalizeColor(modelColor.value) as HashString;
+	recentColors.value = [color, ...recentColors.value.filter((c) => normalizeColor(c) !== color)].slice(
+		0,
+		swatchCount.value,
+	);
+};
+
+onBeforeUnmount(commitRecentColor);
 
 const hue = computed(() => Math.round(((hueSelectorPosition.value.x || 0) / (hueMapWidth.value || 1)) * 360));
 const alpha = computed(() =>
@@ -223,7 +260,10 @@ const alphaSelectorStyle = computed(() => {
 
 const selectColor = (color: HashString) => {
 	setSelectorPosition(color);
-	updateColor();
+	// emit the exact value, not what updateColor() derives from the selector's
+	// pixel position — that round-trip rounds and banks a near-identical duplicate
+	currentColor = color;
+	emit("update:modelValue", color);
 };
 
 const handleInputChange = (color: string | null) => {
@@ -343,5 +383,6 @@ watch(
 defineExpose({
 	syncPositions: () => setSelectorPosition(modelColor.value),
 	hideOptions: () => autocompleteRef.value?.hideOptions(),
+	commitRecentColor,
 });
 </script>

--- a/frontend/src/components/Controls/GradientEditor.vue
+++ b/frontend/src/components/Controls/GradientEditor.vue
@@ -33,7 +33,7 @@
 								@click="(e) => !hasMoved && togglePopover()" />
 						</template>
 						<template #body="{ close }">
-							<div class="rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
+							<div class="w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
 								<ColorPicker
 									renderMode="inline"
 									:showInput="true"

--- a/frontend/src/components/Controls/GradientEditor.vue
+++ b/frontend/src/components/Controls/GradientEditor.vue
@@ -24,7 +24,10 @@
 					:key="index"
 					class="absolute top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
 					:style="{ left: stop.position + '%' }">
-					<Popover placement="top" :offset="10">
+					<Popover
+						placement="top"
+						:offset="10"
+						@update:open="(open: boolean) => handleStopPopoverToggle(open, index)">
 						<template #target="{ togglePopover }">
 							<div
 								class="size-4 cursor-pointer rounded-full border-2 border-white shadow-md ring-1 ring-black/20 transition-transform hover:scale-110 focus:outline-none"
@@ -35,6 +38,7 @@
 						<template #body="{ close }">
 							<div class="w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
 								<ColorPicker
+									:ref="(el) => (stopPickerRefs[index] = el)"
 									renderMode="inline"
 									:showInput="true"
 									:modelValue="stop.color"
@@ -76,15 +80,15 @@
 			</div>
 		</div>
 
-		<!-- Presets -->
+		<!-- Recently used gradients, falling back to the built-in presets -->
 		<div class="flex flex-wrap gap-2">
 			<div
-				v-for="preset in presets"
-				:key="preset.name"
+				v-for="swatch in gradientSwatches"
+				:key="swatch.gradient"
 				class="size-6 cursor-pointer rounded-full border border-outline-gray-2 shadow-sm transition-colors hover:border-outline-gray-4"
-				:style="{ background: preset.gradient }"
-				@click="applyPreset(preset.gradient)"
-				:title="preset.name" />
+				:style="{ background: swatch.gradient }"
+				@click="applyPreset(swatch.gradient)"
+				:title="swatch.name" />
 		</div>
 	</div>
 </template>
@@ -92,10 +96,10 @@
 <script setup lang="ts">
 import { __ } from "@/translation";
 import { parseGradient, stringifyGradient, type Gradient, type GradientStop } from "@/utils/gradientUtils";
-import { useMouseInElement, useMousePressed } from "@vueuse/core";
+import { useMouseInElement, useMousePressed, useStorage } from "@vueuse/core";
 import { STRETCH_TABS } from "@/utils/tabButtons";
 import { Popover, TabButtons } from "frappe-ui";
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import AnglePicker from "./AnglePicker.vue";
 import ColorPicker from "./ColorPicker.vue";
 import Input from "./Input.vue";
@@ -109,6 +113,14 @@ const emit = defineEmits(["update:modelValue"]);
 const barRef = ref<HTMLElement | null>(null);
 const draggingIdx = ref<number | null>(null);
 const hasMoved = ref(false);
+
+// each stop's picker renders inline, so this popover owns its "closed" moment,
+// the same way BackgroundHandler does for the background picker
+const stopPickerRefs: Record<number, any> = {};
+
+const handleStopPopoverToggle = (open: boolean, index: number) => {
+	if (!open) stopPickerRefs[index]?.commitRecentColor();
+};
 
 const { elementX } = useMouseInElement(barRef);
 const { pressed } = useMousePressed();
@@ -153,11 +165,45 @@ const presets = [
 	{ name: "Royal", gradient: "linear-gradient(135deg, #141e30 0%, #243b55 100%)" },
 ];
 
+// flush must be "sync": the default "pre" write runs in a scope-bound watcher, so
+// a value set while the editor is unmounting never reaches localStorage
+const recentGradients = useStorage<string[]>("builderRecentGradients", [], localStorage, {
+	flush: "sync",
+});
+
+// recents fill the row first, presets seed whatever space is left over
+const gradientSwatches = computed(() => {
+	const seen = new Set<string>();
+	const swatches: { name: string; gradient: string }[] = [];
+	const recent = recentGradients.value.map((gradient) => ({ name: __("Recently used"), gradient }));
+
+	for (const swatch of [...recent, ...presets]) {
+		if (seen.has(swatch.gradient)) continue;
+		seen.add(swatch.gradient);
+		swatches.push(swatch);
+		if (swatches.length === presets.length) break;
+	}
+	return swatches;
+});
+
+// only gradients the user actually applied are banked, not the untouched default
+let lastGradient: string | null = null;
+
+onBeforeUnmount(() => {
+	if (!lastGradient) return;
+	const value = lastGradient;
+	recentGradients.value = [value, ...recentGradients.value.filter((g) => g !== value)].slice(
+		0,
+		presets.length,
+	);
+});
+
 const applyPreset = (presetGradient: string) => {
 	const parsed = parseGradient(presetGradient);
 	if (parsed) {
 		gradient.value = parsed;
-		emit("update:modelValue", stringifyGradient(parsed));
+		lastGradient = stringifyGradient(parsed);
+		emit("update:modelValue", lastGradient);
 	}
 };
 
@@ -218,7 +264,8 @@ watch(
 );
 
 const emitUpdate = () => {
-	emit("update:modelValue", stringifyGradient(gradient.value));
+	lastGradient = stringifyGradient(gradient.value);
+	emit("update:modelValue", lastGradient);
 };
 
 const updateType = (type: any) => {


### PR DESCRIPTION
### What

The color picker's swatch row was a hardcoded list of 8 colors. It now surfaces the recently used colors, and the color popovers
are sized consistently.

### Changes

**Recently used colors**

- Last 8 colors persist to `localStorage`, shared across every picker instance in the tab.
- The static palette backfills unused slots, so the row is never empty.
- Colors are banked when the popover closes, not on every drag frame.
- Deduped, so a color can't occupy two slots.
Before :

https://github.com/user-attachments/assets/3b1c7fe4-d1c2-4d69-9c25-482d96e2a370

Now:

https://github.com/user-attachments/assets/ffde152e-5da0-4f63-99f9-02921b27e4a0

**Consistent popover width**

- Background and picker popovers each sized themselves independently. All are now `w-52` (208px), which fits the swatch row without leaving dead space.
Before :
<img width="1080" height="1080" alt="before" src="https://github.com/user-attachments/assets/9d95b93a-a6fc-4ade-8a12-8ccb4ead53da" />

Now : 
<img width="1080" height="1080" alt="now" src="https://github.com/user-attachments/assets/bd477ca8-ced3-4182-9584-d5c25a5cd9f8" />
