### PR TITLE
fix: property plus affordance recedes until interaction

### DIFF
--- a/frontend/src/components/Controls/PropertyLabel.vue
+++ b/frontend/src/components/Controls/PropertyLabel.vue
@@ -3,7 +3,7 @@
 		<Dropdown v-if="showDropdown" size="sm" :options="dropdownOptions">
 			<span
 				ref="dropdownTrigger"
-				class="lucide-plus-circle h-3 w-3 cursor-pointer text-ink-gray-7 hover:text-ink-gray-9"
+				class="lucide-plus-circle h-3 w-3 cursor-pointer text-ink-gray-4 hover:text-ink-gray-7 active:text-ink-gray-9"
 				aria-hidden="true" />
 		</Dropdown>
 		<InputLabel


### PR DESCRIPTION
The circle-plus before every property label rendered at `ink-gray-7`, heavy enough to compete with the labels themselves. It now rests at `ink-gray-4`, darkens to `ink-gray-7` on hover, and to `ink-gray-9` while pressed.

