### PR TITLE
fix(rtl): use logical spacing/text-align classes instead of physical ones

### DIFF
--- a/frontend/src/components/AIAffectedItems.vue
+++ b/frontend/src/components/AIAffectedItems.vue
@@ -12,7 +12,7 @@
 			<button
 				v-for="block in affectedBlocks"
 				:key="block.block_id"
-				class="flex w-full flex-col rounded px-1.5 py-1 text-left hover:bg-surface-gray-2"
+				class="flex w-full flex-col rounded px-1.5 py-1 text-start hover:bg-surface-gray-2"
 				@click="$emit('select-block', block.block_id)">
 				<span class="text-[11px] font-medium text-ink-gray-7">{{ block.blockName || block.element }}</span>
 				<span v-if="block.changedProps.length" class="truncate text-[10px] text-ink-gray-4">
@@ -22,7 +22,7 @@
 			<button
 				v-for="script in affectedScripts"
 				:key="script.script_name"
-				class="flex w-full flex-col rounded px-1.5 py-1 text-left hover:bg-surface-gray-2"
+				class="flex w-full flex-col rounded px-1.5 py-1 text-start hover:bg-surface-gray-2"
 				@click="$emit('open-script', script.script_name)">
 				<span class="text-xs font-medium text-ink-gray-7">{{ script.script_name }}</span>
 				<span v-if="script.changedProps.length" class="truncate text-[10px] text-ink-gray-4">

--- a/frontend/src/components/AIDebugPanel.vue
+++ b/frontend/src/components/AIDebugPanel.vue
@@ -145,7 +145,7 @@
 					<span class="lucide-chevron-right size-3.5 transition-transform group-open:rotate-90" />
 					Raw JSON
 					<button
-						class="ml-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-8"
+						class="ms-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-8"
 						@click.prevent="copyRaw">
 						<span :class="copied ? 'lucide-check' : 'lucide-copy'" class="size-3" />
 						{{ copied ? "copied" : "copy" }}

--- a/frontend/src/components/BlockLayers.vue
+++ b/frontend/src/components/BlockLayers.vue
@@ -32,13 +32,13 @@
 					"
 					@mouseleave.stop="!canvasStore.isDragging && canvasStore.activeCanvas?.setHoveredBlock(null)">
 					<span
-						class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
+						class="group my-[7px] flex items-center gap-1.5 pe-[2px] font-medium"
 						:style="{ paddingLeft: `${indent}px` }"
 						:class="{
 							'!opacity-50': !element.isVisible() || isParentHidden,
 						}">
 						<div>
-							<div class="scroll-into-view-anchor absolute ml-20"></div>
+							<div class="scroll-into-view-anchor absolute ms-20"></div>
 						</div>
 						<span
 							:class="[
@@ -66,7 +66,7 @@
 							aria-hidden="true"
 							v-if="!Boolean(element.extendedFromComponent)" />
 						<span
-							class="lucide-layout-dashboard mr-1 h-3 w-3"
+							class="lucide-layout-dashboard me-1 h-3 w-3"
 							:class="{
 								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
 									element.isExtendedFromComponent(),
@@ -100,7 +100,7 @@
 							v-if="!element.isRoot() && !isParentHidden && !readonly"
 							:class="[
 								element.isVisible() ? 'lucide-eye' : 'lucide-eye-off',
-								'invisible ml-auto mr-2 h-3 w-3 group-hover:visible',
+								'invisible ms-auto me-2 h-3 w-3 group-hover:visible',
 							]"
 							aria-hidden="true"
 							@click.stop="element.toggleVisibility()" />

--- a/frontend/src/components/BuilderAIChatPanel.vue
+++ b/frontend/src/components/BuilderAIChatPanel.vue
@@ -140,7 +140,7 @@
 							</button>
 							<!-- Time taken + debugger trigger (full breakdown lives in the debug panel) -->
 							<template v-if="message.metadata?.debug">
-								<div class="ml-auto flex items-center gap-2">
+								<div class="ms-auto flex items-center gap-2">
 									<span v-if="message.metadata.debug.elapsedMs" class="font-mono">
 										took {{ formatDuration(message.metadata.debug.elapsedMs) }}
 									</span>
@@ -245,7 +245,7 @@
 							<span class="max-w-[120px] truncate">{{ imageFileName }}</span>
 							<button
 								type="button"
-								class="ml-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
+								class="ms-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
 								title="Remove image"
 								@click="clearImage">
 								<span class="lucide-x h-3 w-3" />

--- a/frontend/src/components/BuilderCanvas.vue
+++ b/frontend/src/components/BuilderCanvas.vue
@@ -97,7 +97,7 @@
 			class="text-sm-semibold fixed bottom-12 left-[50%] flex translate-x-[-50%] cursor-default items-center justify-center gap-2 rounded-lg bg-surface-base px-3 py-2 text-center text-ink-gray-7 shadow-md"
 			v-show="!canvasProps.panning && !canvasStore.isDragging">
 			{{ Math.round(canvasProps.scale * 100) + "%" }}
-			<div class="ml-2 cursor-pointer" @click="setScaleAndTranslate">
+			<div class="ms-2 cursor-pointer" @click="setScaleAndTranslate">
 				<FitScreenIcon />
 			</div>
 		</div>

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -10,12 +10,12 @@
 
 				<!-- Search bar -->
 				<div class="flex items-center border-b border-outline-gray-1 px-1">
-					<span class="lucide-search ml-3 size-4 shrink-0 text-ink-gray-4" aria-hidden="true" />
+					<span class="lucide-search ms-3 size-4 shrink-0 text-ink-gray-4" aria-hidden="true" />
 					<!-- Step badge -->
 					<button
 						v-if="stepLabel"
 						type="button"
-						class="text-base-semibold ml-3 flex shrink-0 items-center gap-2 py-1 text-ink-gray-7 transition-colors hover:bg-surface-gray-3"
+						class="text-base-semibold ms-3 flex shrink-0 items-center gap-2 py-1 text-ink-gray-7 transition-colors hover:bg-surface-gray-3"
 						@click="goBack">
 						{{ stepLabel }}
 						<span class="lucide-chevron-right size-3 text-ink-gray-4" aria-hidden="true" />
@@ -24,12 +24,12 @@
 						ref="inputRef"
 						v-model="localQuery"
 						:placeholder="placeholder || (stepLabel ? __('Search...') : __('Search commands...'))"
-						class="w-full border-none bg-transparent py-3.5 pl-3 pr-4 text-base text-ink-gray-8 placeholder-ink-gray-4 outline-none ring-0 focus:outline-none focus:ring-0"
+						class="w-full border-none bg-transparent py-3.5 ps-3 pe-4 text-base text-ink-gray-8 placeholder-ink-gray-4 outline-none ring-0 focus:outline-none focus:ring-0"
 						autocomplete="off"
 						spellcheck="false"
 						@keydown="handleKeydown" />
 					<kbd
-						class="text-xs-medium mr-1.5 flex shrink-0 items-center gap-0.5 rounded border border-outline-gray-2 px-1.5 py-1 text-ink-gray-4"
+						class="text-xs-medium me-1.5 flex shrink-0 items-center gap-0.5 rounded border border-outline-gray-2 px-1.5 py-1 text-ink-gray-4"
 						:title="__('Close')">
 						esc
 					</kbd>

--- a/frontend/src/components/CommandPaletteItem.vue
+++ b/frontend/src/components/CommandPaletteItem.vue
@@ -5,17 +5,17 @@
 		<!-- lucide string icon (e.g. "lucide-search") -->
 		<span
 			v-if="item.icon && typeof item.icon === 'string'"
-			:class="[item.icon, 'mr-2.5 size-3.5 shrink-0', active ? 'text-ink-gray-7' : 'text-ink-gray-5']"
+			:class="[item.icon, 'me-2.5 size-3.5 shrink-0', active ? 'text-ink-gray-7' : 'text-ink-gray-5']"
 			aria-hidden="true" />
 		<!-- component icon -->
 		<component
 			v-else-if="item.icon"
 			:is="item.icon"
-			:class="['mr-2.5 size-3.5 shrink-0', active ? 'text-ink-gray-7' : 'text-ink-gray-5']" />
+			:class="['me-2.5 size-3.5 shrink-0', active ? 'text-ink-gray-7' : 'text-ink-gray-5']" />
 		<span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
 			{{ item.title }}
 		</span>
-		<span v-if="item.description && showDescription" class="ml-3 shrink-0 text-xs text-ink-gray-4">
+		<span v-if="item.description && showDescription" class="ms-3 shrink-0 text-xs text-ink-gray-4">
 			{{ item.description }}
 		</span>
 	</div>

--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -11,7 +11,7 @@
 				:class="{
 					'can-show-arrows': canShowArrows,
 				}">
-				<div v-if="$slots.prefix" class="flex items-center pl-2">
+				<div v-if="$slots.prefix" class="flex items-center ps-2">
 					<slot name="prefix" />
 				</div>
 				<ComboboxInput
@@ -30,12 +30,12 @@
 					:placeholder="placeholder"
 					class="h-full w-full flex-1 border-none bg-transparent px-0 text-base placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 					:class="{
-						'pl-2': !$slots.prefix,
-						'pr-2': !hasValue && !canShowArrows,
+						'ps-2': !$slots.prefix,
+						'pe-2': !hasValue && !canShowArrows,
 					}" />
 				<span
 					v-if="hasOverflow"
-					class="pointer-events-none relative z-10 -ml-4 w-4 flex-shrink-0 self-stretch bg-gradient-to-r from-transparent to-surface-gray-2 group-focus-within:hidden group-hover:to-surface-gray-3"
+					class="pointer-events-none relative z-10 -ms-4 w-4 flex-shrink-0 self-stretch bg-gradient-to-r from-transparent to-surface-gray-2 group-focus-within:hidden group-hover:to-surface-gray-3"
 					aria-hidden="true" />
 				<div class="flex items-center gap-0.5">
 					<NumberArrows
@@ -46,7 +46,7 @@
 
 					<button
 						v-if="hasValue"
-						class="mr-2 flex-shrink-0 cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
+						class="me-2 flex-shrink-0 cursor-pointer text-ink-gray-4 hover:text-ink-gray-5"
 						tabindex="-1"
 						@click.stop="clearSelection"
 						@mousedown.prevent>

--- a/frontend/src/components/Controls/CodeMirror/CustomSearchPanel.vue
+++ b/frontend/src/components/Controls/CodeMirror/CustomSearchPanel.vue
@@ -46,7 +46,7 @@
 						<span class="font-mono text-xs">Ab</span>
 					</Button>
 				</div>
-				<div class="flex shrink-0 items-center border-l border-outline-gray-2 pl-1">
+				<div class="flex shrink-0 items-center border-l border-outline-gray-2 ps-1">
 					<Button
 						size="sm"
 						icon="lucide-chevron-up"

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -18,7 +18,7 @@
 					<div class="relative w-full">
 						<Tooltip :text="isCssVariable ? resolvedColor : undefined">
 							<Autocomplete
-								class="[&>div>input]:pl-8"
+								class="[&>div>input]:ps-8"
 								:class="{
 									'[&>div>div>input]:text-sm [&>div>div>input]:text-ink-violet-6 [&>div>input]:font-mono':
 										isCssVariable,

--- a/frontend/src/components/Controls/DraggablePopup.vue
+++ b/frontend/src/components/Controls/DraggablePopup.vue
@@ -14,7 +14,7 @@
 					}">
 					<div
 						ref="headerRef"
-						class="flex cursor-grab select-none items-center justify-between px-4 py-2 pr-3 text-sm text-ink-gray-9"
+						class="flex cursor-grab select-none items-center justify-between px-4 py-2 pe-3 text-sm text-ink-gray-9"
 						:class="{ 'cursor-grabbing': isDragging }"
 						@mousedown="startDrag">
 						<slot name="header"></slot>

--- a/frontend/src/components/Controls/DynamicValueHandler.vue
+++ b/frontend/src/components/Controls/DynamicValueHandler.vue
@@ -17,7 +17,7 @@
 							)
 						">
 						<div
-							class="w-full cursor-pointer truncate rounded bg-surface-gray-3 p-2 text-left font-mono text-p-sm text-ink-gray-9"
+							class="w-full cursor-pointer truncate rounded bg-surface-gray-3 p-2 text-start font-mono text-p-sm text-ink-gray-9"
 							@click.stop="selectAndSetItem(selectedItem)">
 							<MiddleTruncate :text="selectedItem.key" />
 							<p class="truncate text-xs text-ink-gray-5" :class="{ italic: getValue(selectedItem) == null }">
@@ -27,7 +27,7 @@
 					</li>
 					<li v-for="item in filteredItems" :key="item.key">
 						<div
-							class="w-full cursor-pointer truncate rounded p-2 text-left font-mono text-p-sm text-ink-gray-7 hover:bg-surface-gray-2"
+							class="w-full cursor-pointer truncate rounded p-2 text-start font-mono text-p-sm text-ink-gray-7 hover:bg-surface-gray-2"
 							:class="{
 								'bg-surface-gray-3 text-ink-gray-9':
 									selectedItem?.key === item.key && selectedItem?.comesFrom === item.comesFrom,

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -3,7 +3,7 @@
 		<Tooltip :text="isCssVariable ? resolvedFont : undefined">
 			<Autocomplete
 				ref="fontInput"
-				class="[&>div>input]:pl-9"
+				class="[&>div>input]:ps-9"
 				:class="{
 					'[&>div>div>input]:text-ink-violet-6 [&>div>input]:font-mono': isCssVariable,
 				}"

--- a/frontend/src/components/Controls/InputLabel.vue
+++ b/frontend/src/components/Controls/InputLabel.vue
@@ -3,7 +3,7 @@
 		<span class="truncate"><slot /></span>
 		<Popover trigger="hover" v-if="description" placement="top">
 			<template #target>
-				<span class="lucide-info ml-1 h-[12px] w-[12px] text-gray-500" aria-hidden="true" />
+				<span class="lucide-info ms-1 h-[12px] w-[12px] text-gray-500" aria-hidden="true" />
 			</template>
 			<template #body>
 				<slot name="body">

--- a/frontend/src/components/Controls/PropertyControlInput.vue
+++ b/frontend/src/components/Controls/PropertyControlInput.vue
@@ -18,7 +18,7 @@
 		<!-- Dynamic value overlay -->
 		<div
 			v-if="dynamicValueKey"
-			class="absolute bottom-0 left-0 right-0 top-0 flex cursor-pointer items-center gap-2 rounded bg-surface-violet-2 py-0.5 pl-2.5 pr-6 text-sm text-ink-violet-8"
+			class="absolute bottom-0 left-0 right-0 top-0 flex cursor-pointer items-center gap-2 rounded bg-surface-violet-2 py-0.5 ps-2.5 pe-6 text-sm text-ink-violet-8"
 			@click.stop="$emit('openDynamicModal')">
 			<span class="lucide-zap size-3" aria-hidden="true" />
 			<MiddleTruncate :text="dynamicValueKey" />

--- a/frontend/src/components/Controls/SearchBlock.vue
+++ b/frontend/src/components/Controls/SearchBlock.vue
@@ -19,7 +19,7 @@
 				@input="setQuery"
 				@keydown.enter="handlePrimaryAction" />
 
-			<Popover class="relative inline-block text-left">
+			<Popover class="relative inline-block text-start">
 				<template #target="{ isOpen, togglePopover }">
 					<Button
 						@click="togglePopover"
@@ -31,7 +31,7 @@
 						]">
 						<span
 							v-if="selectedFiltersCount > 0"
-							class="bg-ink-gray-7 ml-1 rounded-full px-2 py-0.5 text-xs text-white">
+							class="bg-ink-gray-7 ms-1 rounded-full px-2 py-0.5 text-xs text-white">
 							{{ selectedFiltersCount }}
 						</span>
 						<span
@@ -50,7 +50,7 @@
 								<Checkbox
 									:modelValue="filter.selected"
 									@update:modelValue="toggleFilter(filter)"
-									class="mr-3" />
+									class="me-3" />
 								<span>{{ filter.name }}</span>
 							</label>
 						</div>
@@ -66,7 +66,7 @@
 
 		<div v-if="canvasStore.activeCanvas?.selectedBlocks?.length" class="mb-4">
 			<label class="flex cursor-pointer items-center text-sm text-ink-gray-7">
-				<Checkbox v-model="searchInSelectedBlock" @update:modelValue="performSearch" class="mr-2" />
+				<Checkbox v-model="searchInSelectedBlock" @update:modelValue="performSearch" class="me-2" />
 				<span>{{ __("Search inside selected block only") }}</span>
 			</label>
 		</div>
@@ -122,7 +122,7 @@
 						v-if="searchMode === 'replace'"
 						@click.stop="replaceInBlock(result, index)"
 						variant="subtle"
-						class="ml-3 px-2 py-1 text-xs"
+						class="ms-3 px-2 py-1 text-xs"
 						:disabled="!replaceQuery">
 						{{ __("Replace") }}
 					</Button>

--- a/frontend/src/components/DashboardContent.vue
+++ b/frontend/src/components/DashboardContent.vue
@@ -35,7 +35,7 @@
 				<div v-if="displayType === 'tree'">
 					<RouteTreeView
 						ref="routeTreeRef"
-						class="pl-2 pr-3"
+						class="ps-2 pe-3"
 						:search-filter="searchFilter"
 						:active-folder="builderStore.activeFolder" />
 				</div>

--- a/frontend/src/components/DashboardSidebar.vue
+++ b/frontend/src/components/DashboardSidebar.vue
@@ -27,7 +27,7 @@
 
 			<p
 				v-if="!builderProjectFolder.data?.length"
-				class="mt-0.5 flex h-7 items-center pl-2 text-sm text-ink-gray-5">
+				class="mt-0.5 flex h-7 items-center ps-2 text-sm text-ink-gray-5">
 				{{ __("No folders yet") }}
 			</p>
 			<nav class="mt-0.5 space-y-0.5">

--- a/frontend/src/components/DynamicValueDropdown.vue
+++ b/frontend/src/components/DynamicValueDropdown.vue
@@ -11,7 +11,7 @@
 
 		<div
 			v-if="dynamicValue?.key"
-			class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 flex items-center gap-2 rounded bg-surface-violet-2 py-0.5 pl-2.5 pr-7 text-sm text-ink-violet-8">
+			class="pointer-events-none absolute bottom-0 left-0 right-0 top-0 flex items-center gap-2 rounded bg-surface-violet-2 py-0.5 ps-2.5 pe-7 text-sm text-ink-violet-8">
 			<span class="lucide-zap size-3 shrink-0" aria-hidden="true" />
 			<MiddleTruncate :text="dynamicValue.key" />
 		</div>

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -16,7 +16,7 @@
 						<div class="relative w-full [&>div>div>div>div]:pe-0">
 							<BuilderInput
 								:class="{
-									'[&>input]:pl-8': labelPosition === 'left',
+									'[&>input]:ps-8': labelPosition === 'left',
 								}"
 								type="text"
 								:label="labelPosition === 'top' ? label : null"

--- a/frontend/src/components/LeftPanelTabs/LayersTab.vue
+++ b/frontend/src/components/LeftPanelTabs/LayersTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="min-h-full p-3 pr-0" @click.stop="canvasStore.activeCanvas?.clearSelection()">
+	<div class="min-h-full p-3 pe-0" @click.stop="canvasStore.activeCanvas?.clearSelection()">
 		<span class="flex items-center gap-2 pb-2 text-sm capitalize text-ink-gray-4">
 			<span
 				:class="[
@@ -12,7 +12,7 @@
 			{{ canvasStore.activeCanvas?.activeBreakpoint }}
 		</span>
 		<BlockLayers
-			class="block-layers w-fit min-w-full pr-3"
+			class="block-layers w-fit min-w-full pe-3"
 			v-if="pageCanvas"
 			:disable-draggable="true"
 			:readonly="builderStore.readOnlyMode"
@@ -20,7 +20,7 @@
 			:blocks="[pageCanvas?.getRootBlock() as Block]"
 			v-show="canvasStore.editingMode == 'page'" />
 		<BlockLayers
-			class="block-layers w-fit min-w-full pr-3"
+			class="block-layers w-fit min-w-full pe-3"
 			ref="componentLayers"
 			:disable-draggable="true"
 			:readonly="builderStore.readOnlyMode"

--- a/frontend/src/components/Modals/TokenManager.vue
+++ b/frontend/src/components/Modals/TokenManager.vue
@@ -45,12 +45,12 @@
 					<div
 						class="sticky top-0 z-10 border-b border-outline-gray-1 bg-surface-base pb-2 pt-1 text-sm text-ink-gray-5"
 						:class="rowGridClass">
-						<div class="pl-2">{{ __("Name") }}</div>
+						<div class="ps-2">{{ __("Name") }}</div>
 						<template v-if="isColorType">
-							<div class="border-l border-outline-gray-1 pl-2">{{ __("Light") }}</div>
-							<div class="border-l border-outline-gray-1 pl-2">{{ __("Dark") }}</div>
+							<div class="border-l border-outline-gray-1 ps-2">{{ __("Light") }}</div>
+							<div class="border-l border-outline-gray-1 ps-2">{{ __("Dark") }}</div>
 						</template>
-						<div v-else class="border-l border-outline-gray-1 pl-2">{{ __("Value") }}</div>
+						<div v-else class="border-l border-outline-gray-1 ps-2">{{ __("Value") }}</div>
 					</div>
 
 					<template v-for="group in displayGroups" :key="group.group ?? '__flat__'">
@@ -181,7 +181,7 @@
 											:text="__('This is a standard variable. It cannot be modified or deleted.')"
 											placement="top">
 											<span
-												class="lucide-info ml-1 h-3.5 w-3.5 shrink-0 text-ink-gray-5"
+												class="lucide-info ms-1 h-3.5 w-3.5 shrink-0 text-ink-gray-5"
 												aria-hidden="true" />
 										</Tooltip>
 										<input
@@ -204,7 +204,7 @@
 										<!-- Copy the token's CSS handle: var(--<id>) — paste it into any style -->
 										<Tooltip v-if="row.name" :text="__('Copy var(--{0})', [row.name])" placement="top">
 											<div
-												class="invisible ml-auto mr-1 shrink-0 group-hover/row:visible"
+												class="invisible ms-auto me-1 shrink-0 group-hover/row:visible"
 												:class="{ '!visible': copiedId === row.id }">
 												<Button
 													variant="ghost"
@@ -382,7 +382,7 @@
 					<button
 						@click="downloadSampleCSV"
 						variant="subtle"
-						class="ml-2 text-xs text-blue-600 underline hover:text-blue-700">
+						class="ms-2 text-xs text-blue-600 underline hover:text-blue-700">
 						{{ __("Download sample") }}
 					</button>
 				</div>

--- a/frontend/src/components/PageClientScriptManager.vue
+++ b/frontend/src/components/PageClientScriptManager.vue
@@ -125,7 +125,7 @@
 					<a
 						v-if="!scriptUsageResource.loading"
 						@click="pageListDialog = true"
-						class="ml-1 cursor-pointer text-p-sm text-ink-gray-4 underline">
+						class="ms-1 cursor-pointer text-p-sm text-ink-gray-4 underline">
 						{{ usageMessage }}
 					</a>
 				</template>

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -39,7 +39,7 @@
 		</div>
 		<Dialog class="overscroll-none" :title="dialogTitle" size="7xl" :isDirty="isDirty" v-model="showDialog">
 			<template #title>
-				<div class="flex w-full items-center justify-between gap-3 pr-2">
+				<div class="flex w-full items-center justify-between gap-3 pe-2">
 					<span class="text-lg font-semibold text-ink-gray-9">{{ dialogTitle }}</span>
 					<TabButtons
 						v-if="showBlockClientScriptToggle"

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -20,7 +20,7 @@
 										open();
 									}
 								">
-								<div class="flex w-fit max-w-[60%] items-center gap-2 pl-2">
+								<div class="flex w-fit max-w-[60%] items-center gap-2 ps-2">
 									<div class="icon">
 										<component
 											v-if="value.propOptions?.type"

--- a/frontend/src/components/PublishButton.vue
+++ b/frontend/src/components/PublishButton.vue
@@ -41,7 +41,7 @@
 				variant="solid"
 				:disabled="Boolean(pageStore.activePage?.is_template) || builderStore.readOnlyMode"
 				icon="lucide-chevron-down"
-				class="!w-6 justify-start rounded-bl-none rounded-tl-none border-0 pr-0 text-xs"></Button>
+				class="!w-6 justify-start rounded-bl-none rounded-tl-none border-0 pe-0 text-xs"></Button>
 		</Dropdown>
 	</div>
 </template>

--- a/frontend/src/components/RouteTreeNode.vue
+++ b/frontend/src/components/RouteTreeNode.vue
@@ -38,7 +38,7 @@
 						:title="node.page.page_title">
 						{{ node.page.page_title }}
 					</span>
-					<span class="ml-auto mr-1 flex shrink-0 items-center gap-1">
+					<span class="ms-auto me-1 flex shrink-0 items-center gap-1">
 						<Tooltip v-if="isHomePage(node.page)" :text="__('Home page')" :hoverDelay="0.5">
 							<HomeIcon class="size-3.5 text-ink-green-6" />
 						</Tooltip>
@@ -88,7 +88,7 @@
 					@click="onLoadMore(node.id, node.loadedCount)">
 					<span class="lucide-more-horizontal size-3" aria-hidden="true" />
 					{{ __("Load {0} more", [Math.min(PAGE_LIMIT_PER_NODE, node.totalCount - node.loadedCount)]) }}
-					<span class="ml-0.5 text-ink-gray-3">{{ __("({0} remaining)", [node.totalCount - node.loadedCount]) }}</span>
+					<span class="ms-0.5 text-ink-gray-3">{{ __("({0} remaining)", [node.totalCount - node.loadedCount]) }}</span>
 				</button>
 			</div>
 		</section>

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -37,7 +37,7 @@
 					@click="loadMore('__root__', rootLoadMore.loadedCount)">
 					<span class="lucide-more-horizontal size-3" aria-hidden="true" />
 					{{ __("Load {0} more", [Math.min(PAGE_LIMIT_PER_NODE, rootLoadMore.totalCount - rootLoadMore.loadedCount)]) }}
-					<span class="ml-0.5 text-ink-gray-3">
+					<span class="ms-0.5 text-ink-gray-3">
 						{{ __("({0} remaining)", [rootLoadMore.totalCount - rootLoadMore.loadedCount]) }}
 					</span>
 				</button>

--- a/frontend/src/components/Settings/AIModelList.vue
+++ b/frontend/src/components/Settings/AIModelList.vue
@@ -28,7 +28,7 @@
 
 			<div v-for="group in grouped" :key="group.provider" class="flex flex-col">
 				<button
-					class="group/provider flex items-center gap-2 border-b border-outline-gray-1 py-1.5 text-left"
+					class="group/provider flex items-center gap-2 border-b border-outline-gray-1 py-1.5 text-start"
 					@click="editProvider(group.provider)">
 					<span
 						class="text-p-sm font-medium"
@@ -47,7 +47,7 @@
 						size="sm"
 						:modelValue="Boolean(row.enabled)"
 						@update:modelValue="(value: boolean) => toggle(row, value)" />
-					<button class="flex min-w-0 flex-1 flex-col text-left" @click="editModel(row)">
+					<button class="flex min-w-0 flex-1 flex-col text-start" @click="editModel(row)">
 						<span class="flex items-center gap-1.5">
 							<span class="truncate text-p-sm text-ink-gray-8">{{ row.label }}</span>
 							<span

--- a/frontend/src/components/Settings/AISetupFlow.vue
+++ b/frontend/src/components/Settings/AISetupFlow.vue
@@ -29,7 +29,7 @@
 				<button
 					v-for="preset in presets"
 					:key="preset.id"
-					class="group flex flex-col gap-1 rounded-lg border p-3.5 text-left transition-colors"
+					class="group flex flex-col gap-1 rounded-lg border p-3.5 text-start transition-colors"
 					:class="
 						preset.configured
 							? 'border-outline-gray-2 bg-surface-gray-1 hover:border-outline-gray-3'
@@ -56,7 +56,7 @@
 				<p class="text-p-sm text-ink-gray-6">{{ active.blurb }}</p>
 			</div>
 
-			<ol v-if="active.key_steps?.length" class="flex flex-col gap-1.5 pl-1">
+			<ol v-if="active.key_steps?.length" class="flex flex-col gap-1.5 ps-1">
 				<li v-for="(s, i) in active.key_steps" :key="s" class="flex gap-2 text-p-sm text-ink-gray-7">
 					<span class="text-ink-gray-4">{{ i + 1 }}</span>
 					<span>{{ s }}</span>

--- a/frontend/src/components/Settings/GlobalAnalytics.vue
+++ b/frontend/src/components/Settings/GlobalAnalytics.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="no-scrollbar h-full overflow-y-auto overflow-x-hidden pr-1">
+	<div class="no-scrollbar h-full overflow-y-auto overflow-x-hidden pe-1">
 		<TrackingDisabledNotice v-if="trackingEnabled === false" />
 		<template v-else>
 			<AnalyticsOverview

--- a/frontend/src/components/Settings/GlobalRedirects.vue
+++ b/frontend/src/components/Settings/GlobalRedirects.vue
@@ -15,8 +15,8 @@
 			<div
 				class="sticky top-0 z-10 border-b border-outline-gray-1 bg-surface-base pb-2 pt-1 text-sm text-ink-gray-5"
 				:class="rowGridClass">
-				<div class="pl-2">{{ __("Source") }}</div>
-				<div class="border-l border-outline-gray-1 pl-2">{{ __("Target") }}</div>
+				<div class="ps-2">{{ __("Source") }}</div>
+				<div class="border-l border-outline-gray-1 ps-2">{{ __("Target") }}</div>
 				<div></div>
 			</div>
 
@@ -115,7 +115,7 @@
 								<code class="font-mono text-ink-gray-7" v-html="highlight('from', example.from)" />
 								<span class="lucide-arrow-right size-3 text-ink-gray-4" aria-hidden="true" />
 								<code class="font-mono text-ink-gray-7" v-html="highlight('to', example.to)" />
-								<span class="pl-4 text-ink-gray-5">{{ example.label }}</span>
+								<span class="ps-4 text-ink-gray-5">{{ example.label }}</span>
 							</template>
 						</div>
 					</div>
@@ -137,7 +137,7 @@ type RedirectRow = { id: string; from: string; to: string; status: string; forwa
 type Draft = { from: string; to: string; status: string; forward: boolean };
 
 const rowGridClass = "grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_28px] items-center gap-x-2 px-1";
-const cellDividerClass = "border-l border-outline-gray-1 pl-2";
+const cellDividerClass = "border-l border-outline-gray-1 ps-2";
 const fields = ["from", "to"] as const;
 const placeholders: Record<Field, string> = { from: "/old-path", to: "/new-path" };
 const statusOptions = [

--- a/frontend/src/components/Settings/GlobalUsers.vue
+++ b/frontend/src/components/Settings/GlobalUsers.vue
@@ -55,11 +55,11 @@
 					<div class="flex min-w-0 flex-col">
 						<span class="truncate text-p-sm text-ink-gray-8">
 							{{ user.full_name }}
-							<Badge v-if="user.name === sessionUser" theme="gray" class="ml-1">{{ __("You") }}</Badge>
+							<Badge v-if="user.name === sessionUser" theme="gray" class="ms-1">{{ __("You") }}</Badge>
 						</span>
 						<span class="truncate text-p-xs text-ink-gray-5">{{ user.name }}</span>
 					</div>
-					<Badge v-if="user.is_admin" theme="gray" class="ml-auto shrink-0">{{ __("Admin") }}</Badge>
+					<Badge v-if="user.is_admin" theme="gray" class="ms-auto shrink-0">{{ __("Admin") }}</Badge>
 				</div>
 				<div v-if="!filteredMembers.length" class="py-6 text-center text-p-sm text-ink-gray-5">
 					<template v-if="searchQuery.trim()">{{ __('No members match "{0}"', [searchQuery]) }}</template>

--- a/frontend/src/components/Settings/PageAnalytics.vue
+++ b/frontend/src/components/Settings/PageAnalytics.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="no-scrollbar h-full overflow-y-auto overflow-x-hidden pr-1">
+	<div class="no-scrollbar h-full overflow-y-auto overflow-x-hidden pe-1">
 		<TrackingDisabledNotice v-if="trackingEnabled === false" />
 		<template v-else>
 			<AnalyticsOverview

--- a/frontend/src/components/Settings/TopReferrersList.vue
+++ b/frontend/src/components/Settings/TopReferrersList.vue
@@ -16,7 +16,7 @@
 						return h('img', {
 							src: `https://${row.domain}/favicon.ico`,
 							alt: row.domain,
-							class: 'inline-block mr-2 w-5 h-5 align-middle rounded',
+							class: 'inline-block me-2 w-5 h-5 align-middle rounded',
 							onError: (e: Event) => {
 								const img = e.target as HTMLImageElement | null;
 								if (img) {

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -8,12 +8,12 @@
 			@select="useTemplate"></TemplatePreview>
 		<template v-else>
 			<!-- header; pt-5 in group view lines the back button up with the preview header's -->
-			<div class="px-8 pb-4 pr-5" :class="activeGroup ? 'pt-5' : 'pt-7'">
+			<div class="px-8 pb-4 pe-5" :class="activeGroup ? 'pt-5' : 'pt-7'">
 				<Button
 					v-if="activeGroup"
 					icon-left="lucide-arrow-left"
 					variant="ghost"
-					class="-ml-3 mb-5"
+					class="-ms-3 mb-5"
 					@click="selectedGroup = ''">
 					{{ __("Back to all templates") }}
 				</Button>

--- a/frontend/src/components/Templates/TemplatePreview.vue
+++ b/frontend/src/components/Templates/TemplatePreview.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="flex h-full flex-col overflow-hidden">
 		<!-- pt/pr center this row on the dialog's absolute close button (top-5/right-5) -->
-		<div class="flex items-center justify-between gap-4 px-8 pb-4 pr-16 pt-5">
+		<div class="flex items-center justify-between gap-4 px-8 pb-4 pe-16 pt-5">
 			<div class="flex min-w-0 flex-1 items-center">
-				<Button icon-left="lucide-arrow-left" variant="ghost" class="-ml-3" @click="$emit('close')">
+				<Button icon-left="lucide-arrow-left" variant="ghost" class="-ms-3" @click="$emit('close')">
 					{{ __("Back") }}
 				</Button>
 			</div>

--- a/frontend/src/components/ToolbarItems/ViewerAvatars.vue
+++ b/frontend/src/components/ToolbarItems/ViewerAvatars.vue
@@ -2,7 +2,7 @@
 	<div class="group flex hover:gap-1">
 		<div v-for="user in builderStore.viewers" :key="user.fullname">
 			<Tooltip :text="currentlyViewedByText" :hoverDelay="0.6" arrow-class="mb-3">
-				<div class="ml-[-10px] h-6 w-6 cursor-pointer transition-all group-hover:ml-0">
+				<div class="ml-[-10px] h-6 w-6 cursor-pointer transition-all group-hover:ms-0">
 					<img
 						class="h-full w-full rounded-full border-2 border-orange-400 object-cover shadow-sm"
 						:title="user.fullname"

--- a/frontend/src/components/VersionHistory.vue
+++ b/frontend/src/components/VersionHistory.vue
@@ -42,7 +42,7 @@
 			<template v-else>
 				<!-- current (working draft) -->
 				<button
-					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-left"
+					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-start"
 					:class="canvasStore.previewSnapshotName === null ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2'"
 					@click="canvasStore.clearVersionPreview()">
 					<span class="mt-1.5 h-2 w-2 shrink-0 self-start rounded-full bg-gray-400" />
@@ -57,7 +57,7 @@
 				<!-- live published version, for pages published before any snapshot existed -->
 				<button
 					v-if="showPublishedVersion"
-					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-left"
+					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-start"
 					:class="
 						canvasStore.previewSnapshotName === PUBLISHED_VERSION
 							? 'bg-surface-gray-3'
@@ -92,7 +92,7 @@
 				<button
 					v-for="snapshot in snapshots.data"
 					:key="snapshot.name"
-					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-left"
+					class="group flex w-full items-center gap-2.5 rounded px-3 py-2 text-start"
 					:class="
 						canvasStore.previewSnapshotName === snapshot.name
 							? 'bg-surface-gray-3'

--- a/frontend/src/components/WebPagePresetPicker.vue
+++ b/frontend/src/components/WebPagePresetPicker.vue
@@ -91,7 +91,7 @@
 						<div
 							class="absolute bottom-0 left-0 top-0 w-0.5"
 							style="background: linear-gradient(180deg, #b8860b, #ffd700, #b8860b)"></div>
-						<div class="flex h-full flex-col justify-center gap-1.5 pl-3">
+						<div class="flex h-full flex-col justify-center gap-1.5 ps-3">
 							<div class="h-1.5 w-4/5 rounded-sm bg-yellow-300 opacity-90"></div>
 							<div class="h-px w-full bg-yellow-300 opacity-20"></div>
 							<div class="h-1 w-3/5 rounded-sm bg-yellow-200 opacity-50"></div>
@@ -247,7 +247,7 @@
 									linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
 								background-size: 10px 10px;
 							"></div>
-						<div class="relative flex flex-col gap-1.5 border-l border-white/20 pl-2">
+						<div class="relative flex flex-col gap-1.5 border-l border-white/20 ps-2">
 							<div class="h-2 w-3/4 border-b border-t border-white/40 bg-white/5"></div>
 							<div class="flex items-center gap-1">
 								<div class="h-1.5 w-1.5 border border-white/60"></div>

--- a/frontend/src/components/ai/AITurnTimeline.vue
+++ b/frontend/src/components/ai/AITurnTimeline.vue
@@ -11,7 +11,7 @@
 			<button
 				v-if="step.kind === 'thinking' && (running(step) || step.text)"
 				type="button"
-				class="flex w-fit items-center gap-1 text-left text-p-xs text-ink-gray-5"
+				class="flex w-fit items-center gap-1 text-start text-p-xs text-ink-gray-5"
 				:class="step.text ? 'hover:text-ink-gray-7' : 'cursor-default'"
 				:disabled="!step.text"
 				@click="toggle(step.id)">
@@ -29,7 +29,7 @@
 			     aside you opened, not the answer. -->
 			<div
 				v-if="step.kind === 'thinking' && step.text && expanded.has(step.id)"
-				class="ai-thought prose prose-sm max-w-none break-words border-l border-outline-gray-2 pl-3 text-p-xs text-ink-gray-5"
+				class="ai-thought prose prose-sm max-w-none break-words border-l border-outline-gray-2 ps-3 text-p-xs text-ink-gray-5"
 				v-html="renderMarkdown(step.text)" />
 
 			<!-- tool: what Bob actually ran -->
@@ -39,7 +39,7 @@
 					{{ step.summary }}
 				</span>
 				<span v-if="step.repeats" class="shrink-0 tabular-nums text-ink-gray-4">×{{ step.repeats }}</span>
-				<span v-if="duration(step.ms)" class="ml-auto shrink-0 tabular-nums text-ink-gray-4">
+				<span v-if="duration(step.ms)" class="ms-auto shrink-0 tabular-nums text-ink-gray-4">
 					{{ duration(step.ms) }}
 				</span>
 			</div>

--- a/frontend/src/components/ai/AIUISpec.vue
+++ b/frontend/src/components/ai/AIUISpec.vue
@@ -93,7 +93,7 @@
 						v-for="(option, j) in el.options || []"
 						:key="j"
 						:disabled="!interactive || disabled"
-						class="group flex flex-1 basis-48 flex-col items-start gap-2 rounded-lg border px-3 py-2.5 text-left transition-all disabled:cursor-not-allowed disabled:opacity-50"
+						class="group flex flex-1 basis-48 flex-col items-start gap-2 rounded-lg border px-3 py-2.5 text-start transition-all disabled:cursor-not-allowed disabled:opacity-50"
 						:class="
 							isSelected(i, j)
 								? 'border-outline-gray-4 bg-surface-gray-2'

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -29,7 +29,7 @@
 			class="canvas-container absolute bottom-0 flex justify-center overflow-hidden bg-surface-gray-2 p-10">
 			<template v-slot:header>
 				<div class="flex items-center justify-between bg-surface-base p-2 text-sm text-ink-gray-8 shadow-sm">
-					<div class="flex items-center gap-1 pl-2 text-xs">
+					<div class="flex items-center gap-1 ps-2 text-xs">
 						<a @click="canvasStore.exitFragmentMode" class="cursor-pointer">{{ __("Page") }}</a>
 						<span class="lucide-chevron-right h-3 w-3" aria-hidden="true" />
 						<span class="flex items-center gap-2">

--- a/frontend/src/pages/PagePreview.vue
+++ b/frontend/src/pages/PagePreview.vue
@@ -4,7 +4,7 @@
 			<router-link
 				:to="{ name: 'builder', params: { pageId: route.params.pageId || 'new' } }"
 				class="flex w-fit text-sm text-ink-gray-7 hover:text-ink-gray-9">
-				<span class="lucide-arrow-left mr-4 h-4 w-4 cursor-pointer" aria-hidden="true" />
+				<span class="lucide-arrow-left me-4 h-4 w-4 cursor-pointer" aria-hidden="true" />
 				{{ __("Back to builder") }}
 			</router-link>
 			<div class="flex gap-1">


### PR DESCRIPTION
## Problem

Hardcoded physical spacing/text-align classes (`ml-`/`mr-`, `pl-`/`pr-`, `text-left`/`text-right`) don't mirror when `dir="rtl"` is applied — margin/padding stays on the same physical side and text stays left/right-anchored regardless of direction.

## Fix

Safe subset only: `ml-/mr-` → `ms-/me-`, `pl-/pr-` → `ps-/pe-`, `text-left/right` → `text-start/end`. Behavior-preserving for LTR (these resolve to the same physical side when direction is `ltr`) and correct under `dir="rtl"`.

Deliberately does **not** touch `left-`/`right-` (positioning), `border-l/r` (side border width), or transforms (`translate-x` etc.) — those can sit right next to a converted class and interact with it in a way that needs a human to look, so a blind swap risks moving something to the wrong place.

## How this was done

Converted mechanically with a small script that has its own 15+-case self-test (variant prefixes, negatives, arbitrary values, fractions all covered; verified `px-`/`mx-`/`left-`/`right-`/`border-l-r`/`translate-x` are never touched), then spot-checked by hand. Zero remaining `ml-/mr-/pl-/pr-/text-left/text-right` instances after conversion.
