### PR TITLE
ci: let the release job install past frontend peer conflicts

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           node-version: 24
 
+      # npm resolves the frontend workspace here and enforces peer ranges yarn only warns about
       - name: Setup dependencies
         run: |
-          npm install @semantic-release/git @semantic-release/exec --no-save
+          npm install @semantic-release/git @semantic-release/exec --no-save --legacy-peer-deps
 
       - name: Create Release
         env:


### PR DESCRIPTION
The v1.33.0 release never ran: [the job](https://github.com/frappe/builder/actions/runs/33160943844/job/98814983461) failed at **Setup dependencies**, before `semantic-release` was invoked.

```
npm error code ERESOLVE
npm error Found: eslint@10.8.1
npm error Could not resolve dependency:
npm error peer eslint@"^2 || ... || ^9" from eslint-plugin-import@2.32.0
```

`#732` bumped the frontend to eslint 10 while `eslint-plugin-import@^2.27.5` still peers on eslint <= 9. We install with yarn v1, which only warns about peer ranges, so it landed clean. The release job is the one place we run `npm` at the workspace root, and npm enforces peers, so it refuses to install the two semantic-release plugins.

Adding `--legacy-peer-deps` puts npm on the same footing as the yarn install the rest of the repo uses.

Verified on a clean checkout of `master` (2ea28db7): reproduced the ERESOLVE, then confirmed the flag installs, all plugins load, and a `--dry-run` resolves **`The next release version is 1.33.0`** (minor, 928 commits).

Merging this pushes `master` and re-triggers the release.