### PR TITLE
fix: skip XSS filtering on builder-authored block fields

### DIFF
--- a/builder/builder/doctype/builder_component/builder_component.json
+++ b/builder/builder/doctype/builder_component/builder_component.json
@@ -23,6 +23,7 @@
   {
    "fieldname": "block",
    "fieldtype": "JSON",
+   "ignore_xss_filter": 1,
    "label": "Block",
    "read_only": 1
   },
@@ -51,7 +52,7 @@
   ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-29 09:30:34.896956",
+ "modified": "2026-08-17 17:40:00.000000",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Component",

--- a/builder/builder/doctype/builder_component/builder_component.json
+++ b/builder/builder/doctype/builder_component/builder_component.json
@@ -22,7 +22,7 @@
   },
   {
    "fieldname": "block",
-   "fieldtype": "JSON",
+   "fieldtype": "Long Text",
    "ignore_xss_filter": 1,
    "label": "Block",
    "read_only": 1
@@ -34,25 +34,25 @@
    "options": "Builder Page",
    "read_only": 1
   },
-   {
-    "fieldname": "component_id",
-    "fieldtype": "Data",
-    "label": "Component ID",
-    "no_copy": 1,
-    "read_only": 1,
-    "unique": 1
-   },
-   {
-    "fieldname": "component_data_script",
-    "fieldtype": "Code",
-    "label": "Component Data Script",
-    "options": "Python",
-    "description": "Server-side Python script that populates component data. Receives props as input. Use: data.events = frappe.get_list('Event')"
-   }
-  ],
+  {
+   "fieldname": "component_id",
+   "fieldtype": "Data",
+   "label": "Component ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "description": "Server-side Python script that populates component data. Receives props as input. Use: data.events = frappe.get_list('Event')",
+   "fieldname": "component_data_script",
+   "fieldtype": "Code",
+   "label": "Component Data Script",
+   "options": "Python"
+  }
+ ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-17 17:40:00.000000",
+ "modified": "2026-08-18 18:11:58.308298",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Component",
@@ -84,6 +84,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/builder/builder/doctype/builder_component/builder_component.py
+++ b/builder/builder/doctype/builder_component/builder_component.py
@@ -25,7 +25,7 @@ class BuilderComponent(StandardFileSync, Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		block: DF.JSON | None
+		block: DF.LongText | None
 		component_data_script: DF.Code | None
 		component_id: DF.Data | None
 		component_name: DF.Data | None

--- a/builder/builder/doctype/builder_page/builder_page.json
+++ b/builder/builder/doctype/builder_page/builder_page.json
@@ -73,6 +73,7 @@
   {
    "fieldname": "blocks",
    "fieldtype": "Long Text",
+   "ignore_xss_filter": 1,
    "label": "Blocks",
    "read_only": 1
   },
@@ -120,6 +121,7 @@
   {
    "fieldname": "draft_blocks",
    "fieldtype": "Long Text",
+   "ignore_xss_filter": 1,
    "label": "Draft Blocks",
    "read_only": 1
   },
@@ -262,7 +264,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-04 10:00:00.000000",
+ "modified": "2026-08-17 17:40:00.000000",
  "modified_by": "Administrator",
  "module": "Builder",
  "name": "Builder Page",


### PR DESCRIPTION
`develop` currently fails the server suite against `frappe/develop`. This restores it.

### Cause

frappe#41626 removed the JSON bypass in `sanitize_html`:

```diff
 	if not always_sanitize:
-		if is_json(html):
-			return html
-
 		if not bool(BeautifulSoup(html, "html.parser").find()):
 			return html
```

That change is intentional and correct. The old docstring already called the bypass risky, and the new tests assert that `{"x": "<script>alert(1)</script>"}` no longer passes through.

Builder relied on it. `builder_page.blocks` and `draft_blocks` are `Long Text` and `builder_component.block` is `JSON`, and all three hold block JSON that contains markup. That content used to take the bypass and reach the database untouched. It now goes through nh3, which rewrites it.

Two tests show the effect:

```
AssertionError: 'var(--new-brand, #eee)' not found in
'[{"blockId": "root", "baseStyles": {"color": "var(--new-brand)", ...
```

```
AssertionError: '<\/script><p>Component Script</p>' not found in '<!DOCTYPE html> ...
```

The design token fallback is stripped, and the `</script>` escaping never appears. Builder escapes on render, so the sanitizer was not the security boundary for these fields. It was simply never reached.

### Change

`ignore_xss_filter` on the three fields that carry builder-authored block JSON, plus a `modified` bump so existing sites reload the doctypes. This makes the previous behaviour explicit instead of accidental. `builder_page.route` already uses the same flag.

### Verification

Run on a fork of `develop`, since the failure reproduces there without any change of mine:

- `develop` tree alone: Server Tests fail with the two assertions above
- same tree plus this change: Server Tests pass, along with UI Tests and Linters

### Alternative

Moving `blocks` and `draft_blocks` to the `JSON` fieldtype, matching `builder_component.block`, would be cleaner semantically but is a schema change. If you prefer that direction, close this one.
