### PR TITLE
fix: match globe icon styling with toolbar icons

### DIFF
--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -19,7 +19,7 @@
 					</Tooltip>
 					<Tooltip :text="__('Publicly accessible')" :hoverDelay="0.6">
 						<span
-							class="lucide-globe size-4 text-ink-gray-5"
+							class="lucide-globe mr-1 h-[14px] w-[14px] !text-gray-700 dark:!text-gray-200"
 							v-if="pageStore.activePage?.published && !pageStore.activePage?.authenticated_access" />
 					</Tooltip>
 					<span


### PR DESCRIPTION
The globe icon in the page title bar was visually inconsistent with the surrounding toolbar icon

Before:
<img width="323" height="46" alt="image" src="https://github.com/user-attachments/assets/849d4470-6ceb-47b0-97f5-aae12dc220c3" />

Now:
<img width="320" height="57" alt="image" src="https://github.com/user-attachments/assets/b89b8e73-b581-4f2e-b6ef-58d5f94323c9" />
