### PR TITLE
fix: match font dropdown width to its input field

### DIFF
--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -266,6 +266,7 @@ const resolveLabelStyle = (option: Option): StyleValue | undefined =>
 
 const clearSelection = () => emit("update:modelValue", null);
 
+
 const getInputValue = (event: Event) => (event.target as HTMLInputElement)?.value?.trim();
 
 const submitArbitraryValue = (inputValue: string) => {

--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -64,10 +64,8 @@
 						referenceElementSelector ? 'fixed' : 'absolute',
 						!referenceElementSelector && openOptionsAbove ? 'bottom-full mb-1' : '',
 						!referenceElementSelector && !openOptionsAbove ? 'mt-1' : '',
-						// wider than the input: anchor right so the extra width grows away from the panel edge
-						!referenceElementSelector && optionsMinWidth ? 'right-0' : '',
 					]"
-					:style="[fixedPositionStyles, optionsMinWidthStyle]"
+					:style="fixedPositionStyles"
 					@after-enter="setOptionsPosition"
 					@after-leave="fixedPositionStyles = {}">
 					<div class="options-list overflow-y-auto p-1 empty:p-0">
@@ -87,7 +85,10 @@
 								@mousedown.prevent
 								class="group flex cursor-default select-none items-center gap-2 rounded px-2 py-1.5 text-sm text-ink-gray-9 transition-colors data-[disabled]:pointer-events-none data-[highlighted]:bg-surface-gray-1 data-[disabled]:opacity-50">
 								<component v-if="option.prefix" :is="option.prefix" class="h-4 w-4 flex-shrink-0" />
-								<MiddleTruncate :text="option.label" :style="resolveLabelStyle(option)" />
+								<MiddleTruncate
+									:text="option.label"
+									:marquee="marqueeOptions"
+									:style="resolveLabelStyle(option)" />
 								<component
 									v-if="option.suffix"
 									:is="option.suffix"
@@ -170,8 +171,7 @@ interface Props {
 	referenceElementSelector?: string;
 	allowArbitraryValue?: boolean;
 	disabled?: boolean;
-	// floor for the options width, so a narrow input doesn't force truncated labels
-	optionsMinWidth?: number;
+	marqueeOptions?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -195,10 +195,6 @@ const hasValue = computed(() => props.modelValue != null && props.modelValue !==
 const comboboxInput = ref<ComponentPublicInstance | null>(null);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 const fixedPositionStyles = ref<Record<string, string>>({});
-// the fixed path bakes the floor into its explicit width instead
-const optionsMinWidthStyle = computed(() =>
-	props.optionsMinWidth && !props.referenceElementSelector ? { minWidth: `${props.optionsMinWidth}px` } : {},
-);
 const openOptionsAbove = ref(false);
 const allOptions = computed(() => (props.getOptions ? asyncOptions.value : props.options));
 
@@ -375,8 +371,7 @@ const getFixedPositionStyles = (): Record<string, string> => {
 	const bottom = openOptionsAbove.value
 		? window.innerHeight - comboboxInputRect.top + OPTIONS_GAP + "px"
 		: "unset";
-	const width = Math.max(comboboxInputRect.width, props.optionsMinWidth || 0);
-	// a widened list keeps its left edge on the input but never leaves the viewport
+	const width = comboboxInputRect.width;
 	const left = Math.min(comboboxInputRect.left, window.innerWidth - width - OPTIONS_GAP) + "px";
 
 	return {

--- a/frontend/src/components/Controls/FontInput.vue
+++ b/frontend/src/components/Controls/FontInput.vue
@@ -10,7 +10,7 @@
 				:actionButton="{ component: FontUploader }"
 				:inputStyle="inputStyle"
 				:referenceElementSelector="referenceElementSelector"
-				:optionsMinWidth="240"
+				marqueeOptions
 				@update:modelValue="handleUpdate" />
 		</Tooltip>
 	</div>

--- a/frontend/src/components/MiddleTruncate.vue
+++ b/frontend/src/components/MiddleTruncate.vue
@@ -4,20 +4,34 @@
 		ref="wrapper"
 		class="flex w-full overflow-hidden whitespace-nowrap"
 		:title="text"
-		:style="hasOverflow ? 'mask-image: linear-gradient(to right, black 90%, transparent)' : ''">
-		<span class="min-w-8 truncate">{{ leading }}</span>
-		<span v-if="trailing">{{ trailing }}</span>
+		:style="maskStyle"
+		@mouseenter="marquee && startScroll()"
+		@mouseleave="marquee && stopScroll()">
+		<span v-if="marquee" ref="scroller" class="marquee-text flex-none" :style="scrollerStyle">{{ text }}</span>
+		<template v-else>
+			<span class="min-w-8 truncate">{{ leading }}</span>
+			<span v-if="trailing">{{ trailing }}</span>
+		</template>
 	</component>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, useTemplateRef } from "vue";
 
-const props = defineProps<{ text: string; as?: string }>();
+const props = defineProps<{
+	text: string;
+	as?: string;
+	marquee?: boolean;
+}>();
 const as = computed(() => props.as ?? "div");
+const SCROLL_SPEED = 60;
+const START_DELAY = 0.3;
+const RESET_DURATION = 0.2;
 
 const wrapper = useTemplateRef<HTMLElement>("wrapper");
+const scroller = useTemplateRef<HTMLElement>("scroller");
 const hasOverflow = ref(false);
+const scrollDistance = ref(0);
 
 let observer: ResizeObserver;
 
@@ -27,10 +41,34 @@ onMounted(() => {
 	};
 	observer = new ResizeObserver(check);
 	observer.observe(wrapper.value!);
+	if (scroller.value) observer.observe(scroller.value);
 	check();
 });
 
 onUnmounted(() => observer?.disconnect());
+
+// measured on hover rather than kept live
+const startScroll = () => {
+	const overflow = (wrapper.value?.scrollWidth ?? 0) - (wrapper.value?.clientWidth ?? 0);
+	scrollDistance.value = Math.max(Math.ceil(overflow), 0);
+};
+
+const stopScroll = () => (scrollDistance.value = 0);
+
+const scrollerStyle = computed(() => {
+	const scrolling = scrollDistance.value > 0;
+	return {
+		transform: `translateX(-${scrollDistance.value}px)`,
+		transitionDuration: `${scrolling ? scrollDistance.value / SCROLL_SPEED : RESET_DURATION}s`,
+		transitionDelay: `${scrolling ? START_DELAY : 0}s`,
+	};
+});
+
+const maskStyle = computed(() =>
+	hasOverflow.value && !scrollDistance.value
+		? "mask-image: linear-gradient(to right, black 90%, transparent)"
+		: "",
+);
 
 const suffixLen = computed(() => {
 	const len = props.text.length;
@@ -40,3 +78,17 @@ const suffixLen = computed(() => {
 const leading = computed(() => (suffixLen.value ? props.text.slice(0, -suffixLen.value) : props.text));
 const trailing = computed(() => (suffixLen.value ? props.text.slice(-suffixLen.value) : ""));
 </script>
+
+<style scoped>
+.marquee-text {
+	transition-property: transform;
+	transition-timing-function: linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.marquee-text {
+		transition-duration: 0s !important;
+		transition-delay: 0s !important;
+	}
+}
+</style>

--- a/frontend/src/components/MiddleTruncate.vue
+++ b/frontend/src/components/MiddleTruncate.vue
@@ -3,11 +3,10 @@
 		:is="as"
 		ref="wrapper"
 		class="flex w-full overflow-hidden whitespace-nowrap"
+		:class="{ 'marquee-clip': marquee }"
 		:title="text"
-		:style="maskStyle"
-		@mouseenter="marquee && startScroll()"
-		@mouseleave="marquee && stopScroll()">
-		<span v-if="marquee" ref="scroller" class="marquee-text flex-none" :style="scrollerStyle">{{ text }}</span>
+		:style="wrapperStyle">
+		<span v-if="marquee" ref="scroller" class="marquee-text flex-none">{{ text }}</span>
 		<template v-else>
 			<span class="min-w-8 truncate">{{ leading }}</span>
 			<span v-if="trailing">{{ trailing }}</span>
@@ -16,6 +15,7 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from "vue";
 import { computed, onMounted, onUnmounted, ref, useTemplateRef } from "vue";
 
 const props = defineProps<{
@@ -24,9 +24,10 @@ const props = defineProps<{
 	marquee?: boolean;
 }>();
 const as = computed(() => props.as ?? "div");
+
+const MASK = "linear-gradient(to right, black 90%, transparent)";
+// px per second, so long and short names read at the same pace
 const SCROLL_SPEED = 60;
-const START_DELAY = 0.3;
-const RESET_DURATION = 0.2;
 
 const wrapper = useTemplateRef<HTMLElement>("wrapper");
 const scroller = useTemplateRef<HTMLElement>("scroller");
@@ -37,38 +38,29 @@ let observer: ResizeObserver;
 
 onMounted(() => {
 	const check = () => {
-		hasOverflow.value = (wrapper.value?.scrollWidth ?? 0) > (wrapper.value?.clientWidth ?? 0);
+		const overflow = (wrapper.value?.scrollWidth ?? 0) - (wrapper.value?.clientWidth ?? 0);
+		hasOverflow.value = overflow > 0;
+		scrollDistance.value = Math.max(Math.ceil(overflow), 0);
 	};
 	observer = new ResizeObserver(check);
 	observer.observe(wrapper.value!);
+	// the text can outgrow the box without the box resizing, e.g. a font preview loading in
 	if (scroller.value) observer.observe(scroller.value);
 	check();
 });
 
 onUnmounted(() => observer?.disconnect());
 
-// measured on hover rather than kept live
-const startScroll = () => {
-	const overflow = (wrapper.value?.scrollWidth ?? 0) - (wrapper.value?.clientWidth ?? 0);
-	scrollDistance.value = Math.max(Math.ceil(overflow), 0);
-};
-
-const stopScroll = () => (scrollDistance.value = 0);
-
-const scrollerStyle = computed(() => {
-	const scrolling = scrollDistance.value > 0;
+// measured here, applied by CSS: the reveal keys off a `data-highlighted` attribute, and only
+// CSS can react to one without the row re-rendering
+const wrapperStyle = computed<CSSProperties>(() => {
+	if (!props.marquee) return { maskImage: hasOverflow.value ? MASK : undefined };
 	return {
-		transform: `translateX(-${scrollDistance.value}px)`,
-		transitionDuration: `${scrolling ? scrollDistance.value / SCROLL_SPEED : RESET_DURATION}s`,
-		transitionDelay: `${scrolling ? START_DELAY : 0}s`,
+		"--marquee-mask": hasOverflow.value ? MASK : "none",
+		"--marquee-distance": `${scrollDistance.value}px`,
+		"--marquee-duration": `${scrollDistance.value / SCROLL_SPEED}s`,
 	};
 });
-
-const maskStyle = computed(() =>
-	hasOverflow.value && !scrollDistance.value
-		? "mask-image: linear-gradient(to right, black 90%, transparent)"
-		: "",
-);
 
 const suffixLen = computed(() => {
 	const len = props.text.length;
@@ -80,11 +72,31 @@ const trailing = computed(() => (suffixLen.value ? props.text.slice(-suffixLen.v
 </script>
 
 <style scoped>
-.marquee-text {
-	transition-property: transform;
-	transition-timing-function: linear;
+.marquee-clip {
+	mask-image: var(--marquee-mask, none);
 }
 
+.marquee-text {
+	transform: translateX(0);
+	/* the way back */
+	transition: transform 0.2s linear 0s;
+}
+
+/* a pointer and the arrow keys set the same attribute, so one rule covers both */
+.marquee-clip:hover,
+[data-highlighted] .marquee-clip {
+	mask-image: none;
+}
+
+.marquee-clip:hover .marquee-text,
+[data-highlighted] .marquee-text {
+	transform: translateX(calc(-1 * var(--marquee-distance, 0px)));
+	transition-duration: var(--marquee-duration, 0s);
+	/* so a row brushed past on the way to another doesn't set off */
+	transition-delay: 0.3s;
+}
+
+/* jump to the end rather than travel, so the tail stays reachable */
 @media (prefers-reduced-motion: reduce) {
 	.marquee-text {
 		transition-duration: 0s !important;


### PR DESCRIPTION
**Problem**
The font dropdown was pinned to a 240px minimum width, unlike other property dropdowns.
<img width="347" height="587" alt="image" src="https://github.com/user-attachments/assets/c1104ab1-1f23-4d6e-bd32-77dcac7759b8" />

**Solution**
Remove the fixed minimum width and use a hover marquee to reveal truncated labels.
When enabled, long option labels scroll horizontally into view on hover, preserving access to the full name without increasing the dropdown width.
<img width="364" height="670" alt="Recording 2026-09-04 154814" src="https://github.com/user-attachments/assets/c3ed5ba5-da27-410a-ae7e-992fcfb712f2" />
