### PR TITLE
fix(a11y): add alt text to images missing it

### DIFF
--- a/frontend/src/components/BuilderBlockTemplates.vue
+++ b/frontend/src/components/BuilderBlockTemplates.vue
@@ -22,7 +22,7 @@
 							:class="{
 								'w-14': !blockTemplate?.preview_width || blockTemplate?.preview_width == 1,
 							}">
-							<img :src="blockTemplate.preview" class="pointer-events-none" />
+							<img :src="blockTemplate.preview" :alt="blockTemplate.template_name" class="pointer-events-none" />
 						</div>
 						<p class="text-wrap text-center text-sm text-ink-gray-6">
 							{{ blockTemplate.template_name }}

--- a/frontend/src/components/PageCard.vue
+++ b/frontend/src/components/PageCard.vue
@@ -9,6 +9,7 @@
 				width="250"
 				height="140"
 				:src="page.meta_image || page.preview"
+				:alt="page.page_title || page.page_name"
 				onerror="this.src='/assets/builder/images/fallback.png'"
 				class="aspect-video w-full overflow-hidden rounded-md object-cover shadow dark:border dark:border-outline-gray-1" />
 			<div class="flex items-center justify-between border-outline-gray-2">

--- a/frontend/src/components/PageListItem.vue
+++ b/frontend/src/components/PageListItem.vue
@@ -10,6 +10,7 @@
 					width="140"
 					height="82"
 					:src="page.meta_image || page.preview"
+					:alt="page.page_title || page.page_name"
 					onerror="this.src='/assets/builder/images/fallback.png'"
 					class="block aspect-video w-36 flex-shrink-0 overflow-hidden rounded-lg bg-surface-gray-1 object-cover shadow-md" />
 				<div class="flex flex-1 items-start justify-between overflow-hidden">

--- a/frontend/src/components/ToolbarItems/ViewerAvatars.vue
+++ b/frontend/src/components/ToolbarItems/ViewerAvatars.vue
@@ -6,6 +6,7 @@
 					<img
 						class="h-full w-full rounded-full border-2 border-orange-400 object-cover shadow-sm"
 						:title="user.fullname"
+						:alt="user.fullname"
 						:src="user.image"
 						v-if="user.image" />
 					<div


### PR DESCRIPTION
## Problem

Four images had no `alt` attribute.

## Fix

Preview thumbnails of a named item get a real alt = that item's title (block-template preview, page card/list previews) — matching frappe/insights' own convention for the same kind of preview card. `ViewerAvatars.vue` has no visible name text next to the avatar (only a hover tooltip, which isn't a reliable accessible-name source), so it gets a real alt too.
