### PR TITLE
fix(i18n): let generate-pot-file import hooks without a site

### DIFF
--- a/builder/hooks.py
+++ b/builder/hooks.py
@@ -195,7 +195,12 @@ scheduler_events = {
 # "builder.auth.validate"
 # ]
 
-builder_path = frappe.conf.builder_path or "builder"
+try:
+	builder_path = frappe.conf.builder_path or "builder"
+except RuntimeError:
+	# frappe.conf is unbound when hooks are imported without a site,
+	# as done by `bench generate-pot-file --app builder`.
+	builder_path = "builder"
 website_route_rules = [
 	{"from_route": f"/{builder_path}/<path:app_path>", "to_route": "_builder"},
 	{"from_route": f"/{builder_path}", "to_route": "_builder"},


### PR DESCRIPTION
`generate-pot-file.yml` has never completed successfully. It was added on 2026-08-08 and has run on 08-08, 08-09 and 08-16. All three runs failed the same way:

```
File "/home/runner/frappe-bench/apps/builder/builder/hooks.py", line 198, in <module>
    builder_path = frappe.conf.builder_path or "builder"
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/local.py", line 55, in _get_current_object
    raise RuntimeError("object is not bound") from None
RuntimeError: object is not bound
```

`hooks.py` reads `frappe.conf` at import time. That works wherever a site is bound, but `bench generate-pot-file --app builder` imports hooks without one, so the proxy raises before extraction starts.

The same workflow runs green in `frappe/crm` and `frappe/lms`, so a site-less import is the expected contract and the fix belongs in the app rather than in CI.

Scheduled runs fail quietly, so nothing surfaces this. `builder/locale/main.pot` was last updated by hand in #721 on 2026-08-13, not by the workflow. The roughly 190 strings wrapped in #746 and #750 are in the source but never reach the POT, so no language can translate them yet.

Behaviour is unchanged wherever a site is bound. Only the site-less import falls back to the default path.

Not runtime-tested: I have no bench here. The failing job log and the passing sibling workflows are the evidence I have.
