### PR TITLE
feat: focus point control for cover images

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -98,6 +98,7 @@ declare module 'vue' {
     GlobalRedirects: typeof import('./src/components/Settings/GlobalRedirects.vue')['default']
     GlobalUsers: typeof import('./src/components/Settings/GlobalUsers.vue')['default']
     GradientEditor: typeof import('./src/components/Controls/GradientEditor.vue')['default']
+    ImageFocusInput: typeof import('./src/components/Controls/ImageFocusInput.vue')['default']
     ImageOptions: typeof import('./src/components/PropsOptions/ImageOptions.vue')['default']
     ImageUploader: typeof import('./src/components/Controls/ImageUploader.vue')['default']
     ImageUploadInput: typeof import('./src/components/ImageUploadInput.vue')['default']

--- a/frontend/src/builder.d.ts
+++ b/frontend/src/builder.d.ts
@@ -1,5 +1,13 @@
 declare type StyleValue = string | number | boolean | null | undefined;
 
+declare module "csstype" {
+	interface Properties {
+		// crops an img/video to a sub-rect; Chromium + Safari render it, Firefox
+		// falls back to the uncropped cover fit
+		objectViewBox?: string;
+	}
+}
+
 declare type styleProperty = keyof CSSProperties | `__${string}`;
 
 declare interface BlockStyleMap {

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -58,31 +58,32 @@
 				<div v-else-if="activeTab === 'image'" class="space-y-4">
 					<!-- A cover background gets the focus-point surface as its preview:
 					     drag to choose what the crop keeps, upload rides as a hover chip. -->
-					<div v-if="bgFocusEnabled" class="group relative">
-						<ImageFocusInput
-							:imageSrc="backgroundImageURL || ''"
-							:modelValue="backgroundPosition"
-							:targetRatio="selectedBlockRatio"
-							@update:modelValue="setBGPosition">
-							<FileUploader
-								@success="setBGImage"
-								:uploadArgs="{
-									private: false,
-									folder: 'Home/Builder Uploads',
-									optimize: true,
-									upload_endpoint: '/api/method/builder.api.upload_builder_asset',
-								}">
-								<template v-slot="{ openFileSelector }">
+					<FileUploader
+						v-if="bgFocusEnabled"
+						@success="setBGImage"
+						:uploadArgs="{
+							private: false,
+							folder: 'Home/Builder Uploads',
+							optimize: true,
+							upload_endpoint: '/api/method/builder.api.upload_builder_asset',
+						}">
+						<template v-slot="{ openFileSelector }">
+							<div class="group relative">
+								<ImageFocusInput
+									:imageSrc="backgroundImageURL || ''"
+									:modelValue="backgroundPosition"
+									:targetRatio="selectedBlockRatio"
+									@update:modelValue="setBGPosition">
 									<Button
 										variant="subtle"
 										icon="upload"
 										:title="__('Upload image')"
 										class="absolute -right-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
 										@click="openFileSelector" />
-								</template>
-							</FileUploader>
-						</ImageFocusInput>
-					</div>
+								</ImageFocusInput>
+							</div>
+						</template>
+					</FileUploader>
 					<div
 						v-else
 						class="image-preview group relative h-24 w-full cursor-pointer overflow-hidden rounded bg-surface-gray-3"

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -55,87 +55,78 @@
 				</div>
 
 				<!-- Image Tab -->
-				<div v-else-if="activeTab === 'image'" class="space-y-4">
-					<!-- A cover background gets the focus-point surface as its preview:
-					     drag to choose what the crop keeps, upload rides as a hover chip. -->
-					<FileUploader
-						v-if="bgFocusEnabled"
-						@success="setBGImage"
-						:uploadArgs="{
-							private: false,
-							folder: 'Home/Builder Uploads',
-							optimize: true,
-							upload_endpoint: '/api/method/builder.api.upload_builder_asset',
-						}">
-						<template v-slot="{ openFileSelector }">
-							<div class="group relative">
-								<ImageFocusInput
-									:imageSrc="backgroundImageURL || ''"
-									:modelValue="backgroundPosition"
-									:targetRatio="selectedBlockRatio"
-									@update:modelValue="setBGPosition">
-									<Button
-										variant="subtle"
-										icon="upload"
-										:title="__('Upload image')"
-										class="absolute -right-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
-										@click="openFileSelector" />
-								</ImageFocusInput>
+				<FileUploader
+					v-else-if="activeTab === 'image'"
+					@success="setBGImage"
+					:uploadArgs="{
+						private: false,
+						folder: 'Home/Builder Uploads',
+						optimize: true,
+						upload_endpoint: '/api/method/builder.api.upload_builder_asset',
+					}">
+					<template v-slot="{ openFileSelector }">
+						<div class="space-y-3">
+							<TabButtons
+								:class="STRETCH_TABS"
+								:options="sizeTabOptions"
+								:modelValue="backgroundSize || 'auto'"
+								@update:modelValue="setBGSize" />
+							<ImageFocusInput
+								v-if="backgroundImageURL"
+								:imageSrc="backgroundImageURL"
+								:modelValue="backgroundPosition"
+								:targetRatio="selectedBlockRatio"
+								:fit="backgroundSize === 'contain' ? 'contain' : 'none'"
+								:disabled="!bgFocusEnabled"
+								@update:modelValue="setBGPosition" />
+							<div
+								v-else
+								class="flex h-24 items-center justify-center rounded border border-dashed border-outline-gray-2 bg-surface-gray-1 text-p-xs text-ink-gray-4">
+								{{ __("No image") }}
 							</div>
-						</template>
-					</FileUploader>
-					<div
-						v-else
-						class="image-preview group relative h-24 w-full cursor-pointer overflow-hidden rounded bg-surface-gray-3"
-						:style="getPreviewStyle(activeState)">
-						<FileUploader
-							@success="setBGImage"
-							:uploadArgs="{
-								private: false,
-								folder: 'Home/Builder Uploads',
-								optimize: true,
-								upload_endpoint: '/api/method/builder.api.upload_builder_asset',
-							}">
-							<template v-slot="{ openFileSelector }">
-								<div
-									class="absolute bottom-0 left-0 right-0 top-0 hidden place-items-center bg-gray-500 bg-opacity-20"
-									:class="{
-										'!grid': !backgroundImageURL,
-										'group-hover:grid': backgroundImageURL,
-									}">
-									<Button @click="openFileSelector">{{ __("Upload") }}</Button>
-								</div>
-							</template>
-						</FileUploader>
-					</div>
-					<div class="space-y-2">
-						<InlineInput
-							:label="__('Size')"
-							:modelValue="backgroundSize"
-							type="select"
-							:options="sizeOptions"
-							@update:modelValue="setBGSize" />
-						<InlineInput
-							v-if="!bgFocusEnabled"
-							:label="__('Position')"
-							:modelValue="backgroundPosition"
-							type="select"
-							:options="positionOptions"
-							@update:modelValue="setBGPosition" />
-						<InlineInput
-							:label="__('Repeat')"
-							:modelValue="backgroundRepeat"
-							type="select"
-							:options="repeatOptions"
-							@update:modelValue="setBGRepeat" />
-					</div>
-					<Button v-if="showServeLocallyButton" class="w-full" @click="serveBackgroundImageLocally">
-						{{ serveLocallyButtonText }}
-					</Button>
-					<Button v-if="backgroundImageURL" class="w-full" variant="subtle" @click="clearBGImage">
-						{{ __("Clear Image") }}
-					</Button>
-				</div>
+							<div v-if="!bgFocusEnabled && backgroundImageURL" class="space-y-2">
+								<InlineInput
+									:label="__('Position')"
+									:modelValue="backgroundPosition"
+									type="select"
+									:options="positionOptions"
+									@update:modelValue="setBGPosition" />
+								<InlineInput
+									:label="__('Repeat')"
+									:modelValue="backgroundRepeat"
+									type="select"
+									:options="repeatOptions"
+									@update:modelValue="setBGRepeat" />
+							</div>
+							<div class="flex items-center gap-1.5">
+								<Button
+									class="flex-1"
+									variant="outline"
+									iconLeft="upload"
+									:label="backgroundImageURL ? __('Replace') : __('Upload')"
+									@click="openFileSelector" />
+								<Button
+									v-if="bgFocusEnabled"
+									variant="outline"
+									icon="rotate-ccw"
+									:title="__('Reset focal point')"
+									@click="setBGPosition('center')" />
+								<Button
+									v-if="showServeLocallyButton"
+									variant="outline"
+									icon="download"
+									:title="serveLocallyButtonText"
+									@click="serveBackgroundImageLocally" />
+								<Button
+									v-if="backgroundImageURL"
+									variant="outline"
+									icon="trash"
+									:title="__('Clear image')"
+									@click="clearBGImage" />
+							</div>
+						</div>
+					</template>
+				</FileUploader>
 
 				<!-- Gradient Tab -->
 				<div v-else class="space-y-4">
@@ -320,9 +311,9 @@ const getPreviewStyle = (state: string | null) => {
 	};
 };
 
-const sizeOptions = [
-	{ label: __("Contain"), value: "contain" },
-	{ label: __("Cover"), value: "cover" },
+const sizeTabOptions = [
+	{ label: __("Fill & crop"), value: "cover" },
+	{ label: __("Fit"), value: "contain" },
 	{ label: __("Auto"), value: "auto" },
 ];
 

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -56,7 +56,35 @@
 
 				<!-- Image Tab -->
 				<div v-else-if="activeTab === 'image'" class="space-y-4">
+					<!-- A cover background gets the focus-point surface as its preview:
+					     drag to choose what the crop keeps, upload rides as a hover chip. -->
+					<div v-if="bgFocusEnabled" class="group relative">
+						<ImageFocusInput
+							:imageSrc="backgroundImageURL || ''"
+							:modelValue="backgroundPosition"
+							:targetRatio="selectedBlockRatio"
+							@update:modelValue="setBGPosition">
+							<FileUploader
+								@success="setBGImage"
+								:uploadArgs="{
+									private: false,
+									folder: 'Home/Builder Uploads',
+									optimize: true,
+									upload_endpoint: '/api/method/builder.api.upload_builder_asset',
+								}">
+								<template v-slot="{ openFileSelector }">
+									<Button
+										variant="subtle"
+										icon="upload"
+										:title="__('Upload image')"
+										class="absolute -right-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+										@click="openFileSelector" />
+								</template>
+							</FileUploader>
+						</ImageFocusInput>
+					</div>
 					<div
+						v-else
 						class="image-preview group relative h-24 w-full cursor-pointer overflow-hidden rounded bg-surface-gray-3"
 						:style="getPreviewStyle(activeState)">
 						<FileUploader
@@ -87,6 +115,7 @@
 							:options="sizeOptions"
 							@update:modelValue="setBGSize" />
 						<InlineInput
+							v-if="!bgFocusEnabled"
 							:label="__('Position')"
 							:modelValue="backgroundPosition"
 							type="select"
@@ -133,6 +162,7 @@
 import { __ } from "@/translation";
 import ColorPicker from "@/components/Controls/ColorPicker.vue";
 import GradientEditor from "@/components/Controls/GradientEditor.vue";
+import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
 import InlineInput from "@/components/Controls/InlineInput.vue";
 import Input from "@/components/Controls/Input.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
@@ -245,6 +275,8 @@ const backgroundImageURL = computed(() => {
 });
 
 const backgroundSize = computed(() => blockController.getStyle(getStyleKey("backgroundSize")) as string);
+const bgFocusEnabled = computed(() => Boolean(backgroundImageURL.value) && backgroundSize.value === "cover");
+const selectedBlockRatio = computed(() => blockController.getSelectedBlockAspectRatio());
 const backgroundPosition = computed(
 	() => blockController.getStyle(getStyleKey("backgroundPosition")) as string,
 );

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -84,20 +84,12 @@
 								class="flex h-24 items-center justify-center rounded border border-dashed border-outline-gray-2 bg-surface-gray-1 text-p-xs text-ink-gray-4">
 								{{ __("No image") }}
 							</div>
-							<div v-if="!bgFocusEnabled && backgroundImageURL" class="space-y-2">
-								<InlineInput
-									:label="__('Position')"
-									:modelValue="backgroundPosition"
-									type="select"
-									:options="positionOptions"
-									@update:modelValue="setBGPosition" />
-								<InlineInput
-									:label="__('Repeat')"
-									:modelValue="backgroundRepeat"
-									type="select"
-									:options="repeatOptions"
-									@update:modelValue="setBGRepeat" />
-							</div>
+							<TabButtons
+								v-if="!bgFocusEnabled && backgroundImageURL"
+								:class="STRETCH_TABS"
+								:options="repeatTabOptions"
+								:modelValue="backgroundRepeat || 'repeat'"
+								@update:modelValue="setBGRepeat" />
 							<div class="flex items-center gap-1.5">
 								<Button
 									class="flex-1"
@@ -111,12 +103,6 @@
 									icon="rotate-ccw"
 									:title="__('Reset focal point')"
 									@click="setBGPosition('center')" />
-								<Button
-									v-if="showServeLocallyButton"
-									variant="outline"
-									icon="download"
-									:title="serveLocallyButtonText"
-									@click="serveBackgroundImageLocally" />
 								<Button
 									v-if="backgroundImageURL"
 									variant="outline"
@@ -155,13 +141,11 @@ import { __ } from "@/translation";
 import ColorPicker from "@/components/Controls/ColorPicker.vue";
 import GradientEditor from "@/components/Controls/GradientEditor.vue";
 import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
-import InlineInput from "@/components/Controls/InlineInput.vue";
 import Input from "@/components/Controls/Input.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import useBuilderStore from "@/stores/builderStore";
 import blockController from "@/utils/blockController";
 import { cssUrl } from "@/utils/helpers";
-import { getOptimizeButtonText, optimizeImage, shouldShowOptimizeButton } from "@/utils/imageUtils";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { STRETCH_TABS } from "@/utils/tabButtons";
 import { FileUploader, Popover, Switch, TabButtons } from "frappe-ui";
@@ -317,19 +301,11 @@ const sizeTabOptions = [
 	{ label: __("Auto"), value: "auto" },
 ];
 
-const positionOptions = [
-	{ label: __("Center"), value: "center" },
-	{ label: __("Top"), value: "top" },
-	{ label: __("Bottom"), value: "bottom" },
-	{ label: __("Left"), value: "left" },
-	{ label: __("Right"), value: "right" },
-];
-
-const repeatOptions = [
-	{ label: __("No Repeat"), value: "no-repeat" },
-	{ label: __("Repeat"), value: "repeat" },
-	{ label: __("Repeat X"), value: "repeat-x" },
-	{ label: __("Repeat Y"), value: "repeat-y" },
+const repeatTabOptions = [
+	{ label: "", value: "no-repeat", icon: "lucide-square" },
+	{ label: "", value: "repeat", icon: "lucide-grid-2x2" },
+	{ label: "", value: "repeat-x", icon: "lucide-gallery-horizontal" },
+	{ label: "", value: "repeat-y", icon: "lucide-gallery-vertical" },
 ];
 
 const setBGImage = (file: { file_url: string }) => {
@@ -432,21 +408,5 @@ const handleSetVariant = (variantName: string, value: string | number | boolean 
 	// instead of the display text (e.g. "Gradient", variable name, image file name)
 	blockController.setStyle(bgKey, (blockController.getStyle("backgroundImage") as string) ?? null);
 	blockController.setStyle(colorKey, (blockController.getStyle("backgroundColor") as string) ?? null);
-};
-
-const showServeLocallyButton = computed(() => shouldShowOptimizeButton(backgroundImageURL.value));
-const serveLocallyButtonText = computed(() => getOptimizeButtonText(backgroundImageURL.value));
-
-const serveBackgroundImageLocally = () => {
-	if (!backgroundImageURL.value) {
-		return;
-	}
-
-	return optimizeImage({
-		imageUrl: backgroundImageURL.value,
-		onSuccess: (newUrl: string) => {
-			blockController.setStyle(getStyleKey("backgroundImage"), cssUrl(newUrl));
-		},
-	});
 };
 </script>

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -302,10 +302,10 @@ const sizeTabOptions = [
 ];
 
 const repeatTabOptions = [
-	{ label: "", value: "no-repeat", icon: "lucide-square" },
-	{ label: "", value: "repeat", icon: "lucide-grid-2x2" },
-	{ label: "", value: "repeat-x", icon: "lucide-gallery-horizontal" },
-	{ label: "", value: "repeat-y", icon: "lucide-gallery-vertical" },
+	{ label: "", value: "no-repeat", icon: "lucide-square", tooltip: __("No repeat") },
+	{ label: "", value: "repeat", icon: "lucide-grid-2x2", tooltip: __("Repeat") },
+	{ label: "", value: "repeat-x", icon: "lucide-gallery-horizontal", tooltip: __("Repeat horizontally") },
+	{ label: "", value: "repeat-y", icon: "lucide-gallery-vertical", tooltip: __("Repeat vertically") },
 ];
 
 const setBGImage = (file: { file_url: string }) => {

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -76,7 +76,7 @@
 								:imageSrc="backgroundImageURL"
 								:modelValue="backgroundPosition"
 								:targetRatio="selectedBlockRatio"
-								:fit="backgroundSize === 'contain' ? 'contain' : 'none'"
+								:fit="backgroundSize === 'contain' ? 'contain' : 'scale-down'"
 								:disabled="!bgFocusEnabled"
 								@update:modelValue="setBGPosition" />
 							<div

--- a/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
@@ -18,6 +18,8 @@ const imageOptionsSectionProperties = [
 				popoverOffset: 120,
 				imageFit: blockController.getStyle("objectFit"),
 				objectPosition: (blockController.getStyle("objectPosition") as string) || "",
+				objectViewBox: (blockController.getStyle("objectViewBox") as string) || "",
+				targetRatio: blockController.getSelectedBlockAspectRatio(),
 				variants: [{ name: "dark", property: "darkSrc", label: __("Dark Mode") }],
 			};
 		},
@@ -25,10 +27,11 @@ const imageOptionsSectionProperties = [
 			"update:imageURL": (val: string) => blockController.setAttribute("src", val),
 			"update:imageFit": (val: StyleValue) => blockController.setStyle("objectFit", val),
 			"update:objectPosition": (val: string) => blockController.setStyle("objectPosition", val),
+			"update:objectViewBox": (val: string) => blockController.setStyle("objectViewBox", val),
 		},
 		searchKeyWords:
-			"Image, URL, Src, Fit, ObjectFit, Object Fit, Fill, Contain, Cover, Dark, Mode, Dark Mode, Theme, Focus, Focal, Point, Crop, Framing, Object Position, ObjectPosition",
-		usedStyleProperties: ["object-fit", "object-position"],
+			"Image, URL, Src, Fit, ObjectFit, Object Fit, Fill, Contain, Cover, Dark, Mode, Dark Mode, Theme, Focus, Focal, Point, Crop, Zoom, Framing, Object Position, ObjectPosition, Object View Box",
+		usedStyleProperties: ["object-fit", "object-position", "object-view-box"],
 	},
 	{
 		component: Button,

--- a/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
@@ -1,5 +1,4 @@
 import AttributePropertyControl from "@/components/Controls/AttributePropertyControl.vue";
-import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
 import ImageUploadInput from "@/components/ImageUploadInput.vue";
 import blockController from "@/utils/blockController";
 import { getOptimizeButtonText, optimizeImage, shouldShowOptimizeButton } from "@/utils/imageUtils";
@@ -18,35 +17,18 @@ const imageOptionsSectionProperties = [
 				allowDynamicValue: true,
 				popoverOffset: 120,
 				imageFit: blockController.getStyle("objectFit"),
+				objectPosition: (blockController.getStyle("objectPosition") as string) || "",
 				variants: [{ name: "dark", property: "darkSrc", label: __("Dark Mode") }],
 			};
 		},
 		events: {
 			"update:imageURL": (val: string) => blockController.setAttribute("src", val),
 			"update:imageFit": (val: StyleValue) => blockController.setStyle("objectFit", val),
+			"update:objectPosition": (val: string) => blockController.setStyle("objectPosition", val),
 		},
 		searchKeyWords:
-			"Image, URL, Src, Fit, ObjectFit, Object Fit, Fill, Contain, Cover, Dark, Mode, Dark Mode, Theme",
-		usedStyleProperties: ["object-fit"],
-	},
-	{
-		component: ImageFocusInput,
-		getProps: () => {
-			return {
-				label: __("Focus Point"),
-				imageSrc: (blockController.getAttribute("src") as string) || "",
-				modelValue: (blockController.getStyle("objectPosition") as string) || "",
-			};
-		},
-		events: {
-			"update:modelValue": (val: string) => blockController.setStyle("objectPosition", val),
-		},
-		searchKeyWords: "Focus, Focal, Point, Crop, Framing, Position, Object Position, ObjectPosition",
-		usedStyleProperties: ["object-position"],
-		condition: () =>
-			blockController.isImage() &&
-			blockController.getStyle("objectFit") === "cover" &&
-			Boolean(blockController.getAttribute("src")),
+			"Image, URL, Src, Fit, ObjectFit, Object Fit, Fill, Contain, Cover, Dark, Mode, Dark Mode, Theme, Focus, Focal, Point, Crop, Framing, Object Position, ObjectPosition",
+		usedStyleProperties: ["object-fit", "object-position"],
 	},
 	{
 		component: Button,

--- a/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/ImageOptionsSection.ts
@@ -1,4 +1,5 @@
 import AttributePropertyControl from "@/components/Controls/AttributePropertyControl.vue";
+import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
 import ImageUploadInput from "@/components/ImageUploadInput.vue";
 import blockController from "@/utils/blockController";
 import { getOptimizeButtonText, optimizeImage, shouldShowOptimizeButton } from "@/utils/imageUtils";
@@ -27,6 +28,25 @@ const imageOptionsSectionProperties = [
 		searchKeyWords:
 			"Image, URL, Src, Fit, ObjectFit, Object Fit, Fill, Contain, Cover, Dark, Mode, Dark Mode, Theme",
 		usedStyleProperties: ["object-fit"],
+	},
+	{
+		component: ImageFocusInput,
+		getProps: () => {
+			return {
+				label: __("Focus Point"),
+				imageSrc: (blockController.getAttribute("src") as string) || "",
+				modelValue: (blockController.getStyle("objectPosition") as string) || "",
+			};
+		},
+		events: {
+			"update:modelValue": (val: string) => blockController.setStyle("objectPosition", val),
+		},
+		searchKeyWords: "Focus, Focal, Point, Crop, Framing, Position, Object Position, ObjectPosition",
+		usedStyleProperties: ["object-position"],
+		condition: () =>
+			blockController.isImage() &&
+			blockController.getStyle("objectFit") === "cover" &&
+			Boolean(blockController.getAttribute("src")),
 	},
 	{
 		component: Button,

--- a/frontend/src/components/BlockPropertySections/LayoutSection.ts
+++ b/frontend/src/components/BlockPropertySections/LayoutSection.ts
@@ -124,5 +124,11 @@ const layoutSectionProperties = [
 export default {
 	name: __("Layout"),
 	properties: layoutSectionProperties,
-	condition: () => !blockController.multipleBlocksSelected() && !blockController.isHTML(),
+	condition: () =>
+		!blockController.multipleBlocksSelected() &&
+		!blockController.isHTML() &&
+		!blockController.isImage() &&
+		!blockController.isSVG() &&
+		!blockController.isVideo() &&
+		!blockController.isInput(),
 };

--- a/frontend/src/components/BlockPropertySections/StyleSection.ts
+++ b/frontend/src/components/BlockPropertySections/StyleSection.ts
@@ -1,4 +1,13 @@
 import BackgroundHandler from "@/components/BackgroundHandler.vue";
+import { cssUrl } from "@/utils/helpers";
+import { getOptimizeButtonText, optimizeImage, shouldShowOptimizeButton } from "@/utils/imageUtils";
+import { Button } from "frappe-ui";
+import { computed } from "vue";
+
+const backgroundImageURL = () => {
+	const bg = (blockController.getStyle("backgroundImage") as string) || "";
+	return bg && !bg.includes("gradient") ? bg.replace(/^url\(['"]?|['"]?\)$/g, "") : "";
+};
 import ColorInput from "@/components/Controls/ColorInput.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import blockController from "@/utils/blockController";
@@ -71,6 +80,26 @@ const styleSectionProperties = [
 		],
 		searchKeyWords:
 			"Background, BackgroundImage, Background Image, Background Position, Background Repeat, Background Size, BG, BGImage, BG Image, BGPosition, BG Position, BGRepeat, BG Repeat, BGSize, BG Size",
+	},
+	{
+		component: Button,
+		getProps: () => {
+			return {
+				class: "text-base self-end",
+			};
+		},
+		innerText: computed(() => getOptimizeButtonText(backgroundImageURL())),
+		searchKeyWords:
+			"Background, Local, Copy, Server, Download, Host, Store, Convert, webp, Convert to webp, image, url",
+		events: {
+			click: () =>
+				optimizeImage({
+					imageUrl: backgroundImageURL(),
+					onSuccess: (newUrl: string) =>
+						blockController.setStyle("backgroundImage", cssUrl(newUrl)),
+				}),
+		},
+		condition: () => shouldShowOptimizeButton(backgroundImageURL()),
 	},
 	{
 		component: StylePropertyControl,

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -1,0 +1,126 @@
+<template>
+	<div class="flex flex-col gap-1.5">
+		<div class="flex items-center justify-between">
+			<InputLabel>{{ label }}</InputLabel>
+			<button
+				v-if="hasCustomValue"
+				type="button"
+				class="text-xs text-ink-gray-5 transition-colors hover:text-ink-gray-7"
+				@click="emit('update:modelValue', '')">
+				{{ __("Reset") }}
+			</button>
+		</div>
+		<div
+			ref="boxRef"
+			class="relative h-32 w-full cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1">
+			<img
+				ref="imgRef"
+				:src="imageSrc"
+				class="pointer-events-none h-full w-full select-none object-contain"
+				draggable="false"
+				@load="onLoad" />
+			<div
+				v-if="imageRect"
+				class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
+				:style="dotStyle" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InputLabel from "@/components/Controls/InputLabel.vue";
+import useCanvasStore from "@/stores/canvasStore";
+import { __ } from "@/translation";
+import type { PauseId } from "@/utils/useCanvasHistory";
+import { useElementSize, useMouseInElement, useMousePressed } from "@vueuse/core";
+import { computed, ref, watch } from "vue";
+
+const props = defineProps<{
+	modelValue?: string;
+	imageSrc: string;
+	label?: string;
+}>();
+
+const emit = defineEmits(["update:modelValue"]);
+
+const canvasStore = useCanvasStore();
+
+const boxRef = ref<HTMLElement | null>(null);
+const imgRef = ref<HTMLImageElement | null>(null);
+const natural = ref<{ w: number; h: number } | null>(null);
+
+const onLoad = () => {
+	const img = imgRef.value;
+	if (img?.naturalWidth) natural.value = { w: img.naturalWidth, h: img.naturalHeight };
+};
+
+const { width: boxWidth, height: boxHeight } = useElementSize(boxRef);
+
+// where the object-contain image actually renders inside the box (it letterboxes)
+const imageRect = computed(() => {
+	if (!natural.value || !boxWidth.value || !boxHeight.value) return null;
+	const scale = Math.min(boxWidth.value / natural.value.w, boxHeight.value / natural.value.h);
+	const w = natural.value.w * scale;
+	const h = natural.value.h * scale;
+	return { w, h, x: (boxWidth.value - w) / 2, y: (boxHeight.value - h) / 2 };
+});
+
+const KEYWORDS: Record<string, number> = { left: 0, top: 0, center: 50, right: 100, bottom: 100 };
+
+const point = computed(() => {
+	const parts = (props.modelValue || "").trim().split(/\s+/).filter(Boolean);
+	const parse = (part: string | undefined) => {
+		if (!part) return 50;
+		if (part.endsWith("%")) {
+			const n = parseFloat(part);
+			return isNaN(n) ? 50 : Math.min(100, Math.max(0, n));
+		}
+		return KEYWORDS[part] ?? 50;
+	};
+	// a lone vertical keyword ("top") names the y axis
+	if (parts.length === 1 && (parts[0] === "top" || parts[0] === "bottom")) {
+		return { x: 50, y: KEYWORDS[parts[0]] };
+	}
+	return { x: parse(parts[0]), y: parse(parts[1]) };
+});
+
+const hasCustomValue = computed(() => Boolean((props.modelValue || "").trim()));
+
+const dotStyle = computed(() => {
+	const rect = imageRect.value;
+	if (!rect) return {};
+	return {
+		left: `${rect.x + (point.value.x / 100) * rect.w}px`,
+		top: `${rect.y + (point.value.y / 100) * rect.h}px`,
+		transform: "translate(-50%, -50%)",
+	};
+});
+
+const { elementX, elementY } = useMouseInElement(boxRef);
+const { pressed } = useMousePressed({ target: boxRef });
+
+let pauseId: PauseId | undefined = undefined;
+
+watch(pressed, (down) => {
+	const history = canvasStore.activeCanvas?.history;
+	if (down) {
+		pauseId = history?.pause();
+		setFromPointer();
+	} else if (pauseId) {
+		history?.resume(pauseId, true);
+		pauseId = undefined;
+	}
+});
+
+watch([elementX, elementY], () => {
+	if (pressed.value) setFromPointer();
+});
+
+function setFromPointer() {
+	const rect = imageRect.value;
+	if (!rect) return;
+	const x = Math.round(Math.min(100, Math.max(0, ((elementX.value - rect.x) / rect.w) * 100)));
+	const y = Math.round(Math.min(100, Math.max(0, ((elementY.value - rect.y) / rect.h) * 100)));
+	emit("update:modelValue", `${x}% ${y}%`);
+}
+</script>

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="flex flex-col gap-1.5">
-		<div class="flex items-center justify-between">
+	<div ref="rootRef" class="flex flex-col gap-1.5">
+		<div v-if="label" class="flex items-center justify-between">
 			<InputLabel>{{ label }}</InputLabel>
 			<button
 				v-if="hasCustomValue"
@@ -12,7 +12,10 @@
 		</div>
 		<div
 			ref="boxRef"
-			class="relative h-32 w-full cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1">
+			class="relative mx-auto cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+			:class="[boxSize ? '' : 'h-24 w-full', dragging && 'is-dragging']"
+			:style="boxSize || {}"
+			@mousedown="onBoxMouseDown">
 			<img
 				ref="imgRef"
 				:src="imageSrc"
@@ -23,6 +26,7 @@
 				v-if="imageRect"
 				class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
 				:style="dotStyle" />
+			<slot />
 		</div>
 	</div>
 </template>
@@ -32,8 +36,8 @@ import InputLabel from "@/components/Controls/InputLabel.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import { __ } from "@/translation";
 import type { PauseId } from "@/utils/useCanvasHistory";
-import { useElementSize, useMouseInElement, useMousePressed } from "@vueuse/core";
-import { computed, ref, watch } from "vue";
+import { useElementSize, useMouseInElement } from "@vueuse/core";
+import { computed, ref } from "vue";
 
 const props = defineProps<{
 	modelValue?: string;
@@ -45,6 +49,7 @@ const emit = defineEmits(["update:modelValue"]);
 
 const canvasStore = useCanvasStore();
 
+const rootRef = ref<HTMLElement | null>(null);
 const boxRef = ref<HTMLElement | null>(null);
 const imgRef = ref<HTMLImageElement | null>(null);
 const natural = ref<{ w: number; h: number } | null>(null);
@@ -55,6 +60,17 @@ const onLoad = () => {
 };
 
 const { width: boxWidth, height: boxHeight } = useElementSize(boxRef);
+const { width: rootWidth } = useElementSize(rootRef);
+
+// the box hugs the image's own aspect ratio (height-capped) so a portrait
+// photo doesn't sit in a letterboxed band with dead space either side
+const MAX_BOX_H = 176;
+const boxSize = computed(() => {
+	if (!natural.value || !rootWidth.value) return null;
+	const ratio = natural.value.w / natural.value.h;
+	const w = Math.min(rootWidth.value, MAX_BOX_H * ratio);
+	return { width: `${Math.round(w)}px`, height: `${Math.round(w / ratio)}px` };
+});
 
 // where the object-contain image actually renders inside the box (it letterboxes)
 const imageRect = computed(() => {
@@ -97,24 +113,32 @@ const dotStyle = computed(() => {
 });
 
 const { elementX, elementY } = useMouseInElement(boxRef);
-const { pressed } = useMousePressed({ target: boxRef });
 
+const dragging = ref(false);
 let pauseId: PauseId | undefined = undefined;
 
-watch(pressed, (down) => {
-	const history = canvasStore.activeCanvas?.history;
-	if (down) {
-		pauseId = history?.pause();
-		setFromPointer();
-	} else if (pauseId) {
-		history?.resume(pauseId, true);
-		pauseId = undefined;
-	}
-});
-
-watch([elementX, elementY], () => {
-	if (pressed.value) setFromPointer();
-});
+// a press on a slotted chip (upload/reset) is a click, never a drag
+function onBoxMouseDown(e: MouseEvent) {
+	if ((e.target as HTMLElement).closest("button")) return;
+	e.preventDefault();
+	dragging.value = true;
+	pauseId = canvasStore.activeCanvas?.history?.pause();
+	setFromPointer();
+	const onMove = () => setFromPointer();
+	document.addEventListener("mousemove", onMove);
+	document.addEventListener(
+		"mouseup",
+		() => {
+			document.removeEventListener("mousemove", onMove);
+			dragging.value = false;
+			if (pauseId) {
+				canvasStore.activeCanvas?.history?.resume(pauseId, true);
+				pauseId = undefined;
+			}
+		},
+		{ once: true },
+	);
+}
 
 function setFromPointer() {
 	const rect = imageRect.value;

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -142,11 +142,10 @@ const point = computed(() => {
 		}
 		return KEYWORDS[part] ?? 50;
 	};
-	// a lone vertical keyword ("top") names the y axis
-	if (parts.length === 1 && (parts[0] === "top" || parts[0] === "bottom")) {
-		return { x: 50, y: KEYWORDS[parts[0]] };
-	}
-	return { x: parse(parts[0]), y: parse(parts[1]) };
+	// keywords name their own axis regardless of order ("top right" == "right top")
+	let [x, y] = parts;
+	if (x === "top" || x === "bottom" || y === "left" || y === "right") [x, y] = [y, x];
+	return { x: parse(x), y: parse(y) };
 });
 
 // with a view-box crop, object-position percentages are relative to the CROPPED

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -110,12 +110,10 @@ const { width: rootWidth } = useElementSize(rootRef);
 const MAX_BOX_H = 176;
 const boxSize = computed(() => {
 	if (!rootWidth.value) return null;
-	// a plain preview mirrors the ELEMENT: full width, its ratio, its fit — the
-	// interactive surface shows the whole image at the image's own ratio
+	// a plain preview stretches across the card at a steady height, drawn with the
+	// element's fit — the interactive surface shows the whole image at its own ratio
 	if (props.disabled) {
-		if (!props.targetRatio) return null;
-		const h = Math.min(MAX_BOX_H, rootWidth.value / props.targetRatio);
-		return { width: `${Math.round(rootWidth.value)}px`, height: `${Math.round(h)}px` };
+		return { width: `${Math.round(rootWidth.value)}px`, height: `${MAX_BOX_H}px` };
 	}
 	const ratio = natural.value && natural.value.w / natural.value.h;
 	if (!ratio) return null;

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -1,24 +1,15 @@
 <template>
-	<div ref="rootRef" class="flex flex-col gap-1.5">
-		<div v-if="label" class="flex items-center justify-between">
-			<InputLabel>{{ label }}</InputLabel>
-			<button
-				v-if="hasCustomValue"
-				type="button"
-				class="text-xs text-ink-gray-5 transition-colors hover:text-ink-gray-7"
-				@click="emit('update:modelValue', '')">
-				{{ __("Reset") }}
-			</button>
-		</div>
+	<div ref="rootRef" class="flex flex-col gap-2">
 		<!-- chips slot beside the clipped box, not inside it, so they can straddle
 		     its edges without being cut by overflow-hidden -->
 		<div
-			class="group/surface relative mx-auto"
+			class="relative mx-auto"
 			:class="[boxSize ? '' : 'h-24 w-full', dragging && 'is-dragging']"
 			:style="boxSize || {}">
 			<div
 				ref="boxRef"
-				class="relative h-full w-full cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+				class="relative h-full w-full overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+				:class="disabled ? '' : 'cursor-crosshair'"
 				@mousedown="onBoxMouseDown">
 				<img
 					ref="imgRef"
@@ -27,39 +18,51 @@
 					draggable="false"
 					@load="onLoad" />
 				<div
-					v-if="cropRectStyle"
+					v-if="!disabled && cropRectStyle"
 					class="pointer-events-none absolute rounded-[2px] border border-white/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.35)]"
 					:style="cropRectStyle" />
 				<div
-					v-if="imageRect"
+					v-if="!disabled && imageRect"
 					class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
 					:style="dotStyle" />
-			</div>
-			<div
-				v-if="viewBox !== undefined && natural"
-				class="absolute -bottom-2 -right-2 hidden gap-1 group-hover/surface:flex [.is-dragging_&]:!hidden">
-				<Button
-					variant="subtle"
-					icon="minus"
-					:title="__('Zoom out')"
-					:disabled="zoom <= 1"
-					class="shadow-sm"
-					@click="stepZoom(-1)" />
-				<Button
-					variant="subtle"
-					icon="plus"
-					:title="__('Zoom in')"
-					:disabled="zoom >= 4"
-					class="shadow-sm"
-					@click="stepZoom(1)" />
+				<div
+					v-if="!disabled && imageRect && !dragging && !hasCustomValue"
+					class="pointer-events-none absolute bottom-1.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-black/60 px-2 py-0.5 text-xs text-white">
+					{{ __("Drag to set focal point") }}
+				</div>
 			</div>
 			<slot />
+		</div>
+		<div
+			v-if="!disabled && viewBox !== undefined && natural"
+			class="flex items-center gap-1.5"
+			:title="`${Math.round(zoom * 100)}%`">
+			<Button
+				variant="ghost"
+				icon="zoom-out"
+				:title="__('Zoom out')"
+				:disabled="zoom <= 1"
+				@click="stepZoom(-1)" />
+			<RangeInput
+				class="w-full"
+				hideInput
+				:modelValue="zoom"
+				:min="1"
+				:max="4"
+				:step="0.05"
+				@update:modelValue="(v: string | number) => emitViewBoxAt(Number(v), point.x, point.y)" />
+			<Button
+				variant="ghost"
+				icon="zoom-in"
+				:title="__('Zoom in')"
+				:disabled="zoom >= 4"
+				@click="stepZoom(1)" />
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-import InputLabel from "@/components/Controls/InputLabel.vue";
+import RangeInput from "@/components/Controls/RangeInput.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import { Button } from "frappe-ui";
 import { __ } from "@/translation";
@@ -75,6 +78,8 @@ const props = defineProps<{
 	viewBox?: string;
 	// aspect ratio of the element the image fills; draws the visible-part frame
 	targetRatio?: number;
+	// plain preview: no dot, frame, hint, or zoom (non-cover fits)
+	disabled?: boolean;
 }>();
 
 const emit = defineEmits(["update:modelValue", "update:viewBox"]);
@@ -162,6 +167,7 @@ let pauseId: PauseId | undefined = undefined;
 
 // a press on a slotted chip (upload/reset) is a click, never a drag
 function onBoxMouseDown(e: MouseEvent) {
+	if (props.disabled) return;
 	if ((e.target as HTMLElement).closest("button")) return;
 	e.preventDefault();
 	dragging.value = true;

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -14,7 +14,8 @@
 				<img
 					ref="imgRef"
 					:src="imageSrc"
-					class="pointer-events-none h-full w-full select-none object-contain"
+					class="pointer-events-none h-full w-full select-none"
+					:style="{ objectFit: disabled ? props.fit || 'contain' : 'contain' }"
 					draggable="false"
 					@load="onLoad" />
 				<div
@@ -25,18 +26,10 @@
 					v-if="!disabled && imageRect"
 					class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
 					:style="dotStyle" />
-				<div
-					v-if="!disabled && imageRect && !dragging && !hasCustomValue"
-					class="pointer-events-none absolute bottom-1.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-black/60 px-2 py-0.5 text-xs text-white">
-					{{ __("Drag to set focal point") }}
-				</div>
 			</div>
 			<slot />
 		</div>
-		<div
-			v-if="!disabled && viewBox !== undefined && natural"
-			class="flex items-center gap-1.5"
-			:title="`${Math.round(zoom * 100)}%`">
+		<div v-if="!disabled && viewBox !== undefined && natural" class="flex items-center gap-1.5">
 			<Button
 				variant="ghost"
 				icon="zoom-out"
@@ -80,6 +73,8 @@ const props = defineProps<{
 	targetRatio?: number;
 	// plain preview: no dot, frame, hint, or zoom (non-cover fits)
 	disabled?: boolean;
+	// the actual object-fit, so the plain preview mirrors what the element shows
+	fit?: string;
 }>();
 
 const emit = defineEmits(["update:modelValue", "update:viewBox"]);
@@ -114,8 +109,11 @@ const { width: rootWidth } = useElementSize(rootRef);
 // photo doesn't sit in a letterboxed band with dead space either side
 const MAX_BOX_H = 176;
 const boxSize = computed(() => {
-	if (!natural.value || !rootWidth.value) return null;
-	const ratio = natural.value.w / natural.value.h;
+	if (!rootWidth.value) return null;
+	// a plain preview mirrors the ELEMENT: its ratio, its fit — the interactive
+	// surface shows the whole image at the image's own ratio
+	const ratio = props.disabled ? props.targetRatio : natural.value && natural.value.w / natural.value.h;
+	if (!ratio) return null;
 	const w = Math.min(rootWidth.value, MAX_BOX_H * ratio);
 	return { width: `${Math.round(w)}px`, height: `${Math.round(w / ratio)}px` };
 });
@@ -147,8 +145,6 @@ const point = computed(() => {
 	}
 	return { x: parse(parts[0]), y: parse(parts[1]) };
 });
-
-const hasCustomValue = computed(() => Boolean((props.modelValue || "").trim()));
 
 const dotStyle = computed(() => {
 	const rect = imageRect.value;

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -149,12 +149,33 @@ const point = computed(() => {
 	return { x: parse(parts[0]), y: parse(parts[1]) };
 });
 
-const dotStyle = computed(() => {
-	const rect = imageRect.value;
-	if (!rect) return {};
+// with a view-box crop, object-position percentages are relative to the CROPPED
+// content — so the dot lives in window space, which also keeps it inside the frame
+const cropWindow = computed(() => {
+	if (!insets.value) return { x: 0, y: 0, spanX: 1, spanY: 1 };
 	return {
-		left: `${rect.x + (point.value.x / 100) * rect.w}px`,
-		top: `${rect.y + (point.value.y / 100) * rect.h}px`,
+		x: insets.value.left / 100,
+		y: insets.value.top / 100,
+		spanX: (100 - insets.value.left - insets.value.right) / 100,
+		spanY: (100 - insets.value.top - insets.value.bottom) / 100,
+	};
+});
+
+const dotPx = computed(() => {
+	const rect = imageRect.value;
+	if (!rect) return null;
+	const win = cropWindow.value;
+	return {
+		x: rect.x + (win.x + (point.value.x / 100) * win.spanX) * rect.w,
+		y: rect.y + (win.y + (point.value.y / 100) * win.spanY) * rect.h,
+	};
+});
+
+const dotStyle = computed(() => {
+	if (!dotPx.value) return {};
+	return {
+		left: `${dotPx.value.x}px`,
+		top: `${dotPx.value.y}px`,
 		transform: "translate(-50%, -50%)",
 	};
 });
@@ -165,11 +186,8 @@ const dragging = ref(false);
 let pauseId: PauseId | undefined = undefined;
 
 const overDot = computed(() => {
-	const rect = imageRect.value;
-	if (!rect) return false;
-	const dx = elementX.value - (rect.x + (point.value.x / 100) * rect.w);
-	const dy = elementY.value - (rect.y + (point.value.y / 100) * rect.h);
-	return Math.abs(dx) <= 8 && Math.abs(dy) <= 8;
+	if (!dotPx.value) return false;
+	return Math.abs(elementX.value - dotPx.value.x) <= 8 && Math.abs(elementY.value - dotPx.value.y) <= 8;
 });
 
 const overFrame = computed(() => {
@@ -231,8 +249,11 @@ function onBoxMouseDown(e: MouseEvent) {
 function setFromPointer() {
 	const rect = imageRect.value;
 	if (!rect) return;
-	const x = Math.round(Math.min(100, Math.max(0, ((elementX.value - rect.x) / rect.w) * 100)));
-	const y = Math.round(Math.min(100, Math.max(0, ((elementY.value - rect.y) / rect.h) * 100)));
+	const win = cropWindow.value;
+	const fx = ((elementX.value - rect.x) / rect.w - win.x) / win.spanX;
+	const fy = ((elementY.value - rect.y) / rect.h - win.y) / win.spanY;
+	const x = Math.round(Math.min(100, Math.max(0, fx * 100)));
+	const y = Math.round(Math.min(100, Math.max(0, fy * 100)));
 	emit("update:modelValue", `${x}% ${y}%`);
 }
 

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -13,7 +13,7 @@
 		<!-- chips slot beside the clipped box, not inside it, so they can straddle
 		     its edges without being cut by overflow-hidden -->
 		<div
-			class="relative mx-auto"
+			class="group/surface relative mx-auto"
 			:class="[boxSize ? '' : 'h-24 w-full', dragging && 'is-dragging']"
 			:style="boxSize || {}">
 			<div
@@ -35,25 +35,33 @@
 					class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
 					:style="dotStyle" />
 			</div>
+			<div
+				v-if="viewBox !== undefined && natural"
+				class="absolute -bottom-2 -right-2 hidden gap-1 group-hover/surface:flex [.is-dragging_&]:!hidden">
+				<Button
+					variant="subtle"
+					icon="minus"
+					:title="__('Zoom out')"
+					:disabled="zoom <= 1"
+					class="shadow-sm"
+					@click="stepZoom(-1)" />
+				<Button
+					variant="subtle"
+					icon="plus"
+					:title="__('Zoom in')"
+					:disabled="zoom >= 4"
+					class="shadow-sm"
+					@click="stepZoom(1)" />
+			</div>
 			<slot />
-		</div>
-		<div v-if="viewBox !== undefined && natural" class="flex items-center justify-between gap-2">
-			<InputLabel class="w-1/3 min-w-[88px] shrink-0">{{ __("Zoom") }}</InputLabel>
-			<RangeInput
-				class="w-full"
-				:modelValue="zoom"
-				:min="1"
-				:max="4"
-				:step="0.05"
-				@update:modelValue="(v: string | number) => emitViewBoxAt(Number(v), point.x, point.y)" />
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
 import InputLabel from "@/components/Controls/InputLabel.vue";
-import RangeInput from "@/components/Controls/RangeInput.vue";
 import useCanvasStore from "@/stores/canvasStore";
+import { Button } from "frappe-ui";
 import { __ } from "@/translation";
 import type { PauseId } from "@/utils/useCanvasHistory";
 import { useElementSize, useMouseInElement } from "@vueuse/core";
@@ -198,6 +206,11 @@ const zoom = computed(() => {
 	const span = 100 - insets.value.left - insets.value.right;
 	return span > 0 ? Math.round((100 / span) * 20) / 20 : 1;
 });
+
+function stepZoom(dir: number) {
+	const z = Math.min(4, Math.max(1, Math.round((zoom.value + dir * 0.25) * 20) / 20));
+	emitViewBoxAt(z, point.value.x, point.value.y);
+}
 
 function emitViewBoxAt(z: number, fx: number, fy: number) {
 	if (props.viewBox === undefined) return;

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -110,9 +110,14 @@ const { width: rootWidth } = useElementSize(rootRef);
 const MAX_BOX_H = 176;
 const boxSize = computed(() => {
 	if (!rootWidth.value) return null;
-	// a plain preview mirrors the ELEMENT: its ratio, its fit — the interactive
-	// surface shows the whole image at the image's own ratio
-	const ratio = props.disabled ? props.targetRatio : natural.value && natural.value.w / natural.value.h;
+	// a plain preview mirrors the ELEMENT: full width, its ratio, its fit — the
+	// interactive surface shows the whole image at the image's own ratio
+	if (props.disabled) {
+		if (!props.targetRatio) return null;
+		const h = Math.min(MAX_BOX_H, rootWidth.value / props.targetRatio);
+		return { width: `${Math.round(rootWidth.value)}px`, height: `${Math.round(h)}px` };
+	}
+	const ratio = natural.value && natural.value.w / natural.value.h;
 	if (!ratio) return null;
 	const w = Math.min(rootWidth.value, MAX_BOX_H * ratio);
 	return { width: `${Math.round(w)}px`, height: `${Math.round(w / ratio)}px` };

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -9,7 +9,7 @@
 			<div
 				ref="boxRef"
 				class="relative h-full w-full overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
-				:class="disabled ? '' : 'cursor-crosshair'"
+				:class="disabled ? '' : cursorClass"
 				@mousedown="onBoxMouseDown">
 				<img
 					ref="imgRef"
@@ -43,7 +43,7 @@
 				:min="1"
 				:max="4"
 				:step="0.05"
-				@update:modelValue="(v: string | number) => emitViewBoxAt(Number(v), point.x, point.y)" />
+				@update:modelValue="(v: string | number) => setZoom(Number(v))" />
 			<Button
 				variant="ghost"
 				icon="zoom-in"
@@ -164,15 +164,55 @@ const { elementX, elementY } = useMouseInElement(boxRef);
 const dragging = ref(false);
 let pauseId: PauseId | undefined = undefined;
 
+const overDot = computed(() => {
+	const rect = imageRect.value;
+	if (!rect) return false;
+	const dx = elementX.value - (rect.x + (point.value.x / 100) * rect.w);
+	const dy = elementY.value - (rect.y + (point.value.y / 100) * rect.h);
+	return Math.abs(dx) <= 8 && Math.abs(dy) <= 8;
+});
+
+const overFrame = computed(() => {
+	const frame = cropRect.value;
+	if (!frame || !insets.value) return false;
+	return (
+		elementX.value >= frame.x &&
+		elementX.value <= frame.x + frame.w &&
+		elementY.value >= frame.y &&
+		elementY.value <= frame.y + frame.h
+	);
+});
+
+// the frame pans the crop window (hand), everywhere else places the focal dot
+const cursorClass = computed(() => {
+	if (dragging.value) return dragMode === "window" ? "cursor-grabbing" : "cursor-crosshair";
+	if (!overDot.value && overFrame.value) return "cursor-grab";
+	return "cursor-crosshair";
+});
+
+let dragMode: "point" | "window" = "point";
+
 // a press on a slotted chip (upload/reset) is a click, never a drag
 function onBoxMouseDown(e: MouseEvent) {
 	if (props.disabled) return;
 	if ((e.target as HTMLElement).closest("button")) return;
 	e.preventDefault();
+	dragMode = !overDot.value && overFrame.value ? "window" : "point";
 	dragging.value = true;
 	pauseId = canvasStore.activeCanvas?.history?.pause();
-	setFromPointer();
-	const onMove = () => setFromPointer();
+	const rect = imageRect.value;
+	const start = { x: elementX.value, y: elementY.value, insets: insets.value };
+	const onMove = () => {
+		if (dragMode === "window" && rect && start.insets) {
+			const span = 100 - start.insets.left - start.insets.right;
+			const dx = ((elementX.value - start.x) / rect.w) * 100;
+			const dy = ((elementY.value - start.y) / rect.h) * 100;
+			emitWindow(start.insets.left + dx, start.insets.top + dy, span);
+		} else {
+			setFromPointer();
+		}
+	};
+	if (dragMode === "point") setFromPointer();
 	document.addEventListener("mousemove", onMove);
 	document.addEventListener(
 		"mouseup",
@@ -194,7 +234,6 @@ function setFromPointer() {
 	const x = Math.round(Math.min(100, Math.max(0, ((elementX.value - rect.x) / rect.w) * 100)));
 	const y = Math.round(Math.min(100, Math.max(0, ((elementY.value - rect.y) / rect.h) * 100)));
 	emit("update:modelValue", `${x}% ${y}%`);
-	if (zoom.value > 1) emitViewBoxAt(zoom.value, x, y);
 }
 
 // --- zoom crop (objectViewBox inset window centred on the focus point) -----
@@ -213,27 +252,38 @@ const zoom = computed(() => {
 });
 
 function stepZoom(dir: number) {
-	const z = Math.min(4, Math.max(1, Math.round((zoom.value + dir * 0.25) * 20) / 20));
-	emitViewBoxAt(z, point.value.x, point.value.y);
+	setZoom(Math.min(4, Math.max(1, Math.round((zoom.value + dir * 0.25) * 20) / 20)));
 }
 
-function emitViewBoxAt(z: number, fx: number, fy: number) {
+function setZoom(z: number) {
 	if (props.viewBox === undefined) return;
 	if (z <= 1.001) {
 		emit("update:viewBox", "");
 		return;
 	}
 	const span = 100 / z;
-	const left = (fx / 100) * (100 - span);
-	const top = (fy / 100) * (100 - span);
+	let cx = point.value.x;
+	let cy = point.value.y;
+	if (insets.value) {
+		const span0 = 100 - insets.value.left - insets.value.right;
+		cx = insets.value.left + span0 / 2;
+		cy = insets.value.top + span0 / 2;
+	}
+	emitWindow(cx - span / 2, cy - span / 2, span);
+}
+
+function emitWindow(left: number, top: number, span: number) {
+	const clamp = (n: number) => Math.min(100 - span, Math.max(0, n));
 	const f = (n: number) => Math.round(n * 10) / 10;
-	emit("update:viewBox", `inset(${f(top)}% ${f(100 - span - left)}% ${f(100 - span - top)}% ${f(left)}%)`);
+	const l = clamp(left);
+	const t = clamp(top);
+	emit("update:viewBox", `inset(${f(t)}% ${f(100 - span - l)}% ${f(100 - span - t)}% ${f(l)}%)`);
 }
 
 // The white frame: the part of the image the element ACTUALLY shows — the zoom
 // window narrowed by the cover fit against the element's own aspect ratio, so
 // dragging the dot slides the frame exactly as the crop slides on canvas.
-const cropRectStyle = computed(() => {
+const cropRect = computed(() => {
 	const rect = imageRect.value;
 	if (!rect || !natural.value || !(insets.value || props.targetRatio)) return null;
 	const winX = (insets.value?.left ?? 0) / 100;
@@ -256,11 +306,12 @@ const cropRectStyle = computed(() => {
 			h = spanY * frac;
 		}
 	}
-	return {
-		left: `${rect.x + x * rect.w}px`,
-		top: `${rect.y + y * rect.h}px`,
-		width: `${w * rect.w}px`,
-		height: `${h * rect.h}px`,
-	};
+	return { x: rect.x + x * rect.w, y: rect.y + y * rect.h, w: w * rect.w, h: h * rect.h };
+});
+
+const cropRectStyle = computed(() => {
+	const frame = cropRect.value;
+	if (!frame) return null;
+	return { left: `${frame.x}px`, top: `${frame.y}px`, width: `${frame.w}px`, height: `${frame.h}px` };
 });
 </script>

--- a/frontend/src/components/Controls/ImageFocusInput.vue
+++ b/frontend/src/components/Controls/ImageFocusInput.vue
@@ -10,42 +10,66 @@
 				{{ __("Reset") }}
 			</button>
 		</div>
+		<!-- chips slot beside the clipped box, not inside it, so they can straddle
+		     its edges without being cut by overflow-hidden -->
 		<div
-			ref="boxRef"
-			class="relative mx-auto cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+			class="relative mx-auto"
 			:class="[boxSize ? '' : 'h-24 w-full', dragging && 'is-dragging']"
-			:style="boxSize || {}"
-			@mousedown="onBoxMouseDown">
-			<img
-				ref="imgRef"
-				:src="imageSrc"
-				class="pointer-events-none h-full w-full select-none object-contain"
-				draggable="false"
-				@load="onLoad" />
+			:style="boxSize || {}">
 			<div
-				v-if="imageRect"
-				class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
-				:style="dotStyle" />
+				ref="boxRef"
+				class="relative h-full w-full cursor-crosshair overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+				@mousedown="onBoxMouseDown">
+				<img
+					ref="imgRef"
+					:src="imageSrc"
+					class="pointer-events-none h-full w-full select-none object-contain"
+					draggable="false"
+					@load="onLoad" />
+				<div
+					v-if="cropRectStyle"
+					class="pointer-events-none absolute rounded-[2px] border border-white/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.35)]"
+					:style="cropRectStyle" />
+				<div
+					v-if="imageRect"
+					class="pointer-events-none absolute size-3 rounded-full border-2 border-white shadow-[0_0_0_1.5px_rgba(0,0,0,0.45)]"
+					:style="dotStyle" />
+			</div>
 			<slot />
+		</div>
+		<div v-if="viewBox !== undefined && natural" class="flex items-center justify-between gap-2">
+			<InputLabel class="w-1/3 min-w-[88px] shrink-0">{{ __("Zoom") }}</InputLabel>
+			<RangeInput
+				class="w-full"
+				:modelValue="zoom"
+				:min="1"
+				:max="4"
+				:step="0.05"
+				@update:modelValue="(v: string | number) => emitViewBoxAt(Number(v), point.x, point.y)" />
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
 import InputLabel from "@/components/Controls/InputLabel.vue";
+import RangeInput from "@/components/Controls/RangeInput.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import { __ } from "@/translation";
 import type { PauseId } from "@/utils/useCanvasHistory";
 import { useElementSize, useMouseInElement } from "@vueuse/core";
-import { computed, ref } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 const props = defineProps<{
 	modelValue?: string;
 	imageSrc: string;
 	label?: string;
+	// objectViewBox inset; pass it (even empty) to get the zoom-crop slider
+	viewBox?: string;
+	// aspect ratio of the element the image fills; draws the visible-part frame
+	targetRatio?: number;
 }>();
 
-const emit = defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue", "update:viewBox"]);
 
 const canvasStore = useCanvasStore();
 
@@ -58,6 +82,17 @@ const onLoad = () => {
 	const img = imgRef.value;
 	if (img?.naturalWidth) natural.value = { w: img.naturalWidth, h: img.naturalHeight };
 };
+
+// a cached image can be complete before the load listener attaches; without this
+// the box never learns the ratio and falls back to the letterboxed strip
+onMounted(onLoad);
+watch(
+	() => props.imageSrc,
+	() => {
+		natural.value = null;
+		void nextTick(onLoad);
+	},
+);
 
 const { width: boxWidth, height: boxHeight } = useElementSize(boxRef);
 const { width: rootWidth } = useElementSize(rootRef);
@@ -146,5 +181,68 @@ function setFromPointer() {
 	const x = Math.round(Math.min(100, Math.max(0, ((elementX.value - rect.x) / rect.w) * 100)));
 	const y = Math.round(Math.min(100, Math.max(0, ((elementY.value - rect.y) / rect.h) * 100)));
 	emit("update:modelValue", `${x}% ${y}%`);
+	if (zoom.value > 1) emitViewBoxAt(zoom.value, x, y);
 }
+
+// --- zoom crop (objectViewBox inset window centred on the focus point) -----
+
+const insets = computed(() => {
+	const m = (props.viewBox || "").match(/inset\(\s*([\d.]+)%\s+([\d.]+)%\s+([\d.]+)%\s+([\d.]+)%\s*\)/);
+	if (!m) return null;
+	const [top, right, bottom, left] = m.slice(1).map(Number);
+	return { top, right, bottom, left };
+});
+
+const zoom = computed(() => {
+	if (!insets.value) return 1;
+	const span = 100 - insets.value.left - insets.value.right;
+	return span > 0 ? Math.round((100 / span) * 20) / 20 : 1;
+});
+
+function emitViewBoxAt(z: number, fx: number, fy: number) {
+	if (props.viewBox === undefined) return;
+	if (z <= 1.001) {
+		emit("update:viewBox", "");
+		return;
+	}
+	const span = 100 / z;
+	const left = (fx / 100) * (100 - span);
+	const top = (fy / 100) * (100 - span);
+	const f = (n: number) => Math.round(n * 10) / 10;
+	emit("update:viewBox", `inset(${f(top)}% ${f(100 - span - left)}% ${f(100 - span - top)}% ${f(left)}%)`);
+}
+
+// The white frame: the part of the image the element ACTUALLY shows — the zoom
+// window narrowed by the cover fit against the element's own aspect ratio, so
+// dragging the dot slides the frame exactly as the crop slides on canvas.
+const cropRectStyle = computed(() => {
+	const rect = imageRect.value;
+	if (!rect || !natural.value || !(insets.value || props.targetRatio)) return null;
+	const winX = (insets.value?.left ?? 0) / 100;
+	const winY = (insets.value?.top ?? 0) / 100;
+	const spanX = insets.value ? (100 - insets.value.left - insets.value.right) / 100 : 1;
+	const spanY = insets.value ? (100 - insets.value.top - insets.value.bottom) / 100 : 1;
+	let x = winX;
+	let y = winY;
+	let w = spanX;
+	let h = spanY;
+	if (props.targetRatio) {
+		const contentRatio = (natural.value.w * spanX) / (natural.value.h * spanY);
+		if (contentRatio > props.targetRatio) {
+			const frac = props.targetRatio / contentRatio;
+			x = winX + (point.value.x / 100) * spanX * (1 - frac);
+			w = spanX * frac;
+		} else if (contentRatio < props.targetRatio) {
+			const frac = contentRatio / props.targetRatio;
+			y = winY + (point.value.y / 100) * spanY * (1 - frac);
+			h = spanY * frac;
+		}
+	}
+	return {
+		left: `${rect.x + x * rect.w}px`,
+		top: `${rect.y + y * rect.h}px`,
+		width: `${w * rect.w}px`,
+		height: `${h * rect.h}px`,
+	};
+});
 </script>

--- a/frontend/src/components/Controls/RangeInput.vue
+++ b/frontend/src/components/Controls/RangeInput.vue
@@ -2,6 +2,7 @@
 	<div class="flex items-center gap-2">
 		<InputLabel v-if="label">{{ label }}</InputLabel>
 		<BuilderInput
+			v-if="!hideInput"
 			:modelValue="modelValue"
 			:hideClearButton="true"
 			type="number"
@@ -36,6 +37,8 @@ const props = defineProps<{
 	max?: number;
 	step?: number;
 	placeholder?: string;
+	// slider-only mode: no number field beside the track
+	hideInput?: boolean;
 }>();
 const emit = defineEmits(["update:modelValue", "focus", "blur"]);
 const inputRef = ref<HTMLInputElement | null>(null);

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -47,21 +47,8 @@
 				</template>
 				<template #body>
 					<div class="w-64 rounded-lg bg-surface-base p-3 shadow-lg">
-						<div v-if="objectPosition !== undefined" class="mb-3 flex items-center justify-between gap-2">
+						<div v-if="objectPosition !== undefined" class="mb-3 flex items-center">
 							<span class="text-sm font-semibold text-ink-gray-9">{{ __("Image") }}</span>
-							<div class="flex items-center gap-1.5">
-								<Button
-									variant="outline"
-									iconLeft="upload"
-									:label="__('Replace')"
-									@click="openFileSelector" />
-								<Button
-									variant="outline"
-									icon="rotate-ccw"
-									:title="__('Reset focal point')"
-									:disabled="!objectPosition && !objectViewBox"
-									@click="resetFocus" />
-							</div>
 						</div>
 						<div v-if="objectPosition !== undefined" class="mb-3">
 							<TabButtons
@@ -78,9 +65,15 @@
 							:modelValue="objectPosition"
 							:viewBox="objectViewBox"
 							:targetRatio="targetRatio"
+							:fit="imageFit"
 							:disabled="imageFit !== 'cover'"
 							@update:modelValue="(val) => emit('update:objectPosition', val)"
 							@update:viewBox="(val) => emit('update:objectViewBox', val)" />
+						<div
+							v-else-if="objectPosition !== undefined"
+							class="flex h-24 items-center justify-center rounded border border-dashed border-outline-gray-2 text-p-xs text-ink-gray-4">
+							{{ __("No image") }}
+						</div>
 						<div v-else class="group relative flex items-center justify-center overflow-hidden rounded">
 							<img
 								:src="currentImageURL || '/assets/builder/images/fallback.png'"
@@ -97,6 +90,20 @@
 								}">
 								<Button variant="subtle" @click="openFileSelector">{{ __("Upload") }}</Button>
 							</div>
+						</div>
+						<div v-if="objectPosition !== undefined" class="mt-3 flex items-center gap-1.5">
+							<Button
+								class="flex-1"
+								variant="outline"
+								iconLeft="upload"
+								:label="currentImageURL ? __('Replace') : __('Upload')"
+								@click="openFileSelector" />
+							<Button
+								variant="outline"
+								icon="rotate-ccw"
+								:title="__('Reset focal point')"
+								:disabled="!objectPosition && !objectViewBox"
+								@click="resetFocus" />
 						</div>
 						<InlineInput
 							v-if="objectPosition === undefined"

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -46,37 +46,46 @@
 					</div>
 				</template>
 				<template #body>
-					<div class="rounded-lg bg-surface-base p-3 shadow-lg">
-						<!-- With a cover fit the preview IS the focus-point surface: one image,
-						     drag to frame the crop, Upload/Reset ride it as hover chips. -->
-						<div v-if="focusEnabled" class="group relative w-48">
-							<ImageFocusInput
-								:imageSrc="currentImageURL"
-								:modelValue="objectPosition"
-								:viewBox="objectViewBox"
-								:targetRatio="targetRatio"
-								@update:modelValue="(val) => emit('update:objectPosition', val)"
-								@update:viewBox="(val) => emit('update:objectViewBox', val)">
+					<div class="w-64 rounded-lg bg-surface-base p-3 shadow-lg">
+						<div v-if="objectPosition !== undefined" class="mb-3 flex items-center justify-between gap-2">
+							<span class="text-sm font-semibold text-ink-gray-9">{{ __("Image") }}</span>
+							<div class="flex items-center gap-1.5">
 								<Button
-									variant="subtle"
-									icon="upload"
-									:title="__('Upload image')"
-									class="absolute -right-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									variant="outline"
+									iconLeft="upload"
+									:label="__('Replace')"
 									@click="openFileSelector" />
 								<Button
-									v-if="objectPosition || objectViewBox"
-									variant="subtle"
+									variant="outline"
 									icon="rotate-ccw"
-									:title="__('Reset focus point')"
-									class="absolute -left-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									:title="__('Reset focal point')"
+									:disabled="!objectPosition && !objectViewBox"
 									@click="resetFocus" />
-							</ImageFocusInput>
+							</div>
 						</div>
+						<div v-if="objectPosition !== undefined" class="mb-3">
+							<TabButtons
+								:class="STRETCH_TABS"
+								:options="fitOptions"
+								:modelValue="imageFit || 'contain'"
+								@update:modelValue="setImageFit" />
+						</div>
+						<!-- one surface for every fit: interactive (dot, frame, zoom) when the
+						     cover crop makes a focal point meaningful, plain preview otherwise -->
+						<ImageFocusInput
+							v-if="currentImageURL && objectPosition !== undefined"
+							:imageSrc="currentImageURL"
+							:modelValue="objectPosition"
+							:viewBox="objectViewBox"
+							:targetRatio="targetRatio"
+							:disabled="imageFit !== 'cover'"
+							@update:modelValue="(val) => emit('update:objectPosition', val)"
+							@update:viewBox="(val) => emit('update:objectViewBox', val)" />
 						<div v-else class="group relative flex items-center justify-center overflow-hidden rounded">
 							<img
 								:src="currentImageURL || '/assets/builder/images/fallback.png'"
 								alt=""
-								class="image-preview relative h-24 w-48 cursor-pointer bg-surface-gray-2"
+								class="image-preview relative h-24 w-full cursor-pointer bg-surface-gray-2"
 								:style="{
 									'object-fit': imageFit || 'contain',
 								}" />
@@ -90,6 +99,7 @@
 							</div>
 						</div>
 						<InlineInput
+							v-if="objectPosition === undefined"
 							:label="__('Image Fit')"
 							class="mt-4"
 							:modelValue="imageFit"
@@ -114,7 +124,8 @@ import ImageUploader from "@/components/Controls/ImageUploader.vue";
 import InlineInput from "@/components/Controls/InlineInput.vue";
 import InputLabel from "@/components/Controls/InputLabel.vue";
 import useBuilderStore from "@/stores/builderStore";
-import { FileUploader, Popover } from "frappe-ui";
+import { STRETCH_TABS } from "@/utils/tabButtons";
+import { FileUploader, Popover, TabButtons } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
 const props = withDefaults(
@@ -154,9 +165,13 @@ watch(
 );
 
 const currentImageURL = computed(() => props.modelValue || "");
-const focusEnabled = computed(
-	() => props.objectPosition !== undefined && props.imageFit === "cover" && Boolean(currentImageURL.value),
-);
+
+const fitOptions = [
+	{ label: __("Fill & crop"), value: "cover" },
+	{ label: __("Fit"), value: "contain" },
+	{ label: __("Stretch"), value: "fill" },
+];
+
 const emit = defineEmits([
 	"update:imageFit",
 	"update:modelValue",

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -15,9 +15,6 @@
 						<InputLabel v-if="label && labelPosition === 'left'">{{ label }}</InputLabel>
 						<div class="relative w-full [&>div>div>div>div]:pe-0">
 							<BuilderInput
-								:class="{
-									'[&>input]:pl-8': labelPosition === 'left',
-								}"
 								type="text"
 								:label="labelPosition === 'top' ? label : null"
 								:placeholder="placeholder"
@@ -25,6 +22,16 @@
 								:hideClearButton="labelPosition === 'top'"
 								@update:modelValue="setImageURL"
 								:modelValue="currentImageURL">
+								<template v-if="labelPosition === 'left'" #prefix>
+									<img
+										:src="currentImageURL || '/assets/builder/images/fallback.png'"
+										alt=""
+										@click="togglePopover"
+										class="h-4 w-4 cursor-pointer rounded border border-outline-gray-3 shadow-sm"
+										:style="{
+											'object-fit': imageFit || 'contain',
+										}" />
+								</template>
 								<template v-if="labelPosition === 'top'" #suffix>
 									<ImageUploader
 										@upload="setImageURL"
@@ -33,15 +40,6 @@
 										:file_types="['image/*']" />
 								</template>
 							</BuilderInput>
-							<img
-								v-if="labelPosition === 'left'"
-								:src="currentImageURL || '/assets/builder/images/fallback.png'"
-								alt=""
-								@click="togglePopover"
-								class="absolute bottom-[6px] left-2 h-4 w-4 rounded border border-outline-gray-3 shadow-sm"
-								:style="{
-									'object-fit': imageFit || 'contain',
-								}" />
 						</div>
 					</div>
 				</template>

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -47,7 +47,29 @@
 				</template>
 				<template #body>
 					<div class="rounded-lg bg-surface-base p-3 shadow-lg">
-						<div class="group relative flex items-center justify-center overflow-hidden rounded">
+						<!-- With a cover fit the preview IS the focus-point surface: one image,
+						     drag to frame the crop, Upload/Reset ride it as hover chips. -->
+						<div v-if="focusEnabled" class="group relative w-48">
+							<ImageFocusInput
+								:imageSrc="currentImageURL"
+								:modelValue="objectPosition"
+								@update:modelValue="(val) => emit('update:objectPosition', val)">
+								<Button
+									variant="subtle"
+									icon="upload"
+									:title="__('Upload image')"
+									class="absolute right-1 top-1 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									@click="openFileSelector" />
+								<Button
+									v-if="objectPosition"
+									variant="subtle"
+									icon="rotate-ccw"
+									:title="__('Reset focus point')"
+									class="absolute left-1 top-1 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									@click="emit('update:objectPosition', '')" />
+							</ImageFocusInput>
+						</div>
+						<div v-else class="group relative flex items-center justify-center overflow-hidden rounded">
 							<img
 								:src="currentImageURL || '/assets/builder/images/fallback.png'"
 								alt=""
@@ -76,13 +98,6 @@
 								{ label: __('Original Size'), value: 'none' },
 							]"
 							@update:modelValue="setImageFit" />
-						<ImageFocusInput
-							v-if="objectPosition !== undefined && imageFit === 'cover' && currentImageURL"
-							class="mt-4"
-							:label="__('Focus Point')"
-							:imageSrc="currentImageURL"
-							:modelValue="objectPosition"
-							@update:modelValue="(val) => emit('update:objectPosition', val)" />
 					</div>
 				</template>
 			</Popover>
@@ -134,6 +149,9 @@ watch(
 );
 
 const currentImageURL = computed(() => props.modelValue || "");
+const focusEnabled = computed(
+	() => props.objectPosition !== undefined && props.imageFit === "cover" && Boolean(currentImageURL.value),
+);
 const emit = defineEmits(["update:imageFit", "update:modelValue", "update:objectPosition"]);
 
 const setImageURL = (fileURL: string) => {

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -76,6 +76,13 @@
 								{ label: __('Original Size'), value: 'none' },
 							]"
 							@update:modelValue="setImageFit" />
+						<ImageFocusInput
+							v-if="objectPosition !== undefined && imageFit === 'cover' && currentImageURL"
+							class="mt-4"
+							:label="__('Focus Point')"
+							:imageSrc="currentImageURL"
+							:modelValue="objectPosition"
+							@update:modelValue="(val) => emit('update:objectPosition', val)" />
 					</div>
 				</template>
 			</Popover>
@@ -84,6 +91,7 @@
 </template>
 <script lang="ts" setup>
 import { __ } from "@/translation";
+import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
 import ImageUploader from "@/components/Controls/ImageUploader.vue";
 import InlineInput from "@/components/Controls/InlineInput.vue";
 import InputLabel from "@/components/Controls/InputLabel.vue";
@@ -99,6 +107,8 @@ const props = withDefaults(
 		labelPosition?: "top" | "left";
 		placeholder?: string;
 		imageFit?: "contain" | "cover" | "fill" | "none";
+		// pass it (even empty) to get the focus-point picker for cover fits
+		objectPosition?: string;
 		description?: string;
 		popoverOffset?: number;
 	}>(),
@@ -124,7 +134,7 @@ watch(
 );
 
 const currentImageURL = computed(() => props.modelValue || "");
-const emit = defineEmits(["update:imageFit", "update:modelValue"]);
+const emit = defineEmits(["update:imageFit", "update:modelValue", "update:objectPosition"]);
 
 const setImageURL = (fileURL: string) => {
 	emit("update:modelValue", fileURL);

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -53,20 +53,23 @@
 							<ImageFocusInput
 								:imageSrc="currentImageURL"
 								:modelValue="objectPosition"
-								@update:modelValue="(val) => emit('update:objectPosition', val)">
+								:viewBox="objectViewBox"
+								:targetRatio="targetRatio"
+								@update:modelValue="(val) => emit('update:objectPosition', val)"
+								@update:viewBox="(val) => emit('update:objectViewBox', val)">
 								<Button
 									variant="subtle"
 									icon="upload"
 									:title="__('Upload image')"
-									class="absolute right-1 top-1 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									class="absolute -right-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
 									@click="openFileSelector" />
 								<Button
-									v-if="objectPosition"
+									v-if="objectPosition || objectViewBox"
 									variant="subtle"
 									icon="rotate-ccw"
 									:title="__('Reset focus point')"
-									class="absolute left-1 top-1 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
-									@click="emit('update:objectPosition', '')" />
+									class="absolute -left-2 -top-2 hidden shadow-sm group-hover:flex [.is-dragging_&]:!hidden"
+									@click="resetFocus" />
 							</ImageFocusInput>
 						</div>
 						<div v-else class="group relative flex items-center justify-center overflow-hidden rounded">
@@ -122,8 +125,10 @@ const props = withDefaults(
 		labelPosition?: "top" | "left";
 		placeholder?: string;
 		imageFit?: "contain" | "cover" | "fill" | "none";
-		// pass it (even empty) to get the focus-point picker for cover fits
+		// pass them (even empty) to get the focus-point picker / zoom crop for cover fits
 		objectPosition?: string;
+		objectViewBox?: string;
+		targetRatio?: number;
 		description?: string;
 		popoverOffset?: number;
 	}>(),
@@ -152,7 +157,17 @@ const currentImageURL = computed(() => props.modelValue || "");
 const focusEnabled = computed(
 	() => props.objectPosition !== undefined && props.imageFit === "cover" && Boolean(currentImageURL.value),
 );
-const emit = defineEmits(["update:imageFit", "update:modelValue", "update:objectPosition"]);
+const emit = defineEmits([
+	"update:imageFit",
+	"update:modelValue",
+	"update:objectPosition",
+	"update:objectViewBox",
+]);
+
+const resetFocus = () => {
+	emit("update:objectPosition", "");
+	emit("update:objectViewBox", "");
+};
 
 const setImageURL = (fileURL: string) => {
 	emit("update:modelValue", fileURL);

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -71,7 +71,7 @@
 							@update:viewBox="(val) => emit('update:objectViewBox', val)" />
 						<div
 							v-else-if="objectPosition !== undefined"
-							class="flex h-24 items-center justify-center rounded border border-dashed border-outline-gray-2 text-p-xs text-ink-gray-4">
+							class="flex h-24 items-center justify-center rounded border border-dashed border-outline-gray-2 bg-surface-gray-1 text-p-xs text-ink-gray-4">
 							{{ __("No image") }}
 						</div>
 						<div v-else class="group relative flex items-center justify-center overflow-hidden rounded">

--- a/frontend/src/utils/blockController.ts
+++ b/frontend/src/utils/blockController.ts
@@ -294,6 +294,13 @@ const blockController = {
 	canHaveChildren: () => {
 		return blockController.isBlockSelected() && blockController.getFirstSelectedBlock().canHaveChildren();
 	},
+	// rendered aspect ratio of the first selected block's canvas element
+	getSelectedBlockAspectRatio: (): number | undefined => {
+		const block = canvasStore.activeCanvas?.selectedBlocks[0];
+		if (!block) return undefined;
+		const el = document.querySelector(`[data-block-id="${block.blockId}"]`) as HTMLElement | null;
+		return el && el.offsetHeight ? el.offsetWidth / el.offsetHeight : undefined;
+	},
 	convertToLink: async () => {
 		const blocks = blockController.getSelectedBlocks();
 		for (const block of blocks) {


### PR DESCRIPTION
## What

Adjusting an image's crop meant hand-typing `object-position`. The image popover is now a small card: fit tabs (Fill & crop / Fit / Stretch), a preview that doubles as a focal-point picker for cover fits (drag the dot, the crop follows live on the canvas), a zoom slider that crops in around the focal point, and Replace/Reset buttons. Blocks with a cover background image get the same picker in the Background popover.

- Focus writes `object-position`, zoom writes `object-view-box` (Firefox ignores it and falls back to the plain cover crop), backgrounds use `background-position`.
- Breakpoint-aware like any style, one undo entry per drag, and existing keyword values (`top`, `bottom right`) parse correctly.
- The Layout section no longer renders for img/svg/video/input blocks, since they can't hold children.

## Demo

https://github.com/user-attachments/assets/6c21ea78-8ae3-423e-ad8d-6a50e241947a



