### PR TITLE
fix(ai): smooth chat panel loading states

### DIFF
--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -48,6 +48,9 @@ export class AIChatController {
 
 	readonly sessionId = ref("");
 	readonly messages = ref<ChatMessage[]>([]);
+	// True while get_ai_session is in flight — the panel holds its empty-state
+	// hero until this settles, so a stored chat never flashes in over it.
+	readonly isLoadingSession = ref(false);
 	// This page's chat sessions (most recent first) — the panel's session switcher.
 	readonly sessions = ref<Array<{ name: string; title: string | null }>>([]);
 	readonly availableModels = ref<AIProvider[]>([]);
@@ -190,13 +193,13 @@ export class AIChatController {
 			if (!newPageId) return;
 			attachAIChatListeners(this.builderStore.realtime, newPageId, this.handlers);
 			this.resetTransientState();
-			// Sessions are page-scoped: never carry one across a page switch.
+			// Sessions are page-scoped: never carry one across a page switch — and
+			// that includes the transcript, which would otherwise sit on screen as
+			// the previous page's chat until the new one loads over it.
 			this.sessionId.value = "";
 			this.sessions.value = [];
-			if (newPageId === "new") {
-				this.messages.value = [];
-				return;
-			}
+			this.messages.value = [];
+			if (newPageId === "new") return;
 			await this.loadSession();
 			// A build may be mid-stream on this page (opened from another chat's link,
 			// or a refresh mid-generation): replay the buffered stream as live preview.
@@ -282,33 +285,56 @@ export class AIChatController {
 		};
 	}
 
+	// The panel mounts hidden behind the tab bar's v-show, and scrolling a
+	// display:none container is a no-op — so a scroll that lands while the tab
+	// is closed is parked here and replayed when the panel becomes visible.
+	private pendingScrollToBottom = false;
+
 	private scrollToBottom() {
 		nextTick(() => {
-			if (this.messageContainer.value) {
-				this.messageContainer.value.scrollTop = this.messageContainer.value.scrollHeight;
+			const el = this.messageContainer.value;
+			if (!el || el.clientHeight === 0) {
+				this.pendingScrollToBottom = true;
+				return;
 			}
+			el.scrollTop = el.scrollHeight;
 		});
 	}
+
+	/** Called by the panel when its tab opens: perform the scroll the hidden
+	 * container couldn't. */
+	flushPendingScroll = () => {
+		if (!this.pendingScrollToBottom) return;
+		this.pendingScrollToBottom = false;
+		this.scrollToBottom();
+	};
 
 	/** Load a chat session: the given one, else the current one, else the page's
 	 * most recently used (the server creates the first). A page can hold several
 	 * parallel sessions — see switchSession/newSession. */
 	async loadSession(sessionId?: string) {
 		if (!this.pageId.value || !this.builderStore.isAIEnabled || this.isUnsavedPage.value) return;
-		const result = await createResource({
-			url: "builder.ai.api.get_ai_session",
-			makeParams: () => ({
-				page_id: this.pageId.value,
-				model: this.selectedModel.value,
-				session_id: sessionId || this.sessionId.value || undefined,
-			}),
-		}).submit();
-		const session = result as { session_id: string; messages: ChatMessage[] };
-		this.sessionId.value = session.session_id;
-		this.messages.value = (session.messages || []).map(
-			(m) => ({ ...m, role: m.role === "user" ? "user" : "assistant" } as ChatMessage),
-		);
-		this.loadSessions();
+		this.isLoadingSession.value = true;
+		try {
+			const result = await createResource({
+				url: "builder.ai.api.get_ai_session",
+				makeParams: () => ({
+					page_id: this.pageId.value,
+					model: this.selectedModel.value,
+					session_id: sessionId || this.sessionId.value || undefined,
+				}),
+			}).submit();
+			const session = result as { session_id: string; messages: ChatMessage[] };
+			this.sessionId.value = session.session_id;
+			this.messages.value = (session.messages || []).map(
+				(m) => ({ ...m, role: m.role === "user" ? "user" : "assistant" } as ChatMessage),
+			);
+			// A restored conversation opens where it left off, not at its beginning.
+			this.scrollToBottom();
+			this.loadSessions();
+		} finally {
+			this.isLoadingSession.value = false;
+		}
 	}
 
 	/** Refresh the session-switcher list (fire-and-forget; the panel renders it). */

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -55,6 +55,8 @@ export class AIChatController {
 	private pendingSessionId: string | null = null;
 	// orders the user's session choices (switch/new/delete); refreshes don't count
 	private sessionIntentEpoch = 0;
+	// in-flight new_ai_session calls; a "reselect" during one must cancel it
+	private pendingSessionCreates = 0;
 
 	private invalidateSessionLoads() {
 		this.loadSessionEpoch++;
@@ -362,8 +364,12 @@ export class AIChatController {
 	};
 
 	switchSession = async (sessionId: string) => {
-		// reselecting the current chat is a no-op only when no other load is pending
-		if (!sessionId || (sessionId === this.sessionId.value && !this.pendingSessionId)) return;
+		// reselecting the current chat is a no-op only when nothing else is pending
+		if (
+			!sessionId ||
+			(sessionId === this.sessionId.value && !this.pendingSessionId && !this.pendingSessionCreates)
+		)
+			return;
 		this.sessionIntentEpoch++;
 		this.resetTransientState();
 		await this.loadSession(sessionId);
@@ -375,18 +381,23 @@ export class AIChatController {
 		const intent = ++this.sessionIntentEpoch;
 		this.invalidateSessionLoads();
 		const pageId = this.pageId.value;
-		const result = await createResource({ url: "builder.ai.api.new_ai_session" }).submit({
-			page_id: pageId,
-			model: this.selectedModel.value,
-		});
-		// a later choice (another chat, another page) beats this create
-		if (intent !== this.sessionIntentEpoch || this.pageId.value !== pageId) return;
-		this.resetTransientState();
-		// loads started during the round-trip above carry a valid epoch; void them
-		this.invalidateSessionLoads();
-		this.sessionId.value = (result as { session_id: string }).session_id;
-		this.messages.value = [];
-		this.loadSessions();
+		this.pendingSessionCreates++;
+		try {
+			const result = await createResource({ url: "builder.ai.api.new_ai_session" }).submit({
+				page_id: pageId,
+				model: this.selectedModel.value,
+			});
+			// a later choice (another chat, another page) beats this create
+			if (intent !== this.sessionIntentEpoch || this.pageId.value !== pageId) return;
+			this.resetTransientState();
+			// loads started during the round-trip above carry a valid epoch; void them
+			this.invalidateSessionLoads();
+			this.sessionId.value = (result as { session_id: string }).session_id;
+			this.messages.value = [];
+			this.loadSessions();
+		} finally {
+			this.pendingSessionCreates--;
+		}
 	};
 
 	deleteSession = async () => {

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -371,10 +371,14 @@ export class AIChatController {
 	newSession = async () => {
 		if (!this.pageId.value || this.isUnsavedPage.value) return;
 		this.invalidateSessionLoads();
+		const pageId = this.pageId.value;
 		const result = await createResource({ url: "builder.ai.api.new_ai_session" }).submit({
-			page_id: this.pageId.value,
+			page_id: pageId,
 			model: this.selectedModel.value,
 		});
+		// Navigated away mid-create: this chat belongs to the old page — committing
+		// it here would plant its session id (and void the new page's own load).
+		if (this.pageId.value !== pageId) return;
 		this.resetTransientState();
 		// Again at commit: a load STARTED during the round-trip above (a finished
 		// turn refreshing its transcript) holds a valid epoch bound to the old chat.

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -769,6 +769,8 @@ export class AIChatController {
 
 	submitPrompt = async () => {
 		if (!this.canSubmit.value || !this.pageId.value || this.isUnsavedPage.value) return;
+		// submitting pins the current chat: a still-pending create must not replace it
+		this.sessionIntentEpoch++;
 
 		let userText = this.prompt.value.trim();
 		this.prompt.value = "";

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -54,6 +54,13 @@ export class AIChatController {
 	// Bumped per loadSession call: a response older than the latest call (or from
 	// before a page switch) is stale and must not paint the current page.
 	private loadSessionEpoch = 0;
+
+	/** Anything that replaces the session outside loadSession (a new chat) must
+	 * void in-flight loads, or their late response resurrects the old chat. */
+	private invalidateSessionLoads() {
+		this.loadSessionEpoch++;
+		this.isLoadingSession.value = false;
+	}
 	// This page's chat sessions (most recent first) — the panel's session switcher.
 	readonly sessions = ref<Array<{ name: string; title: string | null }>>([]);
 	readonly availableModels = ref<AIProvider[]>([]);
@@ -363,6 +370,7 @@ export class AIChatController {
 
 	newSession = async () => {
 		if (!this.pageId.value || this.isUnsavedPage.value) return;
+		this.invalidateSessionLoads();
 		const result = await createResource({ url: "builder.ai.api.new_ai_session" }).submit({
 			page_id: this.pageId.value,
 			model: this.selectedModel.value,

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -362,7 +362,8 @@ export class AIChatController {
 	};
 
 	switchSession = async (sessionId: string) => {
-		if (!sessionId || sessionId === this.sessionId.value) return;
+		// reselecting the current chat is a no-op only when no other load is pending
+		if (!sessionId || (sessionId === this.sessionId.value && !this.pendingSessionId)) return;
 		this.sessionIntentEpoch++;
 		this.resetTransientState();
 		await this.loadSession(sessionId);

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -61,6 +61,11 @@ export class AIChatController {
 		this.loadSessionEpoch++;
 		this.isLoadingSession.value = false;
 	}
+
+	// Counts the user's session choices (switch, new, delete) as opposed to
+	// automatic refreshes: an async commit from an older choice must never
+	// override a newer one, while a mere refresh never blocks a choice.
+	private sessionIntentEpoch = 0;
 	// This page's chat sessions (most recent first) — the panel's session switcher.
 	readonly sessions = ref<Array<{ name: string; title: string | null }>>([]);
 	readonly availableModels = ref<AIProvider[]>([]);
@@ -363,6 +368,7 @@ export class AIChatController {
 
 	switchSession = async (sessionId: string) => {
 		if (!sessionId || sessionId === this.sessionId.value) return;
+		this.sessionIntentEpoch++;
 		this.resetTransientState();
 		await this.loadSession(sessionId);
 		this.scrollToBottom();
@@ -370,15 +376,16 @@ export class AIChatController {
 
 	newSession = async () => {
 		if (!this.pageId.value || this.isUnsavedPage.value) return;
+		const intent = ++this.sessionIntentEpoch;
 		this.invalidateSessionLoads();
 		const pageId = this.pageId.value;
 		const result = await createResource({ url: "builder.ai.api.new_ai_session" }).submit({
 			page_id: pageId,
 			model: this.selectedModel.value,
 		});
-		// Navigated away mid-create: this chat belongs to the old page — committing
-		// it here would plant its session id (and void the new page's own load).
-		if (this.pageId.value !== pageId) return;
+		// The user picked another chat (or page) while this one was being created:
+		// their later choice stands, committing here would overwrite it.
+		if (intent !== this.sessionIntentEpoch || this.pageId.value !== pageId) return;
 		this.resetTransientState();
 		// Again at commit: a load STARTED during the round-trip above (a finished
 		// turn refreshing its transcript) holds a valid epoch bound to the old chat.
@@ -391,6 +398,7 @@ export class AIChatController {
 	deleteSession = async () => {
 		if (!this.sessionId.value) return;
 		if (!(await confirm("Delete this chat? Its messages are removed; the page itself is untouched."))) return;
+		this.sessionIntentEpoch++;
 		await createResource({ url: "builder.ai.api.delete_ai_session" })
 			.submit({ session_id: this.sessionId.value })
 			.catch(() => null);

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -51,6 +51,9 @@ export class AIChatController {
 	// True while get_ai_session is in flight — the panel holds its empty-state
 	// hero until this settles, so a stored chat never flashes in over it.
 	readonly isLoadingSession = ref(false);
+	// Bumped per loadSession call: a response older than the latest call (or from
+	// before a page switch) is stale and must not paint the current page.
+	private loadSessionEpoch = 0;
 	// This page's chat sessions (most recent first) — the panel's session switcher.
 	readonly sessions = ref<Array<{ name: string; title: string | null }>>([]);
 	readonly availableModels = ref<AIProvider[]>([]);
@@ -314,16 +317,19 @@ export class AIChatController {
 	 * parallel sessions — see switchSession/newSession. */
 	async loadSession(sessionId?: string) {
 		if (!this.pageId.value || !this.builderStore.isAIEnabled || this.isUnsavedPage.value) return;
+		const epoch = ++this.loadSessionEpoch;
+		const pageId = this.pageId.value;
 		this.isLoadingSession.value = true;
 		try {
 			const result = await createResource({
 				url: "builder.ai.api.get_ai_session",
 				makeParams: () => ({
-					page_id: this.pageId.value,
+					page_id: pageId,
 					model: this.selectedModel.value,
 					session_id: sessionId || this.sessionId.value || undefined,
 				}),
 			}).submit();
+			if (epoch !== this.loadSessionEpoch || this.pageId.value !== pageId) return;
 			const session = result as { session_id: string; messages: ChatMessage[] };
 			this.sessionId.value = session.session_id;
 			this.messages.value = (session.messages || []).map(
@@ -333,17 +339,19 @@ export class AIChatController {
 			this.scrollToBottom();
 			this.loadSessions();
 		} finally {
-			this.isLoadingSession.value = false;
+			if (epoch === this.loadSessionEpoch) this.isLoadingSession.value = false;
 		}
 	}
 
 	/** Refresh the session-switcher list (fire-and-forget; the panel renders it). */
 	loadSessions = async () => {
 		if (!this.pageId.value || this.isUnsavedPage.value) return;
+		const pageId = this.pageId.value;
 		const rows = await createResource({ url: "builder.ai.api.list_page_ai_sessions" })
-			.submit({ page_id: this.pageId.value })
+			.submit({ page_id: pageId })
 			.catch(() => null);
-		if (rows) this.sessions.value = rows as Array<{ name: string; title: string | null }>;
+		if (rows && this.pageId.value === pageId)
+			this.sessions.value = rows as Array<{ name: string; title: string | null }>;
 	};
 
 	switchSession = async (sessionId: string) => {

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -376,6 +376,9 @@ export class AIChatController {
 			model: this.selectedModel.value,
 		});
 		this.resetTransientState();
+		// Again at commit: a load STARTED during the round-trip above (a finished
+		// turn refreshing its transcript) holds a valid epoch bound to the old chat.
+		this.invalidateSessionLoads();
 		this.sessionId.value = (result as { session_id: string }).session_id;
 		this.messages.value = [];
 		this.loadSessions();

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -48,24 +48,19 @@ export class AIChatController {
 
 	readonly sessionId = ref("");
 	readonly messages = ref<ChatMessage[]>([]);
-	// True while get_ai_session is in flight — the panel holds its empty-state
-	// hero until this settles, so a stored chat never flashes in over it.
 	readonly isLoadingSession = ref(false);
-	// Bumped per loadSession call: a response older than the latest call (or from
-	// before a page switch) is stale and must not paint the current page.
+	// only the newest load may commit; older responses are stale
 	private loadSessionEpoch = 0;
+	// target of the newest in-flight load; refreshes follow it, not the current session
+	private pendingSessionId: string | null = null;
+	// orders the user's session choices (switch/new/delete); refreshes don't count
+	private sessionIntentEpoch = 0;
 
-	/** Anything that replaces the session outside loadSession (a new chat) must
-	 * void in-flight loads, or their late response resurrects the old chat. */
 	private invalidateSessionLoads() {
 		this.loadSessionEpoch++;
+		this.pendingSessionId = null;
 		this.isLoadingSession.value = false;
 	}
-
-	// Counts the user's session choices (switch, new, delete) as opposed to
-	// automatic refreshes: an async commit from an older choice must never
-	// override a newer one, while a mere refresh never blocks a choice.
-	private sessionIntentEpoch = 0;
 	// This page's chat sessions (most recent first) — the panel's session switcher.
 	readonly sessions = ref<Array<{ name: string; title: string | null }>>([]);
 	readonly availableModels = ref<AIProvider[]>([]);
@@ -208,9 +203,9 @@ export class AIChatController {
 			if (!newPageId) return;
 			attachAIChatListeners(this.builderStore.realtime, newPageId, this.handlers);
 			this.resetTransientState();
-			// Sessions are page-scoped: never carry one across a page switch — and
-			// that includes the transcript, which would otherwise sit on screen as
-			// the previous page's chat until the new one loads over it.
+			// Sessions are page-scoped: never carry one across a page switch.
+			this.sessionIntentEpoch++;
+			this.invalidateSessionLoads();
 			this.sessionId.value = "";
 			this.sessions.value = [];
 			this.messages.value = [];
@@ -300,9 +295,7 @@ export class AIChatController {
 		};
 	}
 
-	// The panel mounts hidden behind the tab bar's v-show, and scrolling a
-	// display:none container is a no-op — so a scroll that lands while the tab
-	// is closed is parked here and replayed when the panel becomes visible.
+	// scrolling a display:none container (closed tab) is a no-op; park and replay
 	private pendingScrollToBottom = false;
 
 	private scrollToBottom() {
@@ -316,8 +309,6 @@ export class AIChatController {
 		});
 	}
 
-	/** Called by the panel when its tab opens: perform the scroll the hidden
-	 * container couldn't. */
 	flushPendingScroll = () => {
 		if (!this.pendingScrollToBottom) return;
 		this.pendingScrollToBottom = false;
@@ -329,8 +320,10 @@ export class AIChatController {
 	 * parallel sessions — see switchSession/newSession. */
 	async loadSession(sessionId?: string) {
 		if (!this.pageId.value || !this.builderStore.isAIEnabled || this.isUnsavedPage.value) return;
+		const target = sessionId || this.pendingSessionId || this.sessionId.value || undefined;
 		const epoch = ++this.loadSessionEpoch;
 		const pageId = this.pageId.value;
+		this.pendingSessionId = target ?? null;
 		this.isLoadingSession.value = true;
 		try {
 			const result = await createResource({
@@ -338,7 +331,7 @@ export class AIChatController {
 				makeParams: () => ({
 					page_id: pageId,
 					model: this.selectedModel.value,
-					session_id: sessionId || this.sessionId.value || undefined,
+					session_id: target,
 				}),
 			}).submit();
 			if (epoch !== this.loadSessionEpoch || this.pageId.value !== pageId) return;
@@ -347,11 +340,13 @@ export class AIChatController {
 			this.messages.value = (session.messages || []).map(
 				(m) => ({ ...m, role: m.role === "user" ? "user" : "assistant" } as ChatMessage),
 			);
-			// A restored conversation opens where it left off, not at its beginning.
 			this.scrollToBottom();
 			this.loadSessions();
 		} finally {
-			if (epoch === this.loadSessionEpoch) this.isLoadingSession.value = false;
+			if (epoch === this.loadSessionEpoch) {
+				this.isLoadingSession.value = false;
+				this.pendingSessionId = null;
+			}
 		}
 	}
 
@@ -383,12 +378,10 @@ export class AIChatController {
 			page_id: pageId,
 			model: this.selectedModel.value,
 		});
-		// The user picked another chat (or page) while this one was being created:
-		// their later choice stands, committing here would overwrite it.
+		// a later choice (another chat, another page) beats this create
 		if (intent !== this.sessionIntentEpoch || this.pageId.value !== pageId) return;
 		this.resetTransientState();
-		// Again at commit: a load STARTED during the round-trip above (a finished
-		// turn refreshing its transcript) holds a valid epoch bound to the old chat.
+		// loads started during the round-trip above carry a valid epoch; void them
 		this.invalidateSessionLoads();
 		this.sessionId.value = (result as { session_id: string }).session_id;
 		this.messages.value = [];
@@ -398,10 +391,12 @@ export class AIChatController {
 	deleteSession = async () => {
 		if (!this.sessionId.value) return;
 		if (!(await confirm("Delete this chat? Its messages are removed; the page itself is untouched."))) return;
-		this.sessionIntentEpoch++;
+		const intent = ++this.sessionIntentEpoch;
+		const pageId = this.pageId.value;
 		await createResource({ url: "builder.ai.api.delete_ai_session" })
 			.submit({ session_id: this.sessionId.value })
 			.catch(() => null);
+		if (intent !== this.sessionIntentEpoch || this.pageId.value !== pageId) return;
 		this.resetTransientState();
 		this.sessionId.value = "";
 		await this.loadSession(); // falls back to the next most recent (or a fresh one)

--- a/frontend/src/components/AIChatController.ts
+++ b/frontend/src/components/AIChatController.ts
@@ -573,6 +573,8 @@ export class AIChatController {
 		this.isSubmitting.value = false;
 		this.isCancelling.value = false;
 		this.progressMessage.value = data.message || "Done";
+		// the session this turn belongs to; the user may switch chats mid-await below
+		const completedSession = data.session_id || this.sessionId.value;
 
 		let undoScripts: string[] = [];
 		if (this.dispatcher.pendingScriptOps.value.length) {
@@ -600,21 +602,23 @@ export class AIChatController {
 
 		const localMeta = { ...meta };
 		if (
-			this.sessionId.value &&
+			completedSession &&
 			(localMeta.affectedBlocks?.length || localMeta.affectedScripts?.length || localMeta.undoScripts?.length)
 		) {
 			createResource({ url: "builder.ai.api.update_session_message_metadata" })
-				.submit({ session_id: this.sessionId.value, metadata: localMeta })
+				.submit({ session_id: completedSession, metadata: localMeta })
 				.catch(() => null);
 		}
 
 		await this.loadSession();
 
-		// Re-apply client-only metadata in case the server hasn't flushed it yet.
+		// Re-apply client-only metadata in case the server hasn't flushed it yet —
+		// but only onto the turn's own session, not one switched to meanwhile.
 		if (
-			localMeta.affectedBlocks?.length ||
-			localMeta.affectedScripts?.length ||
-			localMeta.undoScripts?.length
+			this.sessionId.value === completedSession &&
+			(localMeta.affectedBlocks?.length ||
+				localMeta.affectedScripts?.length ||
+				localMeta.undoScripts?.length)
 		) {
 			let idx = this.messages.value.length - 1;
 			while (idx >= 0 && this.messages.value[idx]?.role !== "assistant") idx--;

--- a/frontend/src/components/BuilderAIChatPanel.vue
+++ b/frontend/src/components/BuilderAIChatPanel.vue
@@ -3,8 +3,7 @@
 		<div class="flex items-center justify-between border-b border-outline-gray-1 px-3 py-2.5">
 			<div class="flex min-w-0 flex-col gap-1">
 				<div class="mt-1 text-sm font-semibold text-ink-gray-9">Bob AI</div>
-				<!-- min-h holds the line while the title is still blank, so the header
-				     doesn't grow a row when it arrives -->
+				<!-- min-h holds the row while the title is still blank -->
 				<div class="min-h-4 truncate text-p-xs leading-4 text-ink-gray-5">
 					{{ isSubmitting ? currentActivity : currentSessionTitle }}
 				</div>
@@ -28,11 +27,8 @@
 			</div>
 		</div>
 
-		<!-- Whether AI is set up, and what the last chat holds, are server answers
-		     that haven't arrived yet: drawing any branch now means flashing "Set up
-		     AI" (or the empty-chat hero) at a configured user on a slow network.
-		     One element spans both waits so the shimmer never blinks between them,
-		     and it fades in late so a fast load shows nothing at all. -->
+		<!-- one element spans both waits (setup verdict + session load) so the
+		     shimmer never blinks; the delayed fade keeps fast loads flash-free -->
 		<div
 			v-if="!builderStore.isAIStateKnown || (isLoadingSession && !messages.length)"
 			class="flex flex-1 items-center justify-center pb-40">
@@ -414,8 +410,7 @@ const { revertTurn, selectOption } = chat;
 const { sessions, sessionId, switchSession, newSession, deleteSession, isLoadingSession } = chat;
 
 const currentSessionTitle = computed(() => {
-	// Nothing loaded yet: an empty line beats "New chat" flipping to the real
-	// title a beat later.
+	// blank until loaded, not "New chat" flipping to the real title
 	if (!sessionId.value || !sessions.value.length) return "";
 	const current = sessions.value.find((s) => s.name === sessionId.value);
 	return current?.title || "New chat";
@@ -752,8 +747,7 @@ onMounted(() => {
 	builderStore.refreshAIState();
 });
 
-// The panel usually mounts (and loads its chat) behind a closed tab, where the
-// open-at-the-end scroll can't land. Replay it the moment the tab opens.
+// the chat usually loads behind the closed tab, where the scroll can't land
 watch(
 	() => builderStore.leftPanelActiveTab,
 	(tab) => {

--- a/frontend/src/components/BuilderAIChatPanel.vue
+++ b/frontend/src/components/BuilderAIChatPanel.vue
@@ -3,7 +3,9 @@
 		<div class="flex items-center justify-between border-b border-outline-gray-1 px-3 py-2.5">
 			<div class="flex min-w-0 flex-col gap-1">
 				<div class="mt-1 text-sm font-semibold text-ink-gray-9">Bob AI</div>
-				<div class="truncate text-p-xs leading-4 text-ink-gray-5">
+				<!-- min-h holds the line while the title is still blank, so the header
+				     doesn't grow a row when it arrives -->
+				<div class="min-h-4 truncate text-p-xs leading-4 text-ink-gray-5">
 					{{ isSubmitting ? currentActivity : currentSessionTitle }}
 				</div>
 			</div>
@@ -26,10 +28,23 @@
 			</div>
 		</div>
 
+		<!-- Whether AI is set up, and what the last chat holds, are server answers
+		     that haven't arrived yet: drawing any branch now means flashing "Set up
+		     AI" (or the empty-chat hero) at a configured user on a slow network.
+		     One element spans both waits so the shimmer never blinks between them,
+		     and it fades in late so a fast load shows nothing at all. -->
+		<div
+			v-if="!builderStore.isAIStateKnown || (isLoadingSession && !messages.length)"
+			class="flex flex-1 items-center justify-center pb-40">
+			<span class="bob-pill-in" style="animation-delay: 300ms">
+				<span class="animate-shine text-p-xs">Loading</span>
+			</span>
+		</div>
+
 		<!-- pb offsets the centring so it sits in the upper third: dead centre of a
 		     full-height panel leaves it stranded low with nothing beneath it. -->
 		<div
-			v-if="!builderStore.isAIEnabled"
+			v-else-if="!builderStore.isAIEnabled"
 			class="flex flex-1 flex-col items-center justify-center gap-4 p-6 pb-40">
 			<span class="bob-hero-orb">
 				<BobOrb class="bob-orb-aura" />
@@ -396,9 +411,12 @@ const { selectedModelUnusable } = chat;
 const { progressMessage } = chat;
 const currentActivity = computed(() => progressMessage.value || "Thinking…");
 const { revertTurn, selectOption } = chat;
-const { sessions, sessionId, switchSession, newSession, deleteSession } = chat;
+const { sessions, sessionId, switchSession, newSession, deleteSession, isLoadingSession } = chat;
 
 const currentSessionTitle = computed(() => {
+	// Nothing loaded yet: an empty line beats "New chat" flipping to the real
+	// title a beat later.
+	if (!sessionId.value || !sessions.value.length) return "";
 	const current = sessions.value.find((s) => s.name === sessionId.value);
 	return current?.title || "New chat";
 });
@@ -733,6 +751,15 @@ onMounted(() => {
 	// is actually usable rather than inferring it from Builder Settings alone.
 	builderStore.refreshAIState();
 });
+
+// The panel usually mounts (and loads its chat) behind a closed tab, where the
+// open-at-the-end scroll can't land. Replay it the moment the tab opens.
+watch(
+	() => builderStore.leftPanelActiveTab,
+	(tab) => {
+		if (tab === "Chat") chat.flushPendingScroll();
+	},
+);
 
 // Providers and models are configured in Settings, so the picker is stale the
 // moment that dialog closes. Refetch then rather than making every screen in

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -64,11 +64,17 @@ const useBuilderStore = defineStore("builderStore", {
 		// Set from ai_setup_state: a provider carrying its own key (Anthropic, a
 		// self-hosted gateway) is enough on its own, and the shared OpenRouter key in
 		// Builder Settings is the only thing the client can see for itself.
-		aiConfigured: false,
+		// null until the server answers — false means "asked, not configured".
+		aiConfigured: <boolean | null>null,
 	}),
 	getters: {
 		isAIEnabled(): boolean {
-			return this.aiConfigured || !!builderSettings.doc?.ai_api_key;
+			return !!this.aiConfigured || !!builderSettings.doc?.ai_api_key;
+		},
+		// The panel must not draw the setup hero (or the chat) on a guess: until
+		// one positive signal or the server's verdict arrives, the answer is unknown.
+		isAIStateKnown(): boolean {
+			return this.aiConfigured !== null || this.isAIEnabled;
 		},
 	},
 	actions: {

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -64,15 +64,14 @@ const useBuilderStore = defineStore("builderStore", {
 		// Set from ai_setup_state: a provider carrying its own key (Anthropic, a
 		// self-hosted gateway) is enough on its own, and the shared OpenRouter key in
 		// Builder Settings is the only thing the client can see for itself.
-		// null until the server answers — false means "asked, not configured".
+		// null until the server answers; false means "asked, not configured"
 		aiConfigured: <boolean | null>null,
 	}),
 	getters: {
 		isAIEnabled(): boolean {
 			return !!this.aiConfigured || !!builderSettings.doc?.ai_api_key;
 		},
-		// The panel must not draw the setup hero (or the chat) on a guess: until
-		// one positive signal or the server's verdict arrives, the answer is unknown.
+		// unknown until a positive signal or the server's verdict arrives
 		isAIStateKnown(): boolean {
 			return this.aiConfigured !== null || this.isAIEnabled;
 		},


### PR DESCRIPTION
On slow networks the AI panel flashed "Set up AI" at configured users, and showed an empty chat before the last conversation popped in.

- AI-configured is now a tri-state (unknown until the server answers); the panel shows a single quiet loading shimmer until the verdict and the session both arrive.
- A restored chat opens scrolled to its end, including when it loaded behind the closed tab (scrolling a hidden container is a no-op, so the scroll is replayed on tab open).
- Page switches no longer show the previous page's transcript, and the header no longer flashes "New chat" before the real title.