### PR TITLE
fix: block traversal segments in standard page export paths

### DIFF
--- a/builder/builder/tests/test_utils.py
+++ b/builder/builder/tests/test_utils.py
@@ -14,6 +14,7 @@ from builder.utils import (
 	copy_img_to_asset_folder,
 	escape_single_quotes,
 	execute_script,
+	export_dir_name,
 	extract_components_from_blocks,
 	get_builder_page_preview_file_paths,
 	get_template_assets_folder_path,
@@ -22,6 +23,7 @@ from builder.utils import (
 	normalize_legacy_raw_styles,
 	process_block_assets,
 	remove_unsafe_fields,
+	safe_segment,
 	sanitize_style_value,
 	split_styles,
 )
@@ -56,6 +58,30 @@ class TestBuilderUtils(FrappeTestCase):
 
 		for input_str, expected in test_cases.items():
 			self.assertEqual(escape_single_quotes(input_str), expected)
+
+	def test_export_dir_name(self):
+		test_cases = {
+			"Home Page": "home_page",
+			"Nav-Bar": "nav_bar",
+			"about/us": "about_us",
+			"../../etc/passwd": ".._.._etc_passwd",
+			"..\\..\\secrets": ".._.._secrets",
+		}
+
+		for input_str, expected in test_cases.items():
+			self.assertEqual(export_dir_name(input_str), expected)
+
+	def test_export_dir_name_rejects_traversal_segments(self):
+		for name in ("", ".", ".."):
+			with self.assertRaises(frappe.ValidationError):
+				export_dir_name(name)
+
+	def test_safe_segment_keeps_the_name_within_one_directory(self):
+		self.assertEqual(safe_segment("a/b\\c"), "a_b_c")
+
+		for name in ("", ".", ".."):
+			with self.assertRaises(frappe.ValidationError):
+				safe_segment(name)
 
 	def test_preview_file_paths(self):
 		test_page = frappe.get_doc(

--- a/builder/export_import_standard_page.py
+++ b/builder/export_import_standard_page.py
@@ -53,10 +53,10 @@ def export_page_as_standard(page_name, target_app):
 	data_script = page_config.get("page_data_script") or ""
 	page_config = frappe.as_json(page_config, ensure_ascii=False)
 
-	with open(config_file_path, "w", encoding="utf-8") as f:
+	with open(config_file_path, "w", encoding="utf-8") as f:  # nosemgrep
 		f.write(page_config)
 
-	with open(data_script_path, "w", encoding="utf-8") as f:
+	with open(data_script_path, "w", encoding="utf-8") as f:  # nosemgrep
 		f.write(data_script)
 
 	client_scripts = [row.builder_script for row in page_doc.client_scripts]

--- a/builder/template_sync.py
+++ b/builder/template_sync.py
@@ -42,18 +42,8 @@ from builder.utils import (
 	export_client_scripts,
 	extract_components_from_blocks,
 	make_records,
+	safe_segment,
 )
-
-
-def safe_segment(name):
-	"""Make a value safe for use as one filesystem path segment.
-
-	Replaces path separators and blocks empty/traversal values.
-	"""
-	segment = str(name).replace("/", "_").replace("\\", "_")
-	if segment in ("", ".", ".."):
-		frappe.throw(frappe._("Unsafe template fixture name: {0}").format(name))
-	return segment
 
 
 def get_templates_root(app="builder"):

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -59,13 +59,24 @@ def get_installed_app_path(app_name) -> str | None:
 	return frappe.get_app_path(app_name)
 
 
+def safe_segment(name) -> str:
+	"""Make a value safe for use as one filesystem path segment.
+
+	Replaces path separators and blocks empty/traversal values.
+	"""
+	segment = str(name).replace("/", "_").replace("\\", "_")
+	if segment in ("", ".", ".."):
+		frappe.throw(frappe._("Unsafe fixture name: {0}").format(name))
+	return segment
+
+
 def export_dir_name(name) -> str:
 	"""Directory and JSON file name for an exported record.
 
 	Shared by every exporter and by the delete helpers, so a record always
 	lands where the cleanup looks for it. frappe.scrub keeps a slash.
 	"""
-	return frappe.scrub(str(name)).replace("/", "_")
+	return safe_segment(frappe.scrub(str(name)))
 
 
 def has_page_permission(ptype: str = "write", message: str | None = None):
@@ -746,9 +757,9 @@ def export_client_scripts(client_scripts, client_scripts_path):
 		extension = "js" if script_doc.script_type == "JavaScript" else "css"
 		script_path = os.path.join(script_dir, f"client_script.{extension}")
 
-		with open(script_config_path, "w", encoding="utf-8") as f:
+		with open(script_config_path, "w", encoding="utf-8") as f:  # nosemgrep
 			f.write(frappe.as_json(script_config, ensure_ascii=False))
-		with open(script_path, "w", encoding="utf-8") as f:
+		with open(script_path, "w", encoding="utf-8") as f:  # nosemgrep
 			f.write(script_content)
 
 


### PR DESCRIPTION
The semgrep `frappe-security-file-traversal` rule fires on the standard page exporters (`export_page_as_standard`, `export_client_scripts`), which write fixtures into an installed app's `builder_files/` directory.

Both are gated behind `frappe.conf.developer_mode` and the path segments come from `export_dir_name()`, which scrubs the record name and replaces slashes. It did not, however, reject `.` or `..` as a whole segment, so a record named `..` would write one directory above its export root.

`template_sync.py` already had `safe_segment()` for exactly this. Moved it into `builder/utils.py` (which `template_sync` already imports from), routed `export_dir_name()` through it, and marked the audited writes `# nosemgrep`, matching how the template exporter annotates its own.

Tested with `test_standard_page_sync` (28) and `test_utils` (21), all passing.