### PR TITLE
fix: send component block as a string when saving

### DIFF
--- a/frontend/src/components/BlockPropertySections/StandardPropsInputSection.ts
+++ b/frontend/src/components/BlockPropertySections/StandardPropsInputSection.ts
@@ -144,7 +144,7 @@ const getStandardPropsInputSection = () => {
 };
 
 export default {
-	name: __("Block Options"),
+	name: __("Component Options"),
 	properties: getStandardPropsInputSection,
 	collapsed: false,
 	condition: () =>

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -8,7 +8,7 @@ import useCanvasStore from "@/stores/canvasStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderComponent } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
-import { alert, confirm, getBlockInstance, getBlockObject } from "@/utils/helpers";
+import { alert, confirm, getBlockInstance, getBlockString } from "@/utils/helpers";
 import { createDocumentResource, createResource, toast } from "frappe-ui";
 import { defineStore } from "pinia";
 import { markRaw } from "vue";
@@ -103,7 +103,7 @@ const useComponentStore = defineStore("componentStore", {
 			return webComponent.setValue
 				.submit({
 					name: componentName,
-					block: getBlockObject(block),
+					block: getBlockString(block),
 					component_data_script: doc?.component_data_script || "",
 				})
 				.then(async (data: BuilderComponent) => {


### PR DESCRIPTION
## Problem

Saving an existing component failed with a 500:

```
File "apps/frappe/frappe/database/mariadb/mysqlclient.py", line 190, in escape_dict
    raise TypeError("dict can not be used as parameter")
```

`componentStore.saveComponent` sent `block` as a JS object (`getBlockObject`). The `block` field on Builder Component is `LongText`, so `frappe.client.set_value` passed the dict to the SQL driver.

Creating a component was not affected: `promptSaveAsComponent` already sends `getBlockString(block)`.

## Fix

Use `getBlockString(block)` in `saveComponent`, the same as the create path and `pageStore.savePage`.
