### PR TITLE
fix: stepper arrows on grid Columns and Rows inputs

### DIFF
--- a/frontend/src/components/Controls/Input.vue
+++ b/frontend/src/components/Controls/Input.vue
@@ -78,6 +78,8 @@ interface UseNumberInputOptions {
 }
 
 const isStrictNumber = computed(() => {
+	// Controls like grid Columns/Rows bind a plain number, not a string.
+	if (typeof data.value === "number") return Number.isFinite(data.value);
 	if (typeof data.value !== "string") return false;
 
 	return /^\d*\.?\d+(px|%|em|rem)?$/.test(data.value.trim());


### PR DESCRIPTION
**Problem**
The up/down stepper arrows never render on the Columns and Rows inputs in the Layout section, though every other field has them.

**Cause**
BlockGridLayoutHandler binds a number (parseRepeatFunction uses parseInt), but Input.vue's isStrictNumber returned false for any non-string, so canShowArrows short-circuited.

**Changes**
Input.vue — isStrictNumber accepts finite numbers.

Before:

https://github.com/user-attachments/assets/1282e1a5-534a-4093-916c-55a74d6f4e9d

Now:

https://github.com/user-attachments/assets/6dcf4107-1a18-46d4-94d7-b8fd1405fdbb
