### PR TITLE
feat: font dropdown keeps a minimum width

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -64,8 +64,10 @@
 						referenceElementSelector ? 'fixed' : 'absolute',
 						!referenceElementSelector && openOptionsAbove ? 'bottom-full mb-1' : '',
 						!referenceElementSelector && !openOptionsAbove ? 'mt-1' : '',
+						// wider than the input: anchor right so the extra width grows away from the panel edge
+						!referenceElementSelector && optionsMinWidth ? 'right-0' : '',
 					]"
-					:style="fixedPositionStyles"
+					:style="[fixedPositionStyles, optionsMinWidthStyle]"
 					@after-enter="setOptionsPosition"
 					@after-leave="fixedPositionStyles = {}">
 					<div class="options-list overflow-y-auto p-1 empty:p-0">
@@ -168,6 +170,8 @@ interface Props {
 	referenceElementSelector?: string;
 	allowArbitraryValue?: boolean;
 	disabled?: boolean;
+	// floor for the options width, so a narrow input doesn't force truncated labels
+	optionsMinWidth?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -191,6 +195,10 @@ const hasValue = computed(() => props.modelValue != null && props.modelValue !==
 const comboboxInput = ref<ComponentPublicInstance | null>(null);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 const fixedPositionStyles = ref<Record<string, string>>({});
+// the fixed path bakes the floor into its explicit width instead
+const optionsMinWidthStyle = computed(() =>
+	props.optionsMinWidth && !props.referenceElementSelector ? { minWidth: `${props.optionsMinWidth}px` } : {},
+);
 const openOptionsAbove = ref(false);
 const allOptions = computed(() => (props.getOptions ? asyncOptions.value : props.options));
 
@@ -367,13 +375,15 @@ const getFixedPositionStyles = (): Record<string, string> => {
 	const bottom = openOptionsAbove.value
 		? window.innerHeight - comboboxInputRect.top + OPTIONS_GAP + "px"
 		: "unset";
-	const left = comboboxInputRect.left + "px";
+	const width = Math.max(comboboxInputRect.width, props.optionsMinWidth || 0);
+	// a widened list keeps its left edge on the input but never leaves the viewport
+	const left = Math.min(comboboxInputRect.left, window.innerWidth - width - OPTIONS_GAP) + "px";
 
 	return {
 		top,
 		bottom,
 		left,
-		width: comboboxInputRect.width + "px",
+		width: width + "px",
 		zIndex: "999",
 	};
 };

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -10,6 +10,7 @@
 				:actionButton="{ component: FontUploader }"
 				:inputStyle="inputStyle"
 				:referenceElementSelector="referenceElementSelector"
+				:optionsMinWidth="240"
 				@update:modelValue="handleUpdate" />
 		</Tooltip>
 	</div>
@@ -73,7 +74,7 @@ const displayValue = computed(() => {
 const displayPlaceholder = computed(() => {
 	const p = props.placeholder;
 	if (!p) return __("Set Font");
-	return isToken(p) ? getVariableName(p) ?? p : p;
+	return isToken(p) ? (getVariableName(p) ?? p) : p;
 });
 
 // the field doubles as a specimen: whatever it shows — the family that is set, the name of


### PR DESCRIPTION
## Overview

A narrow Family input forces its own width on the font options list, so family names rendered in their own typeface get truncated (`Do... Space Mono`, `Wi...Unbounded`). The options list now has a width floor.

## Screenshot

<img src="https://raw.githubusercontent.com/surajshetty3416/builder/4d441e1ca53de927d5c26bc4257a7c75f556ea69/font-dropdown-min-width.png" width="360" alt="Family dropdown wider than its input, right-aligned, labels no longer truncated" />

## Details

- `Autocomplete` takes an `optionsMinWidth` prop. The in-place (absolute) path applies it as `min-width` and anchors the list to the input's right edge, so the extra width grows toward the canvas instead of past the panel edge. The teleported (fixed) path bakes the floor into its explicit width and clamps `left` so the list stays in the viewport.
- `FontInput` asks for a 240px floor; other autocompletes are unchanged.
