### PR TITLE
perf(editor): stop the editor leaking memory, and stop pages carrying SVGs inline

### DIFF
--- a/frontend/src/components/BlockContextMenuOptions/index.ts
+++ b/frontend/src/components/BlockContextMenuOptions/index.ts
@@ -38,8 +38,8 @@ const options: ContextMenuOption[] = [
 		condition: ({ block }) => block.isHTML(),
 	},
 	{
-		name: "upload-svg-as-file",
-		label: __("Upload SVG as File"),
+		name: "convert-svg-to-image-file",
+		label: __("Convert to Image File"),
 		action: ({ block }) => convertSVGBlockToImage(block),
 		condition: ({ block }) => block.isSVG() && isOversizedSVG(block.getInnerHTML() || ""),
 		disabled: readOnly,

--- a/frontend/src/components/BlockContextMenuOptions/index.ts
+++ b/frontend/src/components/BlockContextMenuOptions/index.ts
@@ -6,7 +6,14 @@ import type { ContextMenuOption } from "@/types/blockContextMenu";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { createRegistry } from "@/utils/createRegistry";
 import { promptCreateComponent } from "@/utils/dialogs";
-import { confirm, detachBlockFromComponent, getBlockCopy, triggerCopyEvent } from "@/utils/helpers";
+import {
+	confirm,
+	convertSVGBlockToImage,
+	detachBlockFromComponent,
+	getBlockCopy,
+	isOversizedSVG,
+	triggerCopyEvent,
+} from "@/utils/helpers";
 import { useStorage } from "@vueuse/core";
 import { toast } from "frappe-ui";
 import { nextTick, type Ref } from "vue";
@@ -29,6 +36,13 @@ const options: ContextMenuOption[] = [
 		label: __("Edit HTML"),
 		action: ({ block }) => canvasStore.editHTML(block),
 		condition: ({ block }) => block.isHTML(),
+	},
+	{
+		name: "upload-svg-as-file",
+		label: __("Upload SVG as File"),
+		action: ({ block }) => convertSVGBlockToImage(block),
+		condition: ({ block }) => block.isSVG() && isOversizedSVG(block.getInnerHTML() || ""),
+		disabled: readOnly,
 	},
 	{
 		name: "copy",

--- a/frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts
@@ -1,8 +1,19 @@
 import CodeEditor from "@/components/Controls/CodeEditor.vue";
 import blockController from "@/utils/blockController";
+import { convertSVGBlockToImage, isOversizedSVG } from "@/utils/helpers";
+import { Button } from "frappe-ui";
+import { computed } from "vue";
 import useCanvasStore from "../../stores/canvasStore";
 import BasePropertyControl from "../Controls/BasePropertyControl.vue";
 import { __ } from "@/translation";
+
+// the inline SVG of the selected block, only when it is big enough to be worth
+// moving out of the page. Empty string otherwise, so the button stays hidden.
+function getSelectedSVG() {
+	const block = blockController.getSelectedBlocks()[0];
+	const html = block?.getInnerHTML() || "";
+	return block?.isSVG() && isOversizedSVG(html) ? html : "";
+}
 
 const HTMLOptionsSectionProperties = [
 	{
@@ -32,6 +43,26 @@ const HTMLOptionsSectionProperties = [
 		searchKeyWords: "HTML, InnerHTML, Inner HTML",
 		condition: () =>
 			blockController.isHTML() || (blockController.getInnerHTML() && !blockController.isText()),
+	},
+	{
+		component: Button,
+		getProps: () => {
+			return {
+				class: "text-base self-end",
+			};
+		},
+		innerText: computed(() => {
+			const size = Math.round((getSelectedSVG().length || 0) / 1024);
+			return __("Convert to Image File ({0} KB)", [String(size)]);
+		}),
+		searchKeyWords: "SVG, Convert, Image, File, Upload, Inline, Size, Optimize",
+		condition: () => Boolean(getSelectedSVG()),
+		events: {
+			click: () => {
+				const block = blockController.getSelectedBlocks()[0];
+				if (block) convertSVGBlockToImage(block);
+			},
+		},
 	},
 ];
 

--- a/frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts
+++ b/frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts
@@ -7,8 +7,6 @@ import useCanvasStore from "../../stores/canvasStore";
 import BasePropertyControl from "../Controls/BasePropertyControl.vue";
 import { __ } from "@/translation";
 
-// the inline SVG of the selected block, only when it is big enough to be worth
-// moving out of the page. Empty string otherwise, so the button stays hidden.
 function getSelectedSVG() {
 	const block = blockController.getSelectedBlocks()[0];
 	const html = block?.getInnerHTML() || "";

--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -5,7 +5,7 @@
 		@keydown="handleKeyDown"></div>
 </template>
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import codeCompletions from "@/data/codeCompletions";
 import blockController from "@/utils/blockController";
@@ -144,6 +144,13 @@ onMounted(async () => {
 		state: startState,
 		parent: editorContainer.value,
 	});
+});
+
+// CodeMirror does not release its view tree, DOM or document observer on its own,
+// so an undestroyed view keeps the whole editor DOM alive and keeps polling selection.
+onBeforeUnmount(() => {
+	editor?.destroy();
+	editor = null;
 });
 
 defineExpose({

--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
 
 const editorContainer = ref<HTMLDivElement | null>(null);
 let editor: EditorView | null = null;
+let disposed = false;
 const theme = new Compartment();
 
 const emit = defineEmits<{
@@ -140,6 +141,10 @@ onMounted(async () => {
 		blockProps: allBlockProps.value,
 	});
 
+	// the awaits above give the component time to unmount, and teardown has already
+	// run by then: building the view now would orphan it in a detached container
+	if (disposed) return;
+
 	editor = new EditorView({
 		state: startState,
 		parent: editorContainer.value,
@@ -149,6 +154,7 @@ onMounted(async () => {
 // CodeMirror does not release its view tree, DOM or document observer on its own,
 // so an undestroyed view keeps the whole editor DOM alive and keeps polling selection.
 onBeforeUnmount(() => {
+	disposed = true;
 	editor?.destroy();
 	editor = null;
 });

--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -68,7 +68,7 @@ const resetEditor = async (params: { content: string; resetHistory: boolean; aut
 			mode: props.mode,
 			blockProps: allBlockProps.value,
 		});
-		// teardown can land while the state above is being built, and it drops the view
+		// teardown can land while the state above is being built
 		if (!editor) return;
 		editor.setState(startState);
 	} else {
@@ -141,8 +141,7 @@ onMounted(async () => {
 		blockProps: allBlockProps.value,
 	});
 
-	// the awaits above give the component time to unmount, and teardown has already
-	// run by then: building the view now would orphan it in a detached container
+	// unmounted mid-await: building the view now would orphan it in a detached container
 	if (disposed) return;
 
 	editor = new EditorView({
@@ -151,8 +150,7 @@ onMounted(async () => {
 	});
 });
 
-// CodeMirror does not release its view tree, DOM or document observer on its own,
-// so an undestroyed view keeps the whole editor DOM alive and keeps polling selection.
+// CodeMirror keeps its view tree, DOM and document observer alive until told otherwise
 onBeforeUnmount(() => {
 	disposed = true;
 	editor?.destroy();

--- a/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
+++ b/frontend/src/components/Controls/CodeMirror/CodeMirrorEditor.vue
@@ -54,35 +54,35 @@ const getEditorValue = () => {
 };
 
 const resetEditor = async (params: { content: string; resetHistory: boolean; autofocus: boolean }) => {
-	if (editor) {
-		if (params.resetHistory) {
-			editor.setState(
-				(
-					await createStartingState({
-						props,
-						pythonCompletions: await getPythonCompletions(),
-						onSaveCallback: () => emit("save", getEditorValue()),
-						onChangeCallback: () => emit("change", getEditorValue()),
-						onBlurCallback: (value: string) => emit("blur", value),
-						initialValue: params.content,
-						extraExtensions: [theme.of(isDark.value ? oneDark : tomorrow)],
-						mode: props.mode,
-						blockProps: allBlockProps.value,
-					})
-				).startState,
-			);
-		} else {
-			editor.dispatch({
-				changes: {
-					from: 0,
-					to: editor.state.doc.length,
-					insert: params.content,
-				},
-			});
-		}
-		params.autofocus && editor.focus();
-		(editor.dom.querySelector(".cm-content") as HTMLElement)?.classList.remove("@md/editor:!pt-10", "!pt-20");
+	if (!editor) return;
+
+	if (params.resetHistory) {
+		const { startState } = await createStartingState({
+			props,
+			pythonCompletions: await getPythonCompletions(),
+			onSaveCallback: () => emit("save", getEditorValue()),
+			onChangeCallback: () => emit("change", getEditorValue()),
+			onBlurCallback: (value: string) => emit("blur", value),
+			initialValue: params.content,
+			extraExtensions: [theme.of(isDark.value ? oneDark : tomorrow)],
+			mode: props.mode,
+			blockProps: allBlockProps.value,
+		});
+		// teardown can land while the state above is being built, and it drops the view
+		if (!editor) return;
+		editor.setState(startState);
+	} else {
+		editor.dispatch({
+			changes: {
+				from: 0,
+				to: editor.state.doc.length,
+				insert: params.content,
+			},
+		});
 	}
+
+	params.autofocus && editor.focus();
+	(editor.dom.querySelector(".cm-content") as HTMLElement)?.classList.remove("@md/editor:!pt-10", "!pt-20");
 };
 
 const handleKeyDown = (e: KeyboardEvent) => {

--- a/frontend/src/utils/dialogs.ts
+++ b/frontend/src/utils/dialogs.ts
@@ -16,6 +16,24 @@ import { __ } from "@/translation";
 // a frappe-ui prompt that auto-closes once `onConfirm` resolves; throwing from
 // onConfirm surfaces the error inline and keeps the dialog open.
 
+// Resolves true when the user wants the SVG uploaded as a file, false to keep it
+// inline. Dismissing counts as keeping it inline, so a stray Esc never uploads.
+export function promptOversizedSVG(bytes: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		dialog.confirm({
+			title: __("Large SVG"),
+			message: __(
+				"This SVG is {0} KB. Kept inline it is stored in the page itself, which makes saving and editing slower. Upload it as a file instead?",
+				[String(Math.round(bytes / 1024))],
+			),
+			confirmLabel: __("Upload as File"),
+			cancelLabel: __("Keep Inline"),
+			onConfirm: () => resolve(true),
+			onCancel: () => resolve(false),
+		});
+	});
+}
+
 export function promptCreateFolder() {
 	dialog.prompt({
 		title: __("Create New Folder"),

--- a/frontend/src/utils/dialogs.ts
+++ b/frontend/src/utils/dialogs.ts
@@ -16,8 +16,7 @@ import { __ } from "@/translation";
 // a frappe-ui prompt that auto-closes once `onConfirm` resolves; throwing from
 // onConfirm surfaces the error inline and keeps the dialog open.
 
-// Resolves true when the user wants the SVG uploaded as a file, false to keep it
-// inline. Dismissing counts as keeping it inline, so a stray Esc never uploads.
+// dismissing resolves false, so a stray Esc never uploads
 export function promptOversizedSVG(bytes: number): Promise<boolean> {
 	return new Promise((resolve) => {
 		dialog.confirm({

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -384,6 +384,21 @@ async function uploadBuilderAsset(file: File, silent = false) {
 	};
 }
 
+const MAX_INLINE_SVG_SIZE = 20 * 1024;
+
+// An inline SVG lives in the page JSON, so it is re-serialised on every save,
+// walked by every deep watcher and copied into every history entry. Past a point
+// it is cheaper as a file the browser can cache. One that paints from a Builder
+// token has to stay inline though: an <img> cannot read CSS variables.
+function isOversizedSVG(svg: string) {
+	return svg.length > MAX_INLINE_SVG_SIZE && !svg.includes("var(--") && !svg.includes("currentColor");
+}
+
+async function uploadSVGAsFile(svg: string) {
+	const file = new File([svg], `${generateId()}.svg`, { type: "image/svg+xml" });
+	return uploadBuilderAsset(file);
+}
+
 // Naming every data URL image.png makes the server read an SVG or a GIF as a PNG,
 // which fails on upload. The MIME type in the data URL already tells us what it is.
 const DATA_URL_EXTENSIONS: Record<string, string> = {
@@ -979,6 +994,7 @@ export {
 	isHTMLString,
 	isInteractiveControl,
 	isJSONString,
+	isOversizedSVG,
 	isTargetEditable,
 	kebabToCamelCase,
 	mapToObject,
@@ -998,6 +1014,7 @@ export {
 	toTitleCase,
 	triggerCopyEvent,
 	uploadBuilderAsset,
+	uploadSVGAsFile,
 	uploadUserFont,
 	parseJSONWithFallback,
 	deepEqual,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -386,10 +386,10 @@ async function uploadBuilderAsset(file: File, silent = false) {
 
 const MAX_INLINE_SVG_SIZE = 20 * 1024;
 
-// An inline SVG lives in the page JSON, so it is re-serialised on every save,
-// walked by every deep watcher and copied into every history entry. Past a point
-// it is cheaper as a file the browser can cache. One that paints from a Builder
-// token has to stay inline though: an <img> cannot read CSS variables.
+// An inline SVG lives in the page JSON, so every autosave sends it in full, every
+// history entry copies it, and each of its paths is a real node in the canvas. Past
+// a point it is cheaper as a file the browser can cache. One that paints from a
+// Builder token has to stay inline though: an <img> cannot read CSS variables.
 function isOversizedSVG(svg: string) {
 	return svg.length > MAX_INLINE_SVG_SIZE && !svg.includes("var(--") && !svg.includes("currentColor");
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,11 +1,11 @@
 import Block from "@/block";
 import useCanvasStore from "@/stores/canvasStore";
+import { __ } from "@/translation";
 import { BuilderPage } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
 import { dialog, FileUploadHandler, toast } from "frappe-ui";
 import { reactive, toRaw } from "vue";
 import { getRGB, HexToHSV, HSVToHex } from "./colors";
-import { __ } from "@/translation";
 import {
 	addPxToNumber,
 	extractNumberAndUnit,
@@ -397,6 +397,29 @@ function isOversizedSVG(svg: string) {
 async function uploadSVGAsFile(svg: string) {
 	const file = new File([svg], `${generateId()}.svg`, { type: "image/svg+xml" });
 	return uploadBuilderAsset(file);
+}
+
+// Moves an already-inlined SVG out of the page and repoints the block at the file.
+// The block keeps its id, position and styles, so nothing downstream has to move.
+async function convertSVGBlockToImage(block: Block) {
+	const svg = block.getInnerHTML() || "";
+	const { fileURL } = await uploadSVGAsFile(svg);
+	if (!fileURL) return;
+
+	// the intrinsic size lived on the <svg> tag that is about to leave the page
+	const source = new DOMParser().parseFromString(svg, "text/html").body.querySelector("svg");
+	const width = source?.getAttribute("width");
+	const height = source?.getAttribute("height");
+	if (width && !block.baseStyles?.width) block.setStyle("width", addPxToNumber(parseInt(width)));
+	if (height && !block.baseStyles?.height) block.setStyle("height", addPxToNumber(parseInt(height)));
+	// an inline <svg> letterboxes inside its box by default, an <img> stretches,
+	// so without this the artwork skews the moment it becomes a file
+	if (!block.baseStyles?.objectFit) block.setStyle("objectFit", "contain");
+
+	block.element = "img";
+	if (block.originalElement === "__raw_html__") block.originalElement = undefined;
+	block.setInnerHTML("");
+	block.setAttribute("src", fileURL);
 }
 
 // Naming every data URL image.png makes the server read an SVG or a GIF as a PNG,
@@ -954,10 +977,14 @@ export {
 	alert,
 	confirm,
 	copyToClipboard,
+	convertSVGBlockToImage,
 	cssUrl,
 	dataURLFileName,
 	dataURLtoFile,
+	deepEqual,
 	detachBlockFromComponent,
+	diffArray,
+	extractComponentId,
 	extractNumberAndUnit,
 	findNearestSiblingIndex,
 	generateId,
@@ -982,7 +1009,6 @@ export {
 	getRouteVariables,
 	getSpacing,
 	getStandardPropValue,
-	extractComponentId,
 	getTextContent,
 	getVideoBlock,
 	handleBase64Attribute,
@@ -1002,6 +1028,7 @@ export {
 	normalizeValueWithUnits,
 	openInDesk,
 	parseAndSetBackground,
+	parseJSONWithFallback,
 	removeDefaultUnit,
 	replaceMapKey,
 	setSpacing,
@@ -1016,7 +1043,4 @@ export {
 	uploadBuilderAsset,
 	uploadSVGAsFile,
 	uploadUserFont,
-	parseJSONWithFallback,
-	deepEqual,
-	diffArray,
 };

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -386,10 +386,7 @@ async function uploadBuilderAsset(file: File, silent = false) {
 
 const MAX_INLINE_SVG_SIZE = 20 * 1024;
 
-// An inline SVG lives in the page JSON, so every autosave sends it in full, every
-// history entry copies it, and each of its paths is a real node in the canvas. Past
-// a point it is cheaper as a file the browser can cache. One that paints from a
-// Builder token has to stay inline though: an <img> cannot read CSS variables.
+// a token-painted SVG has to stay inline: an <img> cannot read CSS variables
 function isOversizedSVG(svg: string) {
 	return svg.length > MAX_INLINE_SVG_SIZE && !svg.includes("var(--") && !svg.includes("currentColor");
 }
@@ -399,21 +396,17 @@ async function uploadSVGAsFile(svg: string) {
 	return uploadBuilderAsset(file);
 }
 
-// Moves an already-inlined SVG out of the page and repoints the block at the file.
-// The block keeps its id, position and styles, so nothing downstream has to move.
 async function convertSVGBlockToImage(block: Block) {
 	const svg = block.getInnerHTML() || "";
 	const { fileURL } = await uploadSVGAsFile(svg);
 	if (!fileURL) return;
 
-	// the intrinsic size lived on the <svg> tag that is about to leave the page
 	const source = new DOMParser().parseFromString(svg, "text/html").body.querySelector("svg");
 	const width = source?.getAttribute("width");
 	const height = source?.getAttribute("height");
 	if (width && !block.baseStyles?.width) block.setStyle("width", addPxToNumber(parseInt(width)));
 	if (height && !block.baseStyles?.height) block.setStyle("height", addPxToNumber(parseInt(height)));
-	// an inline <svg> letterboxes inside its box by default, an <img> stretches,
-	// so without this the artwork skews the moment it becomes a file
+	// an inline <svg> letterboxes in its box, an <img> stretches
 	if (!block.baseStyles?.objectFit) block.setStyle("objectFit", "contain");
 
 	block.element = "img";

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -163,7 +163,13 @@ export function useBuilderEvents(
 					const fileURL = await resolveOversizedSVG(text);
 					if (fileURL) {
 						const imageBlock = getImageBlock(fileURL);
-						imageBlock.baseStyles = { ...block.baseStyles, ...imageBlock.baseStyles };
+						// the image template defaults to cover, which crops artwork that an
+						// inline <svg> would have letterboxed inside the same box
+						imageBlock.baseStyles = {
+							...block.baseStyles,
+							...imageBlock.baseStyles,
+							objectFit: "contain",
+						};
 						block = imageBlock;
 					}
 				}

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -13,13 +13,17 @@ import { copyBuilderBlocks, pasteBuilderBlocks } from "@/utils/builderBlockCopyP
 import {
 	addPxToNumber,
 	getBlockCopy,
+	getImageBlock,
 	isDialogOpen,
 	isHTMLString,
+	isOversizedSVG,
 	isTargetEditable,
 	showDialog,
 	triggerCopyEvent,
 	uploadBuilderAsset,
+	uploadSVGAsFile,
 } from "@/utils/helpers";
+import { promptOversizedSVG } from "@/utils/dialogs";
 import { useEventListener } from "@vueuse/core";
 import { commandShortcuts } from "@/components/Commands";
 import { toast, useShortcut } from "frappe-ui";
@@ -30,6 +34,14 @@ import { __ } from "@/translation";
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 const pageStore = usePageStore();
+
+// Offer to store a large pasted SVG as a file instead of inlining it into the page.
+// Returns the file URL when the user takes the offer, null to keep it inline.
+async function resolveOversizedSVG(svg: string) {
+	if (!isOversizedSVG(svg) || !(await promptOversizedSVG(svg.length))) return null;
+	const { fileURL } = await uploadSVGAsFile(svg);
+	return fileURL || null;
+}
 
 export function useBuilderEvents(
 	pageCanvas: Ref<InstanceType<typeof BuilderCanvas> | null>,
@@ -119,7 +131,8 @@ export function useBuilderEvents(
 			e.preventDefault();
 			// paste html
 			if (blockController.isHTML()) {
-				blockController.setInnerHTML(text);
+				const fileURL = text.startsWith("<svg") ? await resolveOversizedSVG(text) : null;
+				blockController.setInnerHTML(fileURL ? `<img src="${fileURL}" />` : text);
 			} else {
 				let block = null as unknown as Block | BlockOptions;
 				block = getBlockTemplate("html");
@@ -146,9 +159,18 @@ export function useBuilderEvents(
 						svg.removeAttribute("height");
 					}
 					text = svg.outerHTML;
+
+					const fileURL = await resolveOversizedSVG(text);
+					if (fileURL) {
+						const imageBlock = getImageBlock(fileURL);
+						imageBlock.baseStyles = { ...block.baseStyles, ...imageBlock.baseStyles };
+						block = imageBlock;
+					}
 				}
 
-				block.innerHTML = text;
+				if (!block.attributes?.src) {
+					block.innerHTML = text;
+				}
 
 				const selectedBlocks = blockController.getSelectedBlocks();
 				let parentBlock = selectedBlocks.length ? selectedBlocks[0] : null;

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -35,8 +35,6 @@ const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 const pageStore = usePageStore();
 
-// Offer to store a large pasted SVG as a file instead of inlining it into the page.
-// Returns the file URL when the user takes the offer, null to keep it inline.
 async function resolveOversizedSVG(svg: string) {
 	if (!isOversizedSVG(svg) || !(await promptOversizedSVG(svg.length))) return null;
 	const { fileURL } = await uploadSVGAsFile(svg);
@@ -163,8 +161,7 @@ export function useBuilderEvents(
 					const fileURL = await resolveOversizedSVG(text);
 					if (fileURL) {
 						const imageBlock = getImageBlock(fileURL);
-						// the image template defaults to cover, which crops artwork that an
-						// inline <svg> would have letterboxed inside the same box
+						// the image template defaults to cover, which would crop the artwork
 						imageBlock.baseStyles = {
 							...block.baseStyles,
 							...imageBlock.baseStyles,

--- a/frontend/src/utils/useCanvasHistory.ts
+++ b/frontend/src/utils/useCanvasHistory.ts
@@ -11,6 +11,11 @@ export type PauseId = string & { __brand: "PauseId" };
 
 const CAPACITY = 500;
 const DEBOUNCE_DELAY = 100;
+// Every record is a full serialisation of the tree, so a heavy page can reach
+// hundreds of MB long before it reaches CAPACITY. Whichever limit is hit first wins,
+// but always keep MIN_ENTRIES so undo stays usable on a page too big for the budget.
+const MAX_BYTES = 20 * 1024 * 1024;
+const MIN_ENTRIES = 10;
 
 export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<string>>) {
 	const undoStack = ref([]) as Ref<CanvasState[]>;
@@ -65,11 +70,23 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 		if (!enabled.value) return;
 		undoStack.value.unshift(last.value);
 		last.value = createHistoryRecord();
-		if (undoStack.value.length > CAPACITY) {
-			undoStack.value.splice(CAPACITY, Number.POSITIVE_INFINITY);
-		}
+		trim(undoStack.value);
 		if (redoStack.value.length) {
 			redoStack.value.splice(0, redoStack.value.length);
+		}
+	}
+
+	function trim(stack: CanvasState[]) {
+		if (stack.length > CAPACITY) {
+			stack.splice(CAPACITY, Number.POSITIVE_INFINITY);
+		}
+		let bytes = 0;
+		for (let i = 0; i < stack.length; i++) {
+			bytes += stack[i].block.length;
+			if (bytes > MAX_BYTES && i >= MIN_ENTRIES) {
+				stack.splice(i + 1, Number.POSITIVE_INFINITY);
+				return;
+			}
 		}
 	}
 
@@ -80,7 +97,9 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 	function createHistoryRecord() {
 		return {
 			block: getBlockString(source.value),
-			selectedBlockIds: selectedBlockIds.value,
+			// copy, or the record aliases the live set and every stacked entry
+			// tracks the current selection instead of the one it was taken with
+			selectedBlockIds: new Set(selectedBlockIds.value),
 		};
 	}
 
@@ -111,6 +130,7 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 		const state = undoStack.value.shift();
 		if (state) {
 			redoStack.value.unshift(last.value);
+			trim(redoStack.value);
 			setSource(state);
 		}
 	}
@@ -124,6 +144,7 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 		const state = redoStack.value.shift();
 		if (state) {
 			undoStack.value.unshift(last.value);
+			trim(undoStack.value);
 			setSource(state);
 		}
 	}

--- a/frontend/src/utils/useCanvasHistory.ts
+++ b/frontend/src/utils/useCanvasHistory.ts
@@ -11,9 +11,7 @@ export type PauseId = string & { __brand: "PauseId" };
 
 const CAPACITY = 500;
 const DEBOUNCE_DELAY = 100;
-// Every record is a full serialisation of the tree, so a heavy page can reach
-// hundreds of MB long before it reaches CAPACITY. Whichever limit is hit first wins,
-// but always keep MIN_ENTRIES so undo stays usable on a page too big for the budget.
+// each record serialises the whole tree, so a heavy page blows past this well before CAPACITY
 const MAX_BYTES = 20 * 1024 * 1024;
 const MIN_ENTRIES = 10;
 
@@ -97,8 +95,7 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 	function createHistoryRecord() {
 		return {
 			block: getBlockString(source.value),
-			// copy, or the record aliases the live set and every stacked entry
-			// tracks the current selection instead of the one it was taken with
+			// copy, or every stacked entry aliases the live set
 			selectedBlockIds: new Set(selectedBlockIds.value),
 		};
 	}


### PR DESCRIPTION
Two memory leaks in the editor, plus a way to move big SVGs out of the page.

Every number below is measured on `page-df90c08a`, a real 743 KB page where 87% of the weight is inline SVG (five blocks of 205, 154, 106, 103 and 77 KB).

| From the two leak fixes | Before | After |
|---|---|---|
| DOM nodes after 20 select/copy/delete/paste cycles | +56,420 | **+0** |
| Event listeners, same run | +12,633 | **+0** |
| Heap kept by undo history after 120 edits | +185.6 MB | **+41.6 MB** |
| Undo stack ceiling on this page | ~775 MB | **20 MB** |

| Once the five SVGs are moved to files | Before | After |
|---|---|---|
| Autosave payload | 767,832 B | **104,135 B** |
| Page JSON | 821,439 B | **169,931 B** |
| `<path>` nodes in canvas | 717 | **42** |


## 1. CodeMirror was never destroyed

`CodeMirrorEditor.vue` created an `EditorView` in `onMounted` with no `onBeforeUnmount`. It was the only `EditorView` in the codebase, and the only `.destroy()` anywhere was TipTap's.

CodeMirror does not clean up on its own. If the view is never destroyed, it keeps its DOM and its selection observer alive even after Vue removes the container. Selecting any block with `innerHTML` opens this editor on the block's source in the HTML Options panel, so every time you selected one, another editor was left behind, still watching the selection.

**Repro:** select the 205 KB SVG block, Ctrl+C, Delete, Ctrl+V, repeat 20x. Block count stays at 240 throughout.

**Before**
```
nodes       15,730 -> 91,510   (+2,821 per cycle)
listeners    2,046 -> 14,646     (+630 per cycle)
heap         110.5 -> 322.3 MB
```
A forced GC freed none of it. A heap snapshot showed what was holding it: `TextView`/`MarkView`/`LineView`/`GutterElement --dom-->`, keeping detached `<div class="cm-line">` and `ͼ*` spans alive. A performance trace also showed CodeMirror's `onSelectionChange` running about 58 times a second, which is those leftover observers.

**After**
```
nodes       11,025 -> 11,025   (+0)
listeners    1,353 ->  1,353   (+0)
heap          97.8 ->  149.2 MB   <- what is left is the history stack, fixed in 2 below
```

Checked by running the same test with only this commit removed, so nothing else differed. This is the shared code editor, so the same leak is fixed for client scripts, custom CSS and the page data script.

## 2. Canvas history was capped by entry count, not size

`useCanvasHistory` saves a full `JSON.stringify` of the whole block tree on every edit, and only stops at 500 entries.

**Before**: on a 743 KB page, 120 edits:
```
undo stack   120 entries, 89,184,926 chars (85 MB), still growing toward 500
heap kept    +185.6 MB
ceiling      ~775 MB before a single entry is dropped
```

**After** — same 120 edits:
```
undo stack   caps at 29 entries, 20.6 MB
heap kept     +41.6 MB
```

There is now a size limit too, whichever is reached first, and it always keeps at least 10 entries so undo still works on a page too big for the budget. Redo is trimmed the same way.

It also fixes a bug next to it: `createHistoryRecord` kept a reference to the **live** `selectedBlockIds` set, so every saved entry followed the current selection instead of the one it was taken with, and undo restored the wrong blocks.



## 3. Oversized SVGs no longer have to live in the page

An inline SVG is stored in the page itself. Every autosave sends all of it, every history entry copies it, and each of its paths becomes a real element in the canvas.

**Before:** a 205 KB Figma export pasted straight into the page, with no way to get it out again.

**After:** an SVG over 20 KB can become a file instead, from three places:

- **On paste**: asks `Upload as File` / `Keep Inline`
<img width="469" height="252" alt="Screenshot 2026-08-27 at 10 55 19 PM" src="https://github.com/user-attachments/assets/e4242750-8810-4993-9a81-cc62e45f5f1d" />


Converting keeps the block's id, position and styles, and just points it at the file. An SVG coloured by a Builder token is never offered, because an `<img>` cannot read CSS variables and the theming would break.