### PR TITLE
fix(analytics): restore the site analytics chart under echarts 6

### DIFF
--- a/frontend/src/components/Settings/AnalyticsOverview.vue
+++ b/frontend/src/components/Settings/AnalyticsOverview.vue
@@ -21,13 +21,14 @@
 			</div>
 		</div>
 	</div>
-	<div class="mx-[-16px]">
+	<div>
 		<div v-if="loading" class="flex h-[200px] items-center justify-center py-8 text-sm text-ink-gray-4">
 			{{ __("Loading...") }}
 		</div>
+		<!-- padding on the chart itself would offset echarts' pointer hit-testing, so keep it flush -->
 		<AxisChart
 			v-else-if="data.data && data.data.length"
-			class="!h-[250px] !min-h-[200px]"
+			class="h-[250px] w-full"
 			:config="chartConfigData"
 			:events="chartEvents" />
 		<AnalyticsEmptyState

--- a/frontend/src/composables/useAnalytics.ts
+++ b/frontend/src/composables/useAnalytics.ts
@@ -100,44 +100,53 @@ export function useAnalytics({
 		tooltipText: "var(--ink-gray-7)",
 	};
 
-	const getAxisStyle = () => ({
+	// echarts drops its own palette when a chart config leaves `colors` unset, so series stay invisible without this
+	const seriesColors = ["var(--ink-blue-6)", "var(--ink-teal-6)"];
+	const fillOpacity = 0.15;
+
+	// a css var can't be parsed into a derived hover color, so the hovered state repeats the color instead
+	const areaSeries = (name: string, color: string) => ({
+		name,
+		type: "area",
+		fillOpacity,
+		echartOptions: {
+			emphasis: {
+				lineStyle: { color },
+				areaStyle: { color, opacity: fillOpacity },
+				itemStyle: { color },
+			},
+		},
+	});
+
+	const getAxisStyle = (axisLabel: Record<string, any> = {}) => ({
 		axisLine: { lineStyle: { color: themeColors.axisLineColor } },
 		axisTick: { lineStyle: { color: themeColors.axisLineColor } },
-		axisLabel: { color: themeColors.textColor },
+		axisLabel: { color: themeColors.textColor, ...axisLabel },
 		splitLine: { lineStyle: { color: themeColors.gridLineColor } },
 	});
 
 	const chartConfig = computed(() => ({
 		data: analyticsData.value.data,
 		title: "",
+		colors: seriesColors,
 		xAxis: {
 			key: "interval",
 			type: "category",
+			// axis styling belongs here; a top-level echartOptions.xAxis/yAxis replaces the chart's own axis config
+			echartOptions: getAxisStyle({ alignMaxLabel: "right" }),
 		},
 		yAxis: {
-			title: __("Timeline"),
-		},
-		y2Axis: {
-			title: __("Total Views"),
+			title: __("Views"),
+			echartOptions: getAxisStyle(),
 		},
 		series: [
-			{
-				name: "total_page_views",
-				type: "area",
-				axis: "y2",
-			},
-			{
-				name: "unique_page_views",
-				type: "area",
-				axis: "y2",
-			},
+			areaSeries("total_page_views", seriesColors[0]),
+			areaSeries("unique_page_views", seriesColors[1]),
 		],
 		echartOptions: {
 			backgroundColor: themeColors.backgroundColor,
 			textStyle: { color: themeColors.textColor },
 			grid: { borderColor: themeColors.gridLineColor },
-			xAxis: getAxisStyle(),
-			yAxis: [getAxisStyle(), getAxisStyle()],
 			tooltip: {
 				backgroundColor: themeColors.tooltipBg,
 				borderColor: themeColors.tooltipBorder,


### PR DESCRIPTION
The Site Analytics chart renders nothing: axes, legend and tooltip all work, the lines and areas are simply not painted.

### Why

It has been blank since 9afded2c (#728), which added a root `resolutions` entry forcing `echarts` to `^6.1.0` for the XSS advisory, over the `^5.6.0` frappe-ui declares:

```
echarts@^5.6.0, echarts@^6.1.0:
  version "6.1.0"
```

frappe-ui's `useEchartsOptions` always emits `color: config.colors`, and nothing in Builder passes `colors`. Rendering the same option object against both dists:

| | `getOption().color` | series paths |
|---|---|---|
| echarts 5.6.0 | `["#37A2DA", "#32C5E9", …]` | `fill="#37A2DA"`, `stroke="#37A2DA"` |
| echarts 6.1.0 | `null` | `fill="none"`, no stroke |

echarts 5 ignored the explicit `undefined` and kept its palette; echarts 6 lets the key win. The chart config itself has not changed since analytics landed in fcff09c4 (Jun 2025).

Reverting is not an option: 5.6.0 is the last 5.x on npm and the XSS fix only exists in 6.x, so the resolution stays and the chart config has to be echarts 6 safe.

### What changed

- **Pin the series colors** (`--ink-blue-6`, `--ink-teal-6`) instead of relying on a palette that is no longer there.
- **Style the axes through `xAxis.echartOptions` / `yAxis.echartOptions`.** A top-level `echartOptions.yAxis` array replaces frappe-ui's axis config instead of merging into it, which is why the left axis was blank, ticks read `4,000` instead of `4K` and the axis name never showed.
- **Drop the y2 axis** and its "Timeline" title. Both series count views, so they share one axis, now titled "Views".
- **Repeat the color in each series' emphasis state.** echarts derives the hover color by parsing the series color; it cannot parse a css var, so `liftColor` returned nothing and hovering blanked the chart again.
- **Drop the chart padding and the negative margin** that compensated for it. zrender sizes the svg as `clientWidth - padding` but positions it at the padding box origin, so any padding offsets pointer hit-testing by that amount and the click-to-drill-down never fired.