### PR TITLE
fix(search): report the number of blocks changed, not a replacement count

### DIFF
--- a/frontend/src/components/Controls/SearchBlock.vue
+++ b/frontend/src/components/Controls/SearchBlock.vue
@@ -92,7 +92,11 @@
 				{{ __("Replace All ({0} matches)", [results.length]) }}
 			</Button>
 			<div v-if="searchMode === 'replace' && replacedCount > 0" class="mt-2 text-xs text-ink-gray-5">
-				{{ __("{0} replacements made", [replacedCount]) }}
+				{{
+					replacedCount === 1
+						? __("Replaced in {0} block", [replacedCount])
+						: __("Replaced in {0} blocks", [replacedCount])
+				}}
 			</div>
 		</div>
 
@@ -388,7 +392,7 @@ const replaceAll = () => {
 	});
 
 	if (totalReplacements > 0) {
-		toast.success(__("Made {0} replacements across {0} blocks", [totalReplacements]));
+		toast.success(totalReplacements === 1 ? __("Replaced in {0} block", [totalReplacements]) : __("Replaced in {0} blocks", [totalReplacements]));
 		performSearch();
 	} else {
 		toast.error(__("No replacements made"));


### PR DESCRIPTION
While translating the Builder catalog into German I hit a string that cannot be translated correctly:

```js
__("Made {0} replacements across {0} blocks", [totalReplacements])
```

`{0}` appears twice, so a translator sees two values while only one is passed.

Looking at the call site, the deeper problem is that the replacement count does not exist:

- `replaceInBlock` increments `replacedCount` **once per block**, no matter how many matches were replaced inside it.
- `replaceAll` increments `totalReplacements` once per block whose `replacedCount` grew.

Both counters measure the same thing: the number of blocks changed. A single block can carry many replacements — the content handler replaces with a `gi` regex, and `styles`, `attributes` and `classes` can match in the same block — so the reported number was wrong whenever more than one match sat in a block.

This changes the two affected messages to state what the code actually measures, and splits singular and plural into separate msgids, matching the pattern already used in `TokenManager.vue`.

### Alternative

If you would rather keep the original wording, the other direction is to make the four `replace` handlers return a count instead of a boolean and sum them. That changes an internal contract across all of them, so I did not want to do it in a drive-by fix. Happy to follow up if you prefer that.

### Note

Not runtime-tested: this is a display-only change and I do not have a Builder instance running here. The formatting follows the ternary style already used in `TokenManager.vue`.
