### PR TITLE
fix: close block context menu when a keyboard command runs

### DIFF
--- a/frontend/src/components/BlockContextMenu.vue
+++ b/frontend/src/components/BlockContextMenu.vue
@@ -35,7 +35,12 @@ const showContextMenu = (event: MouseEvent, refBlock: Block) => {
 	contextMenu.value?.show(event);
 };
 
+const hideContextMenu = () => {
+	contextMenu.value?.hide();
+};
+
 defineExpose({
 	showContextMenu,
+	hideContextMenu,
 });
 </script>

--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -63,7 +63,13 @@ export function commandShortcuts() {
 			...command.keys!,
 			group: commandGroupLabels[command.group] ?? __(command.group),
 			condition: command.condition,
-			handler: command.action,
+			// the block context menu is portalled and keeps focus, so a keyboard
+			// command never dismisses it: it would stay on top of whatever the
+			// command opens 
+			handler: () => {
+				builderStore.blockContextMenu?.hideContextMenu();
+				command.action();
+			},
 		}));
 }
 

--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -63,9 +63,6 @@ export function commandShortcuts() {
 			...command.keys!,
 			group: commandGroupLabels[command.group] ?? __(command.group),
 			condition: command.condition,
-			// the block context menu is portalled and keeps focus, so a keyboard
-			// command never dismisses it: it would stay on top of whatever the
-			// command opens 
 			handler: () => {
 				builderStore.blockContextMenu?.hideContextMenu();
 				command.action();


### PR DESCRIPTION
### Problem

Select a block, right-click to open the context menu, then press `?`.
The Keyboard Shortcuts modal opens but the context menu stays on
screen, floating on top of the modal.

https://github.com/user-attachments/assets/37362283-75ac-4656-b128-7351b1db3f1e

### Fix

`commandShortcuts()` now wraps each command's action to dismiss the
block context menu before running it

https://github.com/user-attachments/assets/d300701b-692b-4b28-8e2e-0a42db260aaa



