### PR TITLE
fix: Use consistent title casing for shortcut and menu labels

### DIFF
--- a/builder/locale/ar.po
+++ b/builder/locale/ar.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "وصف"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "حرك"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "فتح في علامة تبويب جديدة"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "حفظ"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "لون الخط"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "تبديل المظهر"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/bg.po
+++ b/builder/locale/bg.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr ""
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/bs.po
+++ b/builder/locale/bs.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "Dodaj meta oznake, stilove i skripte u zaglavlje stranice"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "Dodaj svojstvo"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "Nazad na sve predloške"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "Nazad na Web Uređivač"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "Sažmi Sve Slojeve"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "Sažmi čvor ili se pomakni prema gore u stablu stranice"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "Kontejner (c)"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "Kontejnerski način rada"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "Kontrole"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "Pretvori u Kolekciju"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "Kopiraj Stil"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "Kopiraj stilove bloka"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "Obriši Stranicu"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "Obriši odabrane blokove"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "Obriši varijablu"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "Obriši {0} varijabli"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "Poništi odabir stranica"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "Dupliraj Stranicu"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "Dupliraj blok"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "Izvrši Blokovske Skripte u Uređivaču"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "Izađi iz trenutnog načina rada"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "Proširi Sve Slojeve"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "Proširi čvor ili se pomakni niže u stablu stranice"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "Uklopi Unutar"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "Prilagodi radnu površinu ekranu"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "Fokus na Svojstva Pretrage"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "Fokus na svojstva pretrage"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "Istakni Blokove pomoću Klijentskih Skripti"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "Drži za način kretanja"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "Slika je prevelika. Koristi sliku manju od 5 MB."
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "Način Slike"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "Premjesti"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "Premjesti / ručni način rada"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "Premjesti u Mapu"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "Premjesti niže u stablu stranice"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "Premjesti u grupu"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "Premjesti gore u stablu stranice"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "Otvori u Novoj Kartici"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "Otvori stranicu ili prebacite mapu u stablu stranica"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "Ukloni Stop"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "Ukloni iz grupe"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "Poništi Poništavanja"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "Poništi zumiranje radne površine"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "Spremi"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "Spremi kao Komponentu"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "Spremi trenutnu verziju"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "Spremi stranicu / komponentu"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr "Predložak Pretrage"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "Blokovi pretrage"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "Odaberi standard boju"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "Odaberi način rada"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "Prikaži Desni Panel"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Prikaži prečice na tastaturi"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "Boja Teksta"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "Tekstualni način"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "Prebaci temu"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "Uključi/isključi tamni način rada platna"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "Uključi/isključi lijevi panel"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "Uključi/isključi panele"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "Omotaj"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "Omotaj u Posudu"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-Indeks"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Uvećaj"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Umanji"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/cs.po
+++ b/builder/locale/cs.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Popis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Přesunout"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Otevřít na nové záložce"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Uložit"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Zobrazit klávesové zkratky"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Barva textu"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/da.po
+++ b/builder/locale/da.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Beskrivelse"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Flyt"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Åbn i ny fane"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Gem"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Søgeskabelon"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Vis tastaturgenveje"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Tekstfarve"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Skift tema"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Zoom ind"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Zoom ud"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/de.po
+++ b/builder/locale/de.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "Meta-Tags, Stile und Skripte zum Seitenkopf hinzufügen"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "Eigenschaft hinzufügen"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "Zurück zu allen Vorlagen"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "Zurück zum Builder"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "Alle Ebenen zuklappen"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "Knoten einklappen oder im Seitenbaum nach oben verschieben"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "Container (c)"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "Container-Modus"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "Steuerelemente"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "In Sammlung umwandeln"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "Stil kopieren"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "Blockstile kopieren"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "Seite löschen"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "Ausgewählte Blöcke löschen"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "Variable löschen"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "{0} Variablen löschen"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "Seitenauswahl aufheben"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "Seite duplizieren"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "Block duplizieren"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "Blockskripte im Editor ausführen"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "Aktuellen Modus beenden"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "Alle Ebenen erweitern"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "Knoten ausklappen oder im Seitenbaum nach unten verschieben"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "Einpassen"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "Canvas an Bildschirm anpassen"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "Eigenschaftssuche fokussieren"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "Eigenschaftssuche fokussieren"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "Blöcke mit Clientskripten hervorheben"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "Für Verschiebemodus gedrückt halten"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "Das Bild ist zu groß. Bitte verwenden Sie ein Bild, das kleiner als 5 MB ist."
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "Bildmodus"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "Verschieben"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "Verschiebe- / Handmodus"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "In Ordner verschieben"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "Im Seitenbaum nach unten verschieben"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "In Gruppe verschieben"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "Im Seitenbaum nach oben verschieben"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "In neuem Tab öffnen"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "Seite öffnen oder Ordner im Seitenbaum umschalten"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "Farbstopp entfernen"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "Aus Gruppe entfernen"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "Überschreibungen zurücksetzen"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "Canvas-Zoom zurücksetzen"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "Speichern"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "Als Komponente speichern"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "Aktuelle Version speichern"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "Seite / Komponente speichern"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "Blöcke suchen"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "Standardfarbe auswählen"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "Modus auswählen"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "Rechten Bereich anzeigen"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "Textfarbe"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "Textmodus"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "Theme wechseln"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "Canvas-Dunkelmodus umschalten"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "Linken Bereich umschalten"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "Bereiche umschalten"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "Umbrechen"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "In Container einschließen"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-Index"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Vergrößern"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Verkleinern"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/es.po
+++ b/builder/locale/es.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Descripción"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Mover"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Abrir en nueva pestaña"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Color del texto"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Cambiar tema"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/fa.po
+++ b/builder/locale/fa.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "شرح"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "اجرای اسکریپت‌های بلوک در ویرایشگر"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "حرکت"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "باز کردن در زبانه جدید"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "ذخیره"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "رنگ متن"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "تغییر تم"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "بزرگ‌نمایی"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "کوچک‌نمایی"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/fr.po
+++ b/builder/locale/fr.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Description"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Déplacer"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Rechercher un modèle"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Couleur du texte"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Basculer le thème"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/hi.po
+++ b/builder/locale/hi.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "विवरण"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "कदम"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "बचाना"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "पाठ का रंग"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/hr.po
+++ b/builder/locale/hr.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "Dodaj meta oznake, stilove i skripte u zaglavlje stranice"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "Dodaj svojstvo"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "Natrag na sve predloške"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "Natrag na Web Uređivač"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "Sažmi Sve Slojeve"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "Sažmi čvor ili pomakni se prema gore u stablu stranica"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "Kontejner (c)"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "Način Kontejnera"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "Kontrole"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "Pretvori u Kolekciju"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "Kopiraj Stil"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "Kopiraj stilove bloka"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "Izbriši Stranicu"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "Izbriši odabrane blokove"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "Izbriši varijablu"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "Izbriši {0} varijabli"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "Poništi odabir stranica"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "Dupliraj Stranicu"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "Dupliciraj blok"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "Izvrši Blokovske Skripte u Uređivaču"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "Izađi iz trenutnog načina rada"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "Proširi Sve Slojeve"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "Proširi čvor ili se pomakni prema dolje u stablu stranica"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "Uklopi Unutar"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "Prilagodi radnu površinu zaslonu"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "Fokus na Svojstva Pretrage"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "Fokus na svojstva pretrage"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "Istakni Blokove pomoću Klijentskih Skripti"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "Drži za način kretanja"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "Slika je prevelika. Koristi sliku manju od 5 MB."
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "Način Slike"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "Premjesti"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "Premjesti / ručni način"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "Premjesti u Mapu"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "Premjesti niže u stablu stranice"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "Premjesti u grupu"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "Premjesti gore u stablu stranice"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "Otvori u Novoj Kartici"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "Otvori stranicu ili prebacite mapu u stablu stranica"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "Ukloni Stop"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "Ukloni iz grupe"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "Poništi Poništavanja"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "Poništi zumiranje radne površine"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "Spremi"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "Spremi kao Komponentu"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "Spremi trenutnu verziju"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "Spremi stranicu / komponentu"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr "Predložak Pretraživanja"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "Blokovi pretrage"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "Odaberi standard boju"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "Odaberi način"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "Prikaži Desni Panel"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Prikaži tipkovničke prečace"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "Boja Teksta"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "Tekstualni način"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "Prebaci temu"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "Uključi/isključi tamni način radne površine"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "Uključi/isključi lijevi panel"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "Uključi/isključi panele"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "Umotaj"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "Omotaj u Posudu"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-Indeks"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Uvećaj"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Umanji"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/hu.po
+++ b/builder/locale/hu.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Leírás"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Áthelyezés"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Megnyitás új fülön"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Mentés"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Betűszín"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Téma Váltása"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/id.po
+++ b/builder/locale/id.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Deskripsi"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Bergerak"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Buka di Tab Baru"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Simpan"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Warna Teks"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/it.po
+++ b/builder/locale/it.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Descrizione"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Sposta"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Apri in nuova scheda"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Salva"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Colore del Testo"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/km.po
+++ b/builder/locale/km.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr ""
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/ko.po
+++ b/builder/locale/ko.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr ""
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/main.pot
+++ b/builder/locale/main.pot
@@ -164,7 +164,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -438,7 +438,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -833,7 +833,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -976,7 +976,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1000,7 +1000,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1032,7 +1032,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1272,15 +1272,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1306,7 +1306,7 @@ msgid "Description"
 msgstr ""
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1478,7 +1478,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1681,7 +1681,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1694,7 +1694,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1859,7 +1859,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1872,7 +1872,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2110,7 +2110,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2188,7 +2188,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2627,7 +2627,7 @@ msgid "Move"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2635,16 +2635,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2986,7 +2986,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3499,7 +3499,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3595,7 +3595,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3719,7 +3719,7 @@ msgid "Save"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3744,7 +3744,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3826,7 +3826,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3928,7 +3928,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4064,7 +4064,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4383,7 +4383,7 @@ msgid "Text Color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4543,15 +4543,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5014,7 +5014,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5113,11 +5113,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/mn.po
+++ b/builder/locale/mn.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "Хуудасны толгой хэсэгт мета шошго, хэв маяг болон скрипт нэмэх"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "Үзүүлэлт нэмэх"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "Бүх загвар руу буцах"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "Барилгачин руу буцах"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "Бүх давхаргыг хумих"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "Зангилааг хумих эсвэл хуудасны мод дотор дээш зөөх"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "Контейнер (в)"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "Контейнерын горим"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "Хяналтууд"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "Цуглуулга руу хөрвүүлэх"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "Хуулбарлах хэв маяг"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "Блокийн хэв маягийг хуулах"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "Хуудсыг устгах"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "Сонгосон блокуудыг устгах"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "Хувьсагчийг устгах"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "{0} хувьсагчийг устгах"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "Тайлбар"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "Хуудсуудыг сонгохоо болих"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "Давхардсан хуудас"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "Давхардсан блок"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "Редакторт Блок скриптүүдийг гүйцэтгэх"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "Одоогийн горимоос гарах"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "Бүх давхаргыг дэлгэх"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "Зангилааг өргөжүүлэх эсвэл хуудасны мод дотор доош зөөх"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "Дотор нь багтаах"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "Дэлгэцэнд зураг тохируулах"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "Үл хөдлөх хөрөнгийн хайлтыг фокуслах"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "Үл хөдлөх хөрөнгийн хайлтад анхаарлаа хандуулна уу"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "Клиент скриптүүдээр блокуудыг тодруулах"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "Хөдөлгөөнт горимд шилжихийн тулд удаан дарна уу"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "Зураг хэт том байна. 5 МБ-аас бага хэмжээтэй зураг ашиглана уу."
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "Зургийн горим"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "Зөөх"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "Хөдлөх / гар горим"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "Фолдер руу зөөх"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "Хуудасны мод дотор доош шилжих"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "Бүлэг рүү шилжих"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "Хуудасны модоор дээшээ шилжих"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "Шинэ таб дээр нээх"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "Хуудасны модонд хуудсыг нээх эсвэл фолдерыг асаах/унтраах"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "Зогсоолыг устгах"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "Бүлгээс хасах"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "Дахин дарах үйлдлийг дахин тохируулах"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "Зургийн томруулалтыг дахин тохируулах"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "Хадгалах"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "Бүрэлдэхүүн хэсэг болгон хадгалах"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "Одоогийн хувилбарыг хадгалах"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "Хуудас / бүрэлдэхүүн хэсгийг хадгалах"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr "Хайлтын загвар"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "Хайлтын блокууд"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "Анхдагч өнгө сонгох"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "Горим сонгох"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "Баруун самбарыг харуулах"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Гарын товчлолыг харуулах"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "Текстийн өнгө"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "Текст горим"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "Загварыг асаах/унтраах"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "Зурагны бараан горимыг асаах/унтраах"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "Зүүн самбарыг асаах/унтраах"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "Самбаруудыг асаах/унтраах"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "Боолт"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "Савлах сав"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-индекс"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Томруулж харах"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Жижигрүүлэх"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/my.po
+++ b/builder/locale/my.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "ဖော်ပြချက်"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "ရွှေ့မည်"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "တပ်အသစ်တွင် ဖွင့်"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "သိမ်းမည်။"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "စာသားအရောင်"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/nb.po
+++ b/builder/locale/nb.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Beskrivelse"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Flytt"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Åpne i ny fane"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Lagre"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Tekstfarge"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Bytt tema"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/nl.po
+++ b/builder/locale/nl.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Beschrijving"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Verhuizing"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Openen in nieuw tabblad"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "bewaren"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Tekstkleur"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Thema wisselen"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/pl.po
+++ b/builder/locale/pl.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Przenieś"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Otwórz w nowej karcie"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Zapisz"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Kolor tekstu"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Zmień motyw"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/pt.po
+++ b/builder/locale/pt.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Descrição"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Mover"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Abrir em novo separador"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Cor do texto"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/pt_BR.po
+++ b/builder/locale/pt_BR.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Descrição"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Mover"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Abrir em nova aba"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Salvar"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Cor do texto"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/ro.po
+++ b/builder/locale/ro.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr ""
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/ru.po
+++ b/builder/locale/ru.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Описание"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Переместить"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Открыть в новой вкладке"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Сохранить"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Показать сочетания клавиш"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Цвет текста"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Переключить тему"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/sl.po
+++ b/builder/locale/sl.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Premakni"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Odpri v novem zavihku"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Shrani"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Barva besedila"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/sr.po
+++ b/builder/locale/sr.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Опис"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Премести"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Отвори у новој картици"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Сачувај"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Претражи шаблон"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Прикажи пречице на тастатури"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Боја текста"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Промени тему"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/sr_CS.po
+++ b/builder/locale/sr_CS.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Premesti"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Otvori u novoj kartici"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Sačuvaj"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Pretraži šablon"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Prikaži prečice na tastaturi"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Boja teksta"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Promeni temu"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/sv.po
+++ b/builder/locale/sv.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "Lägg till metataggar, stilar och skript till sidhuvud"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "Lägg till egenskap"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "Tillbaka till alla mallar"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "Tillbaka till Webb Redigerare"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "Minimera Alla Lager"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "Minimera nod eller flytta upp i sidoträd"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "Behållare (c)"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "Behållare läge"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "Kontroller"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "Konvertera till Samling"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "Kopiera Stil"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "Kopiera block stilar"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "Ta bort Sida"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "Ta bort valda block"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "Ta bort variabel"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "Ta bort {0} variabler"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "Beskrivning"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "Avmarkera sidor"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "Duplicera Sida"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "Duplicera block"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "Kör Block Skript i Redigerare"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "Avsluta aktuell läge"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "Maximera Alla Lager"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "Expandera noden eller flytta nedåt i sidoträd"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "Anpassa Insidan"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "Anpassa arbetsyta till skärm"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "Fokusera Egenskap Sökning"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "Fokusera egenskap sökning"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "Framhäv Block med Klient Skript"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "Håll nedtryckt för flyttläge"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "Bilden är för stor. Använd en bild som är mindre än 5 MB."
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "Bildläge"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "Flytta"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "Flytta / hand läge"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "Flytta till Mapp"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "Flytta nedåt i sidoträd"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "Flytta till grupp"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "Flytta uppåt i sidoträd"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "Öppna i Ny Flik"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "Öppna sida eller växla mapp i sidoträd"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "Ta bort Stopp"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "Ta bort från grupp"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "Återställ Åsidosättningar"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "Återställ arbetsyta zoom"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "Spara"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "Spara som Komponent"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "Spara aktuell version"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "Spara sida / komponent"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr "Sök Mall"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "Sök Block"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "Välj standard färg"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "Välj läge"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "Visa Höger Panel"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Visa kortkommando"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "Text Färg"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "Text läge"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "Växla Tema"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "Växla arbetsyta mörkt läge"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "Växla vänster panel"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "Växla paneler"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "Radbryt"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "Radbryt i Behållare"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-Index"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Zooma in"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Zooma ut"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/th.po
+++ b/builder/locale/th.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "คำอธิบาย"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "ย้าย"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "เปิดในแท็บใหม่"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "บันทึก"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "แสดงแป้นพิมพ์ลัด"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "สีข้อความ"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "สลับธีม"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/tr.po
+++ b/builder/locale/tr.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Açıklama"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Taşı"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Yeni Sekmede Aç"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Kaydet"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Yazı Rengi"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/uz.po
+++ b/builder/locale/uz.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Tavsif"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Ko'chirish"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Yangi yorliqda ochish"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Saqlash"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Qidiruv shabloni"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Klaviatura yorliqlarini ko'rsatish"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Matn rangi"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "Mavzuni yoqish/o'chirish"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "Yaqinlashtirish"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "Kattalashtirish"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/vi.po
+++ b/builder/locale/vi.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "Mô tả"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "Di chuyển"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "Mở trong tab mới"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "Lưu"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr "Tìm kiếm Mẫu"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr "Hiển thị phím tắt bàn phím"
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "Màu văn bản"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/zh.po
+++ b/builder/locale/zh.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr ""
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr ""
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -439,7 +439,7 @@ msgid "Back to all templates"
 msgstr ""
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr ""
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -834,7 +834,7 @@ msgid "Collapse All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -977,7 +977,7 @@ msgid "Container (c)"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr ""
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1001,7 +1001,7 @@ msgid "Controls"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1033,7 +1033,7 @@ msgid "Copy Style"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1273,15 +1273,15 @@ msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1307,7 +1307,7 @@ msgid "Description"
 msgstr "描述"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr ""
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1479,7 +1479,7 @@ msgid "Duplicate Page"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr ""
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1682,7 +1682,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1695,7 +1695,7 @@ msgid "Expand All Layers"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1860,7 +1860,7 @@ msgid "Fit Inside"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr ""
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1873,7 +1873,7 @@ msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2111,7 +2111,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr ""
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr ""
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2189,7 +2189,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr ""
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2628,7 +2628,7 @@ msgid "Move"
 msgstr "移动"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr ""
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2636,16 +2636,16 @@ msgid "Move To Folder"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr ""
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2987,7 +2987,7 @@ msgid "Open in New Tab"
 msgstr "在新标签页中打开"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr ""
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3500,7 +3500,7 @@ msgid "Remove Stop"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr ""
 
 #: frontend/src/data/domains.ts:72
@@ -3596,7 +3596,7 @@ msgid "Reset Overrides"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3720,7 +3720,7 @@ msgid "Save"
 msgstr "保存"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr ""
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3745,7 +3745,7 @@ msgid "Save current version"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr ""
 
 #: builder/ai/api.py:522
@@ -3827,7 +3827,7 @@ msgid "Search Template"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr ""
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3929,7 +3929,7 @@ msgid "Select default color"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr ""
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4065,7 +4065,7 @@ msgid "Show Right Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4384,7 +4384,7 @@ msgid "Text Color"
 msgstr "文字颜色"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr ""
 
 #: builder/ai/presets.py:273
@@ -4544,15 +4544,15 @@ msgid "Toggle Theme"
 msgstr "切换主题"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr ""
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr ""
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5015,7 +5015,7 @@ msgid "Wrap"
 msgstr ""
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr ""
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5114,11 +5114,11 @@ msgid "Z-Index"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/builder/locale/zh_TW.po
+++ b/builder/locale/zh_TW.po
@@ -166,7 +166,7 @@ msgid "Add meta tags, styles, and scripts to page head"
 msgstr "在頁面 head 加入 meta 標籤、樣式與指令碼"
 
 #: frontend/src/components/MoreStylesPanel.vue:168
-msgid "Add property"
+msgid "Add Property"
 msgstr "新增屬性"
 
 #: frontend/src/components/Settings/PageCode.vue:17
@@ -440,7 +440,7 @@ msgid "Back to all templates"
 msgstr "返回所有範本"
 
 #: frontend/src/pages/PagePreview.vue:8 frontend/src/pages/PagePreview.vue:156
-msgid "Back to builder"
+msgid "Back to Builder"
 msgstr "返回 Builder"
 
 #: frontend/src/components/BackgroundHandler.vue:8
@@ -835,7 +835,7 @@ msgid "Collapse All Layers"
 msgstr "收合所有圖層"
 
 #: frontend/src/components/RouteTreeView.vue:374
-msgid "Collapse node or move up in page tree"
+msgid "Collapse Node or Move Up in Page Tree"
 msgstr "收合節點或在頁面樹中往上移動"
 
 #: frontend/src/components/BlockPropertySections/CollectionOptionsSection.ts:125
@@ -978,7 +978,7 @@ msgid "Container (c)"
 msgstr "容器（c）"
 
 #: frontend/src/utils/useBuilderEvents.ts:367
-msgid "Container mode"
+msgid "Container Mode"
 msgstr "容器模式"
 
 #. Label of the content (Small Text) field in DocType 'Builder AI Memory'
@@ -1002,7 +1002,7 @@ msgid "Controls"
 msgstr "控制項"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:61
-msgid "Convert To Collection"
+msgid "Convert to Collection"
 msgstr "轉換為集合"
 
 #: frontend/src/utils/imageUtils.ts:33
@@ -1034,7 +1034,7 @@ msgid "Copy Style"
 msgstr "複製樣式"
 
 #: frontend/src/components/Commands/index.ts:262
-msgid "Copy block styles"
+msgid "Copy Block Styles"
 msgstr "複製區塊樣式"
 
 #: frontend/src/utils/useBuilderEvents.ts:473
@@ -1274,15 +1274,15 @@ msgstr "刪除頁面"
 
 #: frontend/src/utils/useBuilderEvents.ts:240
 #: frontend/src/utils/useBuilderEvents.ts:254
-msgid "Delete selected blocks"
+msgid "Delete Selected Blocks"
 msgstr "刪除選取的區塊"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete variable"
+msgid "Delete Variable"
 msgstr "刪除變數"
 
 #: frontend/src/components/Modals/TokenManager.vue:767
-msgid "Delete {0} variables"
+msgid "Delete {0} Variables"
 msgstr "刪除 {0} 個變數"
 
 #: frontend/src/components/Modals/TokenManager.vue:758
@@ -1308,7 +1308,7 @@ msgid "Description"
 msgstr "說明"
 
 #: frontend/src/components/DashboardContent.vue:134
-msgid "Deselect pages"
+msgid "Deselect Pages"
 msgstr "取消選取頁面"
 
 #: frontend/src/components/LeftPanelTabs/index.ts:77
@@ -1480,7 +1480,7 @@ msgid "Duplicate Page"
 msgstr "建立頁面複本"
 
 #: frontend/src/components/Commands/index.ts:281
-msgid "Duplicate block"
+msgid "Duplicate Block"
 msgstr "建立區塊複本"
 
 #: frontend/src/components/ToolbarItems/ReadOnlyBadge.vue:11
@@ -1683,7 +1683,7 @@ msgid "Execute Block Scripts in Editor"
 msgstr "在編輯器中執行區塊腳本"
 
 #: frontend/src/utils/useBuilderEvents.ts:268
-msgid "Exit current mode"
+msgid "Exit Current Mode"
 msgstr "退出目前模式"
 
 #: frontend/src/components/BlockPropertySections/HTMLOptionsSection.ts:24
@@ -1696,7 +1696,7 @@ msgid "Expand All Layers"
 msgstr "展開所有圖層"
 
 #: frontend/src/components/RouteTreeView.vue:355
-msgid "Expand node or move down in page tree"
+msgid "Expand Node or Move Down in Page Tree"
 msgstr "展開節點或在頁面樹中往下移動"
 
 #: frontend/src/components/Settings/GlobalRedirects.vue:155
@@ -1861,7 +1861,7 @@ msgid "Fit Inside"
 msgstr "符合內部"
 
 #: frontend/src/utils/useBuilderEvents.ts:291
-msgid "Fit canvas to screen"
+msgid "Fit Canvas to Screen"
 msgstr "使畫布符合螢幕"
 
 #: frontend/src/components/BlockGridLayoutHandler.vue:12
@@ -1874,7 +1874,7 @@ msgid "Focus Property Search"
 msgstr "聚焦屬性搜尋"
 
 #: frontend/src/components/Commands/index.ts:250
-msgid "Focus property search"
+msgid "Focus Property Search"
 msgstr "聚焦屬性搜尋"
 
 #: frontend/src/components/Settings/PageGeneral.vue:159
@@ -2112,7 +2112,7 @@ msgid "Highlight Blocks with Client Scripts"
 msgstr "醒目提示含用戶端指令碼的區塊"
 
 #: frontend/src/pages/PageBuilder.vue:192
-msgid "Hold for move mode"
+msgid "Hold for Move Mode"
 msgstr "按住以進入移動模式"
 
 #: frontend/src/components/Settings/PageGeneral.vue:200
@@ -2190,7 +2190,7 @@ msgid "Image is too large. Please use an image smaller than 5 MB."
 msgstr "圖片過大，請使用小於5MB的圖片。"
 
 #: frontend/src/utils/useBuilderEvents.ts:376
-msgid "Image mode"
+msgid "Image Mode"
 msgstr "圖片模式"
 
 #: frontend/src/utils/imageUtils.ts:58
@@ -2629,7 +2629,7 @@ msgid "Move"
 msgstr "移動"
 
 #: frontend/src/utils/useBuilderEvents.ts:402
-msgid "Move / hand mode"
+msgid "Move / Hand Mode"
 msgstr "移動／手形模式"
 
 #: frontend/src/components/DashboardHead.vue:9
@@ -2637,16 +2637,16 @@ msgid "Move To Folder"
 msgstr "移動至資料夾"
 
 #: frontend/src/components/RouteTreeView.vue:335
-msgid "Move down in page tree"
+msgid "Move Down in Page Tree"
 msgstr "在頁面樹中往下移動"
 
 #: frontend/src/components/Modals/TokenManager.vue:365
 #: frontend/src/components/Modals/TokenManager.vue:769
-msgid "Move to group"
+msgid "Move to Group"
 msgstr "移動至群組"
 
 #: frontend/src/components/RouteTreeView.vue:345
-msgid "Move up in page tree"
+msgid "Move Up in Page Tree"
 msgstr "在頁面樹中往上移動"
 
 #: frontend/src/components/Modals/TokenManager.vue:727
@@ -2988,7 +2988,7 @@ msgid "Open in New Tab"
 msgstr "在新分頁中開啟"
 
 #: frontend/src/components/RouteTreeView.vue:390
-msgid "Open page or toggle folder in page tree"
+msgid "Open Page or Toggle Folder in Page Tree"
 msgstr "開啟頁面或在頁面樹中切換資料夾"
 
 #: frontend/src/components/BlockPropertySections/LinkSection.ts:46
@@ -3501,7 +3501,7 @@ msgid "Remove Stop"
 msgstr "移除色標"
 
 #: frontend/src/components/Modals/TokenManager.vue:771
-msgid "Remove from group"
+msgid "Remove from Group"
 msgstr "從群組移除"
 
 #: frontend/src/data/domains.ts:72
@@ -3597,7 +3597,7 @@ msgid "Reset Overrides"
 msgstr "重設覆寫"
 
 #: frontend/src/utils/useBuilderEvents.ts:279
-msgid "Reset canvas zoom"
+msgid "Reset Canvas Zoom"
 msgstr "重設畫布縮放"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:162
@@ -3721,7 +3721,7 @@ msgid "Save"
 msgstr "儲存"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:218
-msgid "Save As Component"
+msgid "Save as Component"
 msgstr "另存為元件"
 
 #: frontend/src/stores/componentStore.ts:88
@@ -3746,7 +3746,7 @@ msgid "Save current version"
 msgstr "儲存目前版本"
 
 #: frontend/src/utils/useBuilderEvents.ts:228
-msgid "Save page / component"
+msgid "Save Page / Component"
 msgstr "儲存頁面／元件"
 
 #: builder/ai/api.py:522
@@ -3828,7 +3828,7 @@ msgid "Search Template"
 msgstr "搜尋範本"
 
 #: frontend/src/components/Commands/index.ts:240
-msgid "Search blocks"
+msgid "Search Blocks"
 msgstr "搜尋區塊"
 
 #: frontend/src/components/Controls/SearchBlock.vue:17
@@ -3930,7 +3930,7 @@ msgid "Select default color"
 msgstr "選擇預設顏色"
 
 #: frontend/src/utils/useBuilderEvents.ts:394
-msgid "Select mode"
+msgid "Select Mode"
 msgstr "選取模式"
 
 #: frontend/src/components/Modals/TokenManager.vue:372
@@ -4066,7 +4066,7 @@ msgid "Show Right Panel"
 msgstr "顯示右側面板"
 
 #: frontend/src/components/Commands/index.ts:205
-msgid "Show keyboard shortcuts"
+msgid "Show Keyboard Shortcuts"
 msgstr ""
 
 #: frontend/src/components/BlockFlexLayoutHandler.vue:50
@@ -4385,7 +4385,7 @@ msgid "Text Color"
 msgstr "文字顏色"
 
 #: frontend/src/utils/useBuilderEvents.ts:385
-msgid "Text mode"
+msgid "Text Mode"
 msgstr "文字模式"
 
 #: builder/ai/presets.py:273
@@ -4545,15 +4545,15 @@ msgid "Toggle Theme"
 msgstr "切換佈景主題"
 
 #: frontend/src/components/Commands/index.ts:230
-msgid "Toggle canvas dark mode"
+msgid "Toggle Canvas Dark Mode"
 msgstr "切換畫布深色模式"
 
 #: frontend/src/components/Commands/index.ts:175
-msgid "Toggle left panel"
+msgid "Toggle Left Panel"
 msgstr "切換左側面板"
 
 #: frontend/src/components/Commands/index.ts:217
-msgid "Toggle panels"
+msgid "Toggle Panels"
 msgstr "切換面板"
 
 #. Label of the token_name (Data) field in DocType 'Builder Token'
@@ -5016,7 +5016,7 @@ msgid "Wrap"
 msgstr "換行"
 
 #: frontend/src/components/BlockContextMenuOptions/index.ts:86
-msgid "Wrap In Container"
+msgid "Wrap in Container"
 msgstr "包在容器中"
 
 #: frontend/src/components/ShadowHandler.vue:153
@@ -5115,11 +5115,11 @@ msgid "Z-Index"
 msgstr "Z-Index"
 
 #: frontend/src/utils/useBuilderEvents.ts:346
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr "放大"
 
 #: frontend/src/utils/useBuilderEvents.ts:357
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr "縮小"
 
 #. Option for the 'Role' (Select) field in DocType 'Builder AI Message'

--- a/frontend/src/components/BlockContextMenuOptions/index.ts
+++ b/frontend/src/components/BlockContextMenuOptions/index.ts
@@ -72,7 +72,7 @@ const options: ContextMenuOption[] = [
 	},
 	{
 		name: "convert-to-collection",
-		label: __("Convert To Collection"),
+		label: __("Convert to Collection"),
 		action: ({ block }) => {
 			block.isRepeaterBlock = true;
 			toast.warning(__("Please select a collection"));
@@ -97,7 +97,7 @@ const options: ContextMenuOption[] = [
 	},
 	{
 		name: "wrap-in-container",
-		label: __("Wrap In Container"),
+		label: __("Wrap in Container"),
 		action: ({ block }) => {
 			const newBlockObj = getBlockTemplate("fit-container");
 			const parentBlock = block.getParentBlock();
@@ -229,7 +229,7 @@ const options: ContextMenuOption[] = [
 	},
 	{
 		name: "save-component",
-		label: __("Save As Component"),
+		label: __("Save as Component"),
 		action: ({ block }) => promptCreateComponent(block),
 		condition: ({ block }) => !block.isExtendedFromComponent(),
 		disabled: readOnly,

--- a/frontend/src/components/BuilderLeftPanel.vue
+++ b/frontend/src/components/BuilderLeftPanel.vue
@@ -70,7 +70,7 @@ useShortcut(
 		.filter((tab) => tab.shortcut)
 		.map((tab) => ({
 			...tab.shortcut!,
-			description: `Show ${tab.label} panel`,
+			description: `Show ${tab.label} Panel`,
 			group: "View",
 			handler: () => select(tab),
 		})),

--- a/frontend/src/components/Commands/index.ts
+++ b/frontend/src/components/Commands/index.ts
@@ -177,7 +177,7 @@ commands.register({
 	description: __("View"),
 	group: "View",
 	condition: isBuilderRoute,
-	keys: { key: "\\", ctrl: true, shift: true, description: __("Toggle left panel") },
+	keys: { key: "\\", ctrl: true, shift: true, description: __("Toggle Left Panel") },
 	action: () => (builderStore.showLeftPanel = !builderStore.showLeftPanel),
 });
 
@@ -207,7 +207,7 @@ commands.register({
 	description: __("General"),
 	group: "General",
 	condition: isBuilderRoute,
-	keys: { key: "?", description: __("Show keyboard shortcuts") },
+	keys: { key: "?", description: __("Show Keyboard Shortcuts") },
 	action: () => (builderStore.shortcutsModalOpen = true),
 });
 
@@ -219,7 +219,7 @@ commands.register({
 	icon: "lucide-panels-left-bottom",
 	group: "View",
 	inPalette: false,
-	keys: { key: "\\", ctrl: true, description: __("Toggle panels") },
+	keys: { key: "\\", ctrl: true, description: __("Toggle Panels") },
 	action: () => {
 		builderStore.showRightPanel = !builderStore.showRightPanel;
 		builderStore.showLeftPanel = builderStore.showRightPanel;
@@ -232,7 +232,7 @@ commands.register({
 	icon: "lucide-moon",
 	group: "View",
 	inPalette: false,
-	keys: { key: "d", ctrl: true, shift: true, description: __("Toggle canvas dark mode") },
+	keys: { key: "d", ctrl: true, shift: true, description: __("Toggle Canvas Dark Mode") },
 	action: () => (builderStore.canvasDarkMode = !builderStore.canvasDarkMode),
 });
 
@@ -242,7 +242,7 @@ commands.register({
 	icon: "lucide-search",
 	group: "General",
 	inPalette: false,
-	keys: { key: "f", ctrl: true, shift: true, description: __("Search blocks") },
+	keys: { key: "f", ctrl: true, shift: true, description: __("Search Blocks") },
 	action: () => (builderStore.showSearchBlock = true),
 });
 
@@ -252,7 +252,7 @@ commands.register({
 	icon: "lucide-search",
 	group: "General",
 	inPalette: false,
-	keys: { key: "f", ctrl: true, allowInInput: true, description: __("Focus property search") },
+	keys: { key: "f", ctrl: true, allowInInput: true, description: __("Focus Property Search") },
 	action: () => {
 		document.querySelector(".properties-search-input")?.querySelector("input")?.focus();
 	},
@@ -264,7 +264,7 @@ commands.register({
 	icon: "lucide-clipboard-copy",
 	group: "Edit",
 	inPalette: false,
-	keys: { key: "c", ctrl: true, shift: true, description: __("Copy block styles") },
+	keys: { key: "c", ctrl: true, shift: true, description: __("Copy Block Styles") },
 	action: () => {
 		if (!blockController.isBlockSelected() || blockController.multipleBlocksSelected()) return;
 		const block = blockController.getSelectedBlocks()[0];
@@ -278,7 +278,7 @@ commands.register({
 	icon: "lucide-copy",
 	group: "Edit",
 	inPalette: false,
-	keys: { key: "d", ctrl: true, description: __("Duplicate block") },
+	keys: { key: "d", ctrl: true, description: __("Duplicate Block") },
 	action: () => {
 		if (builderStore.readOnlyMode) return;
 		if (!blockController.isBlockSelected() || blockController.multipleBlocksSelected()) return;

--- a/frontend/src/components/DashboardContent.vue
+++ b/frontend/src/components/DashboardContent.vue
@@ -131,7 +131,7 @@ watch(displayType, () => fetchPages());
 // remove selection mode when the escape key is pressed
 useShortcut({
 	key: "Escape",
-	description: __("Deselect pages"),
+	description: __("Deselect Pages"),
 	group: __("Dashboard"),
 	handler: () => {
 		selectedPages.value.clear();

--- a/frontend/src/components/Modals/TokenManager.vue
+++ b/frontend/src/components/Modals/TokenManager.vue
@@ -386,7 +386,7 @@
 
 				<Dialog
 					v-model="showGroupDialog"
-					:title="__('Move to group')"
+					:title="__('Move to Group')"
 					size="sm"
 					:actions="[{ label: __('Move'), variant: 'solid', onClick: confirmGroupDialog }]">
 					<template #default>
@@ -825,11 +825,11 @@ const contextMenuOptions = computed(() => {
 		return [{ label: __("Remove"), action: () => (newVariable.value = null) }];
 	}
 	const count = selectedIds.value.size;
-	const deleteLabel = count > 1 ? __("Delete {0} variables", [count]) : __("Delete variable");
+	const deleteLabel = count > 1 ? __("Delete {0} Variables", [count]) : __("Delete Variable");
 	return [
-		{ label: __("Move to group"), action: openGroupDialog },
+		{ label: __("Move to Group"), action: openGroupDialog },
 		{
-			label: __("Remove from group"),
+			label: __("Remove from Group"),
 			action: () => moveSelectedToGroup(""),
 			condition: () => selectedRows().some((row) => row.group),
 		},

--- a/frontend/src/components/MoreStylesPanel.vue
+++ b/frontend/src/components/MoreStylesPanel.vue
@@ -165,7 +165,7 @@ const propertyOptions = computed(() => [
 	{
 		type: "custom" as const,
 		key: "add-property",
-		label: __("Add property"),
+		label: __("Add Property"),
 		slot: "add-property",
 		condition: ({ query }: { query: string }) => canAddProperty(query),
 		onClick: ({ query }: { query: string }) => addProperty(query),

--- a/frontend/src/components/RouteTreeView.vue
+++ b/frontend/src/components/RouteTreeView.vue
@@ -332,7 +332,7 @@ const treeActive = () => regularNodes().length > 0;
 useShortcut([
 	{
 		key: "ArrowDown",
-		description: __("Move down in page tree"),
+		description: __("Move Down in Page Tree"),
 		group: __("Page Tree"),
 		condition: treeActive,
 		handler: () => {
@@ -342,7 +342,7 @@ useShortcut([
 	},
 	{
 		key: "ArrowUp",
-		description: __("Move up in page tree"),
+		description: __("Move Up in Page Tree"),
 		group: __("Page Tree"),
 		condition: treeActive,
 		handler: () => {
@@ -352,7 +352,7 @@ useShortcut([
 	},
 	{
 		key: "ArrowRight",
-		description: __("Expand node or move down in page tree"),
+		description: __("Expand Node or Move Down in Page Tree"),
 		group: __("Page Tree"),
 		condition: treeActive,
 		handler: () => {
@@ -371,7 +371,7 @@ useShortcut([
 	},
 	{
 		key: "ArrowLeft",
-		description: __("Collapse node or move up in page tree"),
+		description: __("Collapse Node or Move Up in Page Tree"),
 		group: __("Page Tree"),
 		condition: treeActive,
 		handler: () => {
@@ -387,7 +387,7 @@ useShortcut([
 	},
 	{
 		key: "Enter",
-		description: __("Open page or toggle folder in page tree"),
+		description: __("Open Page or Toggle Folder in Page Tree"),
 		group: __("Page Tree"),
 		condition: treeActive,
 		handler: () => {

--- a/frontend/src/pages/PageBuilder.vue
+++ b/frontend/src/pages/PageBuilder.vue
@@ -189,7 +189,7 @@ useBuilderEvents(pageCanvas, fragmentCanvas, saveAndExitFragmentMode, route, rou
 useShortcut([
 	{
 		key: " ",
-		description: __("Hold for move mode"),
+		description: __("Hold for Move Mode"),
 		group: __("Tools"),
 		handler: () => {
 			if (!canvasStore.editableBlock) {

--- a/frontend/src/pages/PagePreview.vue
+++ b/frontend/src/pages/PagePreview.vue
@@ -153,7 +153,7 @@ const transitionTheme = (toggle: () => void) => {
 
 useShortcut({
 	key: "Escape",
-	description: __("Back to builder"),
+	description: __("Back to Builder"),
 	group: __("Navigation"),
 	handler: () => {
 		if (router.currentRoute.value.name === "preview") {

--- a/frontend/src/utils/useBuilderEvents.ts
+++ b/frontend/src/utils/useBuilderEvents.ts
@@ -245,7 +245,7 @@ export function useBuilderEvents(
 		{
 			key: "s",
 			ctrl: true,
-			description: __("Save page / component"),
+			description: __("Save Page / Component"),
 			group: __("General"),
 			allowInInput: true,
 			handler: (e) => {
@@ -257,7 +257,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "Backspace",
-			description: __("Delete selected blocks"),
+			description: __("Delete Selected Blocks"),
 			group: __("Edit"),
 			handler: (e) => {
 				if (builderStore.readOnlyMode) return;
@@ -271,7 +271,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "Delete",
-			description: __("Delete selected blocks"),
+			description: __("Delete Selected Blocks"),
 			group: __("Edit"),
 			handler: (e) => {
 				if (builderStore.readOnlyMode) return;
@@ -285,7 +285,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "Escape",
-			description: __("Exit current mode"),
+			description: __("Exit Current Mode"),
 			group: __("General"),
 			condition: () => canvasStore.editingMode !== "page",
 			handler: (e) => {
@@ -296,7 +296,7 @@ export function useBuilderEvents(
 		{
 			key: "0",
 			ctrl: true,
-			description: __("Reset canvas zoom"),
+			description: __("Reset Canvas Zoom"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -308,7 +308,7 @@ export function useBuilderEvents(
 			key: "0",
 			ctrl: true,
 			shift: true,
-			description: __("Fit canvas to screen"),
+			description: __("Fit Canvas to Screen"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -318,7 +318,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "ArrowRight",
-			description: __("Pan canvas"),
+			description: __("Pan Canvas"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -329,7 +329,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "ArrowLeft",
-			description: __("Pan canvas"),
+			description: __("Pan Canvas"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -340,7 +340,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "ArrowUp",
-			description: __("Pan canvas"),
+			description: __("Pan Canvas"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -351,7 +351,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "ArrowDown",
-			description: __("Pan canvas"),
+			description: __("Pan Canvas"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -363,7 +363,7 @@ export function useBuilderEvents(
 		{
 			key: "=",
 			ctrl: true,
-			description: __("Zoom in"),
+			description: __("Zoom In"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -374,7 +374,7 @@ export function useBuilderEvents(
 		{
 			key: "-",
 			ctrl: true,
-			description: __("Zoom out"),
+			description: __("Zoom Out"),
 			group: __("Canvas"),
 			handler: () => {
 				if (pageCanvas.value) {
@@ -384,7 +384,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "c",
-			description: __("Container mode"),
+			description: __("Container Mode"),
 			group: __("Tools"),
 			handler: () => {
 				if (builderStore.readOnlyMode) return;
@@ -393,7 +393,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "i",
-			description: __("Image mode"),
+			description: __("Image Mode"),
 			group: __("Tools"),
 			handler: () => {
 				if (builderStore.readOnlyMode) return;
@@ -402,7 +402,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "t",
-			description: __("Text mode"),
+			description: __("Text Mode"),
 			group: __("Tools"),
 			handler: () => {
 				if (builderStore.readOnlyMode) return;
@@ -411,7 +411,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "v",
-			description: __("Select mode"),
+			description: __("Select Mode"),
 			group: __("Tools"),
 			handler: () => {
 				builderStore.mode = "select";
@@ -419,7 +419,7 @@ export function useBuilderEvents(
 		},
 		{
 			key: "h",
-			description: __("Move / hand mode"),
+			description: __("Move / Hand Mode"),
 			group: __("Tools"),
 			handler: () => {
 				builderStore.mode = "move";


### PR DESCRIPTION
Use consistent Title Case for shortcut descriptions and right-click menu labels throughout.

Before:
<img width="231" height="322" alt="image" src="https://github.com/user-attachments/assets/33b5ffff-40c6-4ea0-9cbe-f8b1b2057960" />

Now:
<img width="225" height="317" alt="image" src="https://github.com/user-attachments/assets/473a848b-9f8a-4f99-a328-25bf5c1307ae" />
