### PR TITLE
feat(font-picker): preview the selected font and design tokens in their own typeface

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -28,6 +28,7 @@
 					@keydown.enter="handleEnter"
 					:display-value="getDisplayValue"
 					:placeholder="placeholder"
+					:style="inputStyle"
 					class="h-full w-full flex-1 border-none bg-transparent px-0 text-base placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 					:class="{
 						'pl-2': !$slots.prefix,
@@ -159,6 +160,9 @@ interface Props {
 	// token's name instead of var(--id); the combobox still selects by value
 	displayValue?: string | null;
 	placeholder?: string;
+	// styles the field's own text, for values that are worth rendering as a specimen
+	// (a font family set in that family); the options keep using `labelStyle`
+	inputStyle?: StyleValue;
 	showInputAsOption?: boolean;
 	actionButton?: ActionButton;
 	referenceElementSelector?: string;

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -11,6 +11,7 @@
 				:placeholder="displayPlaceholder"
 				:getOptions="getOptions"
 				:actionButton="{ component: FontUploader }"
+				:inputStyle="inputStyle"
 				@update:modelValue="handleUpdate" />
 		</Tooltip>
 	</div>
@@ -35,7 +36,6 @@ const props = withDefaults(
 	}>(),
 	{
 		modelValue: null,
-		placeholder: __("Set Font"),
 	},
 );
 
@@ -50,13 +50,11 @@ type FontOption = {
 const { fontTokens, resolveVariableValue, getVariableName } = useBuilderToken();
 const fontInput = ref<typeof Autocomplete | null>(null);
 
-const isCssVariable = computed(
-	() =>
-		typeof props.modelValue === "string" &&
-		(props.modelValue.startsWith("var(--") || props.modelValue.startsWith("--")),
-);
+const isToken = (value?: string | null): value is string =>
+	typeof value === "string" && (value.startsWith("var(--") || value.startsWith("--"));
 
-// resolve a Font token to its real family so the specimen renders in it
+const isCssVariable = computed(() => isToken(props.modelValue));
+
 const resolvedFont = computed(() => {
 	if (!props.modelValue) return "inherit";
 	return isCssVariable.value ? resolveVariableValue(props.modelValue) : props.modelValue;
@@ -73,10 +71,18 @@ const displayValue = computed(() => {
 // a cascading/inherited placeholder may itself be a token — show its name, not var(--uuid)
 const displayPlaceholder = computed(() => {
 	const p = props.placeholder;
-	if (typeof p === "string" && (p.startsWith("var(--") || p.startsWith("--"))) {
-		return getVariableName(p) ?? p;
-	}
-	return p;
+	if (!p) return __("Set Font");
+	return isToken(p) ? getVariableName(p) ?? p : p;
+});
+
+// the field doubles as a specimen: whatever family name it shows — the one that is set,
+// or the inherited one standing in as placeholder — is rendered in that family. Both are
+// already applied on the canvas, so the face is loaded. A token shows its own name rather
+// than a family, so it keeps the mono treatment that marks it as one.
+const inputStyle = computed(() => {
+	const family = props.modelValue || props.placeholder;
+	if (!family || isToken(family)) return undefined;
+	return { fontFamily: family };
 });
 
 const handleUpdate = (val: string | null) => emit("update:modelValue", val);

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -45,6 +45,7 @@ type FontOption = {
 	label: string;
 	value: string;
 	labelStyle?: () => { fontFamily: string } | undefined;
+	previewFont?: string;
 };
 
 const { fontTokens, resolveVariableValue, getVariableName } = useBuilderToken();
@@ -95,6 +96,7 @@ const getOptions = async (filterString: string) => {
 		label: family,
 		value: family,
 		labelStyle: () => previewFontStyle(family),
+		previewFont: family,
 	});
 	// a token's name is what the field shows when one is picked, and it matches no
 	// family: filtering the font lists by it would leave only the token to choose from
@@ -104,10 +106,17 @@ const getOptions = async (filterString: string) => {
 	// token updates every block bound to it. The family is part of the label, so
 	// it stays searchable.
 	const tokenOptions = filterOptions(
-		fontTokens.value.map((token: BuilderToken) => ({
-			label: `${token.token_name || token.value} (${token.value})`,
-			value: `var(--${token.name})`,
-		})),
+		fontTokens.value.map((token: BuilderToken) => {
+			const label = `${token.token_name || token.value} (${token.value})`;
+			// previewed against the whole label, since it carries the token's name as well
+			// as the family, and a subset cut to the family alone could not render it
+			return {
+				label,
+				value: `var(--${token.name})`,
+				labelStyle: () => previewFontStyle(label),
+				previewFont: token.value as string,
+			};
+		}),
 		filterString,
 	);
 	const userFontOptions = filterOptions(
@@ -132,9 +141,10 @@ const getOptions = async (filterString: string) => {
 		options.push(...defaultFontOptions);
 	}
 
-	// separators and design tokens are the only entries without a preview: a token's
-	// label carries its name too, which the family's own subset cannot render
-	enqueuePreviewLoad(options.filter((o) => o.labelStyle).map((o) => o.value));
+	// separators are the only entries without a preview
+	enqueuePreviewLoad(
+		options.flatMap((o) => (o.previewFont ? [{ font: o.previewFont, label: o.label }] : [])),
+	);
 	return options;
 };
 

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -3,9 +3,6 @@
 		<Tooltip :text="isCssVariable ? resolvedFont : undefined">
 			<Autocomplete
 				ref="fontInput"
-				:class="{
-					'[&>div>div>input]:text-ink-violet-6 [&>div>input]:font-mono': isCssVariable,
-				}"
 				:modelValue="modelValue"
 				:displayValue="displayValue"
 				:placeholder="displayPlaceholder"
@@ -56,10 +53,9 @@ const isToken = (value?: string | null): value is string =>
 
 const isCssVariable = computed(() => isToken(props.modelValue));
 
-const resolvedFont = computed(() => {
-	if (!props.modelValue) return "inherit";
-	return isCssVariable.value ? resolveVariableValue(props.modelValue) : props.modelValue;
-});
+// a Font token stands in for a family; an unknown one resolves to itself, leaving none
+const toFamily = (value: string) => (isToken(value) ? resolveVariableValue(value) : value);
+const resolvedFont = computed(() => (props.modelValue ? toFamily(props.modelValue) : "inherit"));
 
 // show the token's friendly name instead of the raw var(--uuid), mirroring the color field
 const displayValue = computed(() => {
@@ -76,14 +72,15 @@ const displayPlaceholder = computed(() => {
 	return isToken(p) ? getVariableName(p) ?? p : p;
 });
 
-// the field doubles as a specimen: whatever family name it shows — the one that is set,
-// or the inherited one standing in as placeholder — is rendered in that family. Both are
-// already applied on the canvas, so the face is loaded. A token shows its own name rather
-// than a family, so it keeps the mono treatment that marks it as one.
+// the field doubles as a specimen: whatever it shows — the family that is set, the name of
+// the token standing in for one, or the inherited value behind the placeholder — is
+// rendered in the family it resolves to. Each of them is applied on the canvas, so the
+// full face is loaded and covers a token name as readily as a family name.
 const inputStyle = computed(() => {
-	const family = props.modelValue || props.placeholder;
-	if (!family || isToken(family)) return undefined;
-	return { fontFamily: family };
+	const value = props.modelValue || props.placeholder;
+	const family = value && toFamily(value);
+	// an unresolved token is still var(--uuid): no family to set
+	return family && !isToken(family) ? { fontFamily: family } : undefined;
 });
 
 const handleUpdate = (val: string | null) => emit("update:modelValue", val);

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -3,7 +3,6 @@
 		<Tooltip :text="isCssVariable ? resolvedFont : undefined">
 			<Autocomplete
 				ref="fontInput"
-				class="[&>div>input]:pl-9"
 				:class="{
 					'[&>div>div>input]:text-ink-violet-6 [&>div>input]:font-mono': isCssVariable,
 				}"
@@ -12,15 +11,7 @@
 				:placeholder="displayPlaceholder"
 				:getOptions="getOptions"
 				:actionButton="{ component: FontUploader }"
-				@update:modelValue="handleUpdate">
-				<template #prefix>
-					<div
-						class="flex size-4 items-center justify-center rounded bg-surface-gray-3 text-xs leading-none text-ink-gray-7 shadow-sm"
-						:style="{ fontFamily: resolvedFont }">
-						A
-					</div>
-				</template>
-			</Autocomplete>
+				@update:modelValue="handleUpdate" />
 		</Tooltip>
 	</div>
 </template>

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -29,10 +29,11 @@ const WEIGHT_LABELS: Record<FontWeight, string> = {
 const GF_CSS = "https://fonts.googleapis.com/css2";
 const fontCache = new Map<string, Promise<string>>();
 
-// A preview only ever renders the family's own name, so it loads a subset holding just
-// those glyphs (~1KB instead of the full face). That face must NOT be registered under
-// the real family name: a block that later applies the same font would otherwise race
-// against a face carrying a handful of glyphs. Alias it instead.
+// A preview renders one label — a family's own name, or a Font token's label, which
+// carries the token's name alongside it — so it loads a subset holding just that label's
+// glyphs (~1KB instead of the full face). That face must NOT be registered under the real
+// family name: a block that later applies the same font would otherwise race against a
+// face carrying a handful of glyphs. Alias it instead.
 const PREVIEW_PREFIX = "__builder_preview_";
 // the picker re-queries on every keystroke, so batch the resulting loads
 const PREVIEW_DEBOUNCE = 120;
@@ -40,11 +41,17 @@ const PREVIEW_DEBOUNCE = 120;
 // the whole catalog resident. Well above the ~20 rows on screen, so nothing visible goes.
 const PREVIEW_FACE_LIMIT = 150;
 
+// all three are keyed by the label being previewed, not by the family: one family can back
+// more than one label (its own row, and any Font token bound to it), and each needs a
+// subset cut to its own glyphs
 const previewRequests = new Map<string, Promise<void>>();
-// family -> the family its preview renders with; reactive so pickers restyle on arrival
+// label -> the family its preview renders with; reactive so pickers restyle on arrival
 const previewFamilies = shallowRef(new Map<string, string>());
 // only subset faces, in insertion order — real faces belong to blocks and are never evicted
 const previewFaces = new Map<string, FontFace>();
+// aliases have to be unique per label, but a label is free-form text and a family name is
+// not, so they are numbered rather than built out of the label itself
+let previewFaceCount = 0;
 
 // the Google Fonts catalog is ~110KB, so it stays out of the main bundle
 // and loads on first use (font pickers read the reactive ref)
@@ -170,18 +177,18 @@ const isCustomFont = (font: string) =>
 	(userFont.data || []).some((f: { font_name: string }) => f.font_name === font);
 
 // Google's text= parameter returns a face carrying only the requested characters, which
-// for a preview is the family's own name — roughly 1KB rather than the full file.
-async function loadSubsetFace(font: string): Promise<string> {
-	const glyphs = [...new Set(font)].join("");
+// for a preview is the label it has to render — roughly 1KB rather than the full file.
+async function loadSubsetFace(font: string, label: string): Promise<string> {
+	const glyphs = [...new Set(label)].join("");
 	const res = await fetch(`${GF_CSS}?family=${encodeURIComponent(font)}&text=${encodeURIComponent(glyphs)}`);
 	if (!res.ok) throw new Error(`No Google font named ${font}`);
 	const url = (await res.text()).match(/url\((https:\/\/[^)]+)\)/)?.[1];
 	if (!url) throw new Error(`No font file in the stylesheet for ${font}`);
 
-	const previewFamily = `${PREVIEW_PREFIX}${font}`;
+	const previewFamily = `${PREVIEW_PREFIX}${++previewFaceCount}`;
 	const face = await new FontFace(previewFamily, `url("${url}")`).load();
 	document.fonts.add(face);
-	previewFaces.set(font, face);
+	previewFaces.set(label, face);
 	evictOldestPreviews();
 	return previewFamily;
 }
@@ -201,43 +208,50 @@ function evictOldestPreviews() {
 	previewFamilies.value = families;
 }
 
-function resolvePreviewFace(font: string): Promise<string> {
+function resolvePreviewFace(font: string, label: string): Promise<string> {
 	// a font already applied on the canvas has its full face on the way, and uploaded
 	// fonts are served whole from the site itself — either way there is nothing to
 	// subset, and setFont already caches both under the real family name
-	return isCustomFont(font) || fontCache.has(font) ? setFont(font) : loadSubsetFace(font);
+	return isCustomFont(font) || fontCache.has(font) ? setFont(font) : loadSubsetFace(font, label);
 }
 
-/** Loads just enough of a font to render its own name. Failures leave it unpreviewed. */
-export function loadFontPreview(font: string): Promise<void> {
-	const pending = previewRequests.get(font);
+/** Loads just enough of a font to render one label — its own family name by default.
+ * Failures leave it unpreviewed. */
+export function loadFontPreview(font: string, label: string = font): Promise<void> {
+	const pending = previewRequests.get(label);
 	if (pending) return pending;
 
-	const request = resolvePreviewFace(font)
+	const request = resolvePreviewFace(font, label)
 		.then((family) => {
 			// swap the map so the pickers restyle once the face is actually usable
-			previewFamilies.value = new Map(previewFamilies.value).set(font, family);
+			previewFamilies.value = new Map(previewFamilies.value).set(label, family);
 		})
 		.catch(() => console.warn(`Failed to load font preview: ${font}`));
 
-	previewRequests.set(font, request);
+	previewRequests.set(label, request);
 	return request;
 }
 
-let queuedPreviews: string[] = [];
+/** A row to preview: the family to load, and the label that row actually renders. */
+export interface FontPreview {
+	font: string;
+	label: string;
+}
+
+let queuedPreviews: FontPreview[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | undefined;
 
 function flushPreviewQueue() {
 	flushTimer = undefined;
-	queuedPreviews.forEach(loadFontPreview);
+	queuedPreviews.forEach(({ font, label }) => loadFontPreview(font, label));
 	queuedPreviews = [];
 }
 
 /** Queues previews for the currently visible options, coalescing bursts of keystrokes. */
-export function enqueuePreviewLoad(fonts: string[]): void {
+export function enqueuePreviewLoad(previews: FontPreview[]): void {
 	// every keystroke supersedes the last, so the pending set is replaced rather than
 	// accumulated: pausing on "rob" should not also fetch what matched "r"
-	queuedPreviews = fonts.filter((font) => !previewRequests.has(font));
+	queuedPreviews = previews.filter(({ label }) => !previewRequests.has(label));
 	if (flushTimer) clearTimeout(flushTimer);
 	if (queuedPreviews.length) flushTimer = setTimeout(flushPreviewQueue, PREVIEW_DEBOUNCE);
 }
@@ -246,8 +260,8 @@ export function enqueuePreviewLoad(fonts: string[]): void {
  * Style for rendering a label in its own typeface. Returns undefined until the preview
  * has loaded, so the label stays in the UI font instead of flashing a fallback serif.
  */
-export function previewFontStyle(font: string): { fontFamily: string } | undefined {
-	const family = previewFamilies.value.get(font);
+export function previewFontStyle(label: string): { fontFamily: string } | undefined {
+	const family = previewFamilies.value.get(label);
 	// JSON.stringify quotes the family, which matters for names containing spaces
 	return family ? { fontFamily: JSON.stringify(family) } : undefined;
 }


### PR DESCRIPTION
### What

Follow-up to #724, which made each dropdown row render in the face it names.Two places were still in the UI font: the field itself, and the design token rows.

### Changes

- Field renders its value in its own typeface
- Design token rows preview too
- Removed the specimen icon and token color styling

Before:

https://github.com/user-attachments/assets/bc688491-de4d-4f1d-bfcb-048aa7351f9d

Now:

https://github.com/user-attachments/assets/180fe9a2-e784-4dff-b825-ffc547bbff1f


