### PR TITLE
fix(editor): destroy CodeMirror view on unmount

### DIFF
--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -5,7 +5,7 @@
 		@keydown="handleKeyDown"></div>
 </template>
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import codeCompletions from "@/data/codeCompletions";
 import blockController from "@/utils/blockController";
@@ -144,6 +144,13 @@ onMounted(async () => {
 		state: startState,
 		parent: editorContainer.value,
 	});
+});
+
+// CodeMirror does not release its view tree, DOM or document observer on its own,
+// so an undestroyed view keeps the whole editor DOM alive and keeps polling selection.
+onBeforeUnmount(() => {
+	editor?.destroy();
+	editor = null;
 });
 
 defineExpose({


### PR DESCRIPTION
## Problem

`CodeMirrorEditor.vue` creates an `EditorView` in `onMounted` and never destroys it. It is the only `EditorView` in the codebase, and the only `.destroy()` anywhere is TipTap's.

CodeMirror does not clean up after itself. An undestroyed view keeps its whole view tree, its DOM, and its `DOMObserver` alive after Vue unmounts the container.

This is easy to hit because selecting any block that has `innerHTML` mounts this editor on the block's raw source in the **HTML Options** panel. Every reselect or remount leaks another full editor, and the orphaned observers keep polling the document selection for the rest of the session.

## Reproduction

On a page with an SVG block holding 205 KB of inline markup: select it, copy, delete, paste it back, repeat. Block count stays constant throughout.

| 20 cycles | DOM nodes | event listeners | heap |
|---|---|---|---|
| before | **+56,420** (+2,821/cycle) | **+12,633** | +210 MB |
| after | **+0** | **+0** | +51 MB |

None of it was reclaimed by a forced GC.

## Evidence

A V8 heap snapshot names the retainers directly:

```
DETACHED:  8,391 Text · 3,252 Comment · <div class="cm-line"> · <span class="ͼ63/65/66/67">
RETAINERS: TextView --dom-->  2,028      MarkView --dom-->  1,302
           LineView --dom-->    174      GutterElement --dom-->    42
```

`cm-line` and the `ͼ*` classes are CodeMirror 6. A performance trace of an ordinary editing session separately showed `onSelectionChange` in the CodeMirror bundle firing ~58 times a second, which is the leaked `DOMObserver`s still polling.

Verified by A/B with only this change stashed, so nothing else varied between runs.

## Notes

- Since this is the shared code editor component, it also fixes the same leak in client scripts, custom CSS, and the page data script, not just HTML Options.
- The residual +51 MB above is a separate, pre-existing issue: `useCanvasHistory` stores a full `JSON.stringify` of the entire block tree per commit with `CAPACITY = 500`, which is ~1.55 MB per edit on a page this size. Not addressed here.