### PR TITLE
chore: remove Delete Page keyboard shortcut

### DIFF
--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -311,19 +311,3 @@ commands.register({
 		if (canvas?.history?.canRedo) canvas.history.redo();
 	},
 });
-
-commands.register({
-	name: "delete-page",
-	title: __("Delete Page"),
-	icon: "lucide-trash-2",
-	group: "General",
-	inPalette: false,
-	// same binding as toggle-canvas-dark-mode, as it was before this registry
-	keys: { key: "d", ctrl: true, shift: true, description: __("Delete Page") },
-	condition: () => Boolean(pageStore.activePage && !pageStore.activePage.is_standard),
-	action: () => {
-		if (pageStore.activePage && !pageStore.activePage.is_standard) {
-			pageStore.deletePage(pageStore.activePage).then(() => router.push({ name: "home" }));
-		}
-	},
-});


### PR DESCRIPTION
Ctrl+Shift+D was double-bound to both delete-page and toggle-canvas-dark-mode. The delete-page command was in the palette and unreferenced elsewhere, so the registration is dropped entirely. Page deletion remains available via MainMenu and PageActionsDropdown.