### PR TITLE
fix: two keyboard shortcut bugs

### DIFF
--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -85,6 +85,11 @@ const builderStore = useBuilderStore();
 const pageStore = usePageStore();
 const canvasStore = useCanvasStore();
 
+// module scope, not inside the command action: useStorage subscribes to storage
+// events and registers its cleanup on the active effect scope. A key handler has
+// none, so calling it per keypress would leak a subscription every time.
+const copiedStyle = useStorage("copiedStyle", { blockId: "", style: {} }, sessionStorage) as Ref<StyleCopy>;
+
 const setLayersTab = async () => {
 	builderStore.showLeftPanel = true;
 	builderStore.leftPanelActiveTab = "Layers";
@@ -263,11 +268,6 @@ commands.register({
 	action: () => {
 		if (!blockController.isBlockSelected() || blockController.multipleBlocksSelected()) return;
 		const block = blockController.getSelectedBlocks()[0];
-		const copiedStyle = useStorage(
-			"copiedStyle",
-			{ blockId: "", style: {} },
-			sessionStorage,
-		) as Ref<StyleCopy>;
 		copiedStyle.value = { blockId: block.blockId, style: block.getStylesCopy() };
 	},
 });

--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -85,9 +85,7 @@ const builderStore = useBuilderStore();
 const pageStore = usePageStore();
 const canvasStore = useCanvasStore();
 
-// module scope, not inside the command action: useStorage subscribes to storage
-// events and registers its cleanup on the active effect scope. A key handler has
-// none, so calling it per keypress would leak a subscription every time.
+// module scope: useStorage in the handler would leak a subscription per keypress
 const copiedStyle = useStorage("copiedStyle", { blockId: "", style: {} }, sessionStorage) as Ref<StyleCopy>;
 
 const setLayersTab = async () => {

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -57,7 +57,6 @@ const useBuilderStore = defineStore("builderStore", {
 			attribute: "data-theme",
 		}),
 		canvasDarkMode: useStorage("canvasDarkMode", false),
-		highlightBlocksWithClientScripts: false,
 		showSettingsDialog: false,
 		settingsActiveTab: useStorage("settingsActiveTab", "page_general"),
 		openImageUpload: false,

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -430,20 +430,6 @@ export function useBuilderEvents(
 				builderStore.mode = "move";
 			},
 		},
-		{
-			key: "l",
-			ctrl: true,
-			shift: true,
-			triggeredOn: "hold",
-			description: __("Highlight Blocks with Client Scripts"),
-			group: __("View"),
-			onHold: () => {
-				builderStore.highlightBlocksWithClientScripts = true;
-			},
-			onRelease: () => {
-				builderStore.highlightBlocksWithClientScripts = false;
-			},
-		},
 	]);
 
 	// on tab activation, reload for latest data


### PR DESCRIPTION
**What**

Ctrl+Shift+C leaked a listener per press copy-block-styles called useStorage() inside action(). VueUse attaches cleanup to Vue's active effect scope; a keypress handler has none, so the cleanup was silently dropped. Now hoisted to module scope

Ctrl+Shift+L was bound twice
The "Highlight Blocks with Client Scripts" hold binding collided with the Layers tab (highlightBlocksWithClientScripts was written, never read). Removed the binding and the dead store field.

<img width="452" height="589" alt="Screenshot 2026-09-03 120028" src="https://github.com/user-attachments/assets/5c39fdfb-8ee9-4528-a1c9-465ac6f16fd8" />
