### PR TITLE
feat: published status across dashboard and editor

### DIFF
--- a/frontend/src/components/DashboardHead.vue
+++ b/frontend/src/components/DashboardHead.vue
@@ -1,9 +1,11 @@
 <template>
 	<div class="m-auto flex w-3/4 max-w-6xl items-center justify-between bg-surface-base px-3.5 py-5 pt-8">
-		<h1 class="text-2xl-semibold text-ink-gray-9">
+		<h1
+			class="text-2xl-semibold truncate text-ink-gray-9"
+			:title="builderStore.activeFolder || __('All Pages')">
 			{{ builderStore.activeFolder || __("All Pages") }}
 		</h1>
-		<div class="flex gap-2">
+		<div class="flex shrink-0 gap-2">
 			<div>
 				<Button variant="solid" v-if="selectionMode && selectedPages.size" @click="promptSelectFolder()">
 					{{ __("Move To Folder") }}

--- a/frontend/src/components/PageCard.vue
+++ b/frontend/src/components/PageCard.vue
@@ -24,14 +24,25 @@
 						</p>
 					</UseTimeAgo>
 				</span>
-				<PageActionsDropdown :page="page" size="xs" placement="right">
-					<Button
-						icon="lucide-more-horizontal"
-						size="sm"
-						variant="ghost"
-						class="bg-surface-elevation-1 !text-ink-gray-5 hover:!text-ink-gray-9"
-						@click.stop></Button>
-				</PageActionsDropdown>
+				<div class="flex shrink-0 items-center gap-1.5">
+					<Tooltip
+						v-if="page.published && page.authenticated_access"
+						:text="__('This page has limited access')"
+						:hoverDelay="0.5">
+						<span class="lucide-shield-user size-3.5 text-ink-amber-6" />
+					</Tooltip>
+					<Tooltip v-else-if="page.published" :text="__('Publicly accessible')" :hoverDelay="0.5">
+						<span class="lucide-globe size-3.5 text-ink-gray-5" />
+					</Tooltip>
+					<PageActionsDropdown :page="page" size="xs" placement="right">
+						<Button
+							icon="lucide-more-horizontal"
+							size="sm"
+							variant="ghost"
+							class="bg-surface-elevation-1 !text-ink-gray-5 hover:!text-ink-gray-9"
+							@click.stop></Button>
+					</PageActionsDropdown>
+				</div>
 			</div>
 		</div>
 	</router-link>
@@ -42,6 +53,7 @@ import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
 import { BuilderPage } from "@/types/doctypes";
 import { getUserInfo } from "@/usersInfo";
 import { UseTimeAgo } from "@vueuse/components";
+import { Tooltip } from "frappe-ui";
 
 const props = defineProps<{
 	page: BuilderPage;

--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -17,6 +17,11 @@
 							class="lucide-shield-user size-4 text-ink-amber-6"
 							v-if="pageStore.activePage?.published && pageStore.activePage?.authenticated_access" />
 					</Tooltip>
+					<Tooltip :text="__('Publicly accessible')" :hoverDelay="0.6">
+						<span
+							class="lucide-globe size-4 text-ink-gray-5"
+							v-if="pageStore.activePage?.published && !pageStore.activePage?.authenticated_access" />
+					</Tooltip>
 					<span
 						class="max-w-48 truncate text-base text-ink-gray-8"
 						:title="pageStore?.activePage?.page_title || __('My Page')">

--- a/frontend/src/pages/PageBuilderDashboard.vue
+++ b/frontend/src/pages/PageBuilderDashboard.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex h-screen">
 		<DashboardSidebar></DashboardSidebar>
-		<div class="flex w-full flex-1 flex-col overflow-hidden pb-10">
+		<div class="flex w-full flex-1 flex-col overflow-hidden">
 			<DashboardToolbar class="sticky top-0" />
 			<DashboardHead />
 			<DashboardContent />


### PR DESCRIPTION
**Description**
No glanceable way to tell if a page is live. Grid view was the only dashboard layout without a publish indicator (list has a badge, tree has a crossed-out globe), and the editor had none at all.

**Changes:**
Adds a globe icon for published pages in two places that had no publish indicator: grid cards on the dashboard and the page title in the editor toolbar. 

Also fixes two dashboard layout bugs: the heading now truncates instead of wrapping at narrow widths, and pb-10 on the scroll column was clipping the last row of cards

Before :

https://github.com/user-attachments/assets/5b02c1d8-b6ca-4b46-8bed-3ad254ed0996

Now:

https://github.com/user-attachments/assets/69ebefe1-8e3a-4d28-823f-168ad3d1d434
