### PR TITLE
feat(telemetry): carry the page through its lifecycle events

### DIFF
--- a/builder/api.py
+++ b/builder/api.py
@@ -440,6 +440,7 @@ def duplicate_page(page_name: str):
 	del new_page.page_name
 	new_page.route = None
 	clone_client_scripts(page, new_page)
+	new_page.flags.source = "duplicate"
 	new_page.insert()
 	return new_page
 
@@ -483,7 +484,9 @@ def get_template_groups() -> list[dict]:
 		return []
 
 
-def create_page_from_bundle(bundle: dict, project_folder: str | None = None) -> str:
+def create_page_from_bundle(
+	bundle: dict, project_folder: str | None = None, template_page: str | None = None
+) -> str:
 	"""Create an editable page from a fetched hub bundle and return its name.
 
 	Installs shared components/variables/scripts/fonts, then builds the page
@@ -525,6 +528,8 @@ def create_page_from_bundle(bundle: dict, project_folder: str | None = None) -> 
 		)
 		new_script.insert(ignore_permissions=True)
 		new_page.append("client_scripts", {"builder_script": new_script.name})
+	new_page.flags.source = "template"
+	new_page.flags.template_page = template_page
 	new_page.insert()
 	# only fall back to async generation when the template carried no preview
 	if not preview:
@@ -551,7 +556,7 @@ def create_page_from_template(template_page: str, project_folder: str | None = N
 		frappe.throw(frappe._("Could not load the selected template. Please try again."))
 
 	assert isinstance(bundle, dict)
-	return create_page_from_bundle(bundle, project_folder)
+	return create_page_from_bundle(bundle, project_folder, template_page)
 
 
 @frappe.whitelist()
@@ -576,7 +581,7 @@ def import_template_group(template_group: str, project_folder: str | None = None
 			continue
 		if not bundle or not bundle.get("page"):
 			continue
-		name = create_page_from_bundle(bundle, project_folder)
+		name = create_page_from_bundle(bundle, project_folder, page.get("name"))
 		created.append(name)
 
 	if not created:
@@ -762,3 +767,17 @@ def get_component_data(
 	)
 
 	return _get_component_data(component_name, props, script)
+
+
+@frappe.whitelist()
+@has_page_read("You do not have permission to submit the survey.")
+def identify_persona(role: str | None = None, use_case: str | None = None, source: str | None = None) -> None:
+	"""Attach the onboarding answers to the site's Pulse profile so every Builder
+	metric can be split by persona without joining events."""
+	if not any((role, use_case, source)):
+		return
+	try:
+		from frappe.utils.telemetry.pulse.client import identify
+	except ImportError:  # pulse identify shipped with frappe v16
+		return
+	identify({"builder_role": role, "builder_use_case": use_case, "builder_source": source})

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -42,6 +42,7 @@ from builder.utils import (
 	camel_case_to_kebab_case,
 	clean_data,
 	compact_json,
+	count_blocks,
 	escape_single_quotes,
 	execute_script,
 	get_builder_page_preview_file_paths,
@@ -160,7 +161,10 @@ class BuilderPage(WebsiteGenerator):
 		self.process_blocks()
 		self.set_preview()
 		self.set_default_values()
-		capture("builder_page_created", "builder")
+
+	# the name is only final after insert: naming wipes whatever before_insert set
+	def after_insert(self):
+		capture("builder_page_created", "builder", properties=self.creation_event_properties())
 
 	# every write path, not just insert: callers that hand over a block tree
 	# (paste, AI writes, the API) would otherwise fail on update with
@@ -188,6 +192,30 @@ class BuilderPage(WebsiteGenerator):
 			if not self.name:
 				self.autoname()
 			self.route = f"pages/{self.name}"
+
+	def block_count(self) -> int:
+		return count_blocks(self.draft_blocks or self.blocks)
+
+	def creation_event_properties(self) -> dict:
+		block_count = self.block_count()
+		# template and duplicate are stamped by their api entry points; anything
+		# else arriving with content (paste, REST) is an import
+		return {
+			"page": self.name,
+			"source": self.flags.source or ("blank" if block_count <= 1 else "import"),
+			"template_page": self.flags.template_page,
+			"block_count": block_count,
+		}
+
+	def publish_event_properties(self, is_first_publish: bool) -> dict:
+		return {
+			"page": self.name,
+			"is_first_publish": is_first_publish,
+			"seconds_since_created": int(frappe.utils.time_diff_in_seconds(now(), self.creation)),
+			"block_count": self.block_count(),
+			"has_client_script": bool(self.client_scripts),
+			"has_data_script": bool(self.page_data_script),
+		}
 
 	def validate(self):
 		super().validate()  # WebsiteGenerator route normalization
@@ -220,6 +248,9 @@ class BuilderPage(WebsiteGenerator):
 			or self.has_value_changed("blocks")
 		):
 			self.clear_route_cache()
+
+		if self.has_value_changed("published") and not self.published and not self.is_new():
+			capture("builder_page_unpublished", "builder", properties={"page": self.name})
 
 		if self.has_value_changed("published") and not self.published:
 			# if this is homepage then clear homepage from builder settings
@@ -345,6 +376,7 @@ class BuilderPage(WebsiteGenerator):
 
 	@frappe.whitelist()
 	def publish(self):
+		is_first_publish = not self.published and not self.published_at
 		self.published = 1
 		self.published_at = now()
 		if self.draft_blocks:
@@ -361,7 +393,9 @@ class BuilderPage(WebsiteGenerator):
 			self.blocks = self.draft_blocks
 			self.draft_blocks = None
 		self.save()
-		capture("builder_page_published", "builder")
+		capture(
+			"builder_page_published", "builder", properties=self.publish_event_properties(is_first_publish)
+		)
 		frappe.enqueue_doc(
 			self.doctype,
 			self.name,
@@ -376,7 +410,6 @@ class BuilderPage(WebsiteGenerator):
 	def unpublish(self):
 		self.published = 0
 		self.save()
-		capture("builder_page_unpublished", "builder")
 
 	@frappe.whitelist()
 	def create_manual_snapshot(self, label: str | None = None):

--- a/builder/builder/tests/test_telemetry.py
+++ b/builder/builder/tests/test_telemetry.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from builder.api import create_page_from_bundle, duplicate_page, identify_persona
+from builder.utils import count_blocks
 
 CAPTURE = "builder.builder.doctype.builder_page.builder_page.capture"
 IDENTIFY = "frappe.utils.telemetry.pulse.client.identify"
@@ -21,6 +22,10 @@ def new_page(**fields):
 
 
 class TestPageLifecycleEvents(FrappeTestCase):
+	def test_counts_a_legacy_single_root_block(self):
+		self.assertEqual(count_blocks(ROOT_WITH_CHILD), 2)
+		self.assertEqual(count_blocks(None), 0)
+
 	def test_created_event_identifies_the_page(self):
 		with patch(CAPTURE) as capture:
 			page = new_page(draft_blocks=[ROOT_WITH_CHILD])

--- a/builder/builder/tests/test_telemetry.py
+++ b/builder/builder/tests/test_telemetry.py
@@ -1,0 +1,108 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from builder.api import create_page_from_bundle, duplicate_page, identify_persona
+
+CAPTURE = "builder.builder.doctype.builder_page.builder_page.capture"
+IDENTIFY = "frappe.utils.telemetry.pulse.client.identify"
+
+ROOT = {"element": "div"}
+ROOT_WITH_CHILD = {"element": "div", "children": [{"element": "p"}]}
+
+
+def captured(capture, event):
+	return [call.kwargs["properties"] for call in capture.call_args_list if call.args[0] == event]
+
+
+def new_page(**fields):
+	return frappe.get_doc({"doctype": "Builder Page", "page_title": "Telemetry", **fields}).insert()
+
+
+class TestPageLifecycleEvents(FrappeTestCase):
+	def test_created_event_identifies_the_page(self):
+		with patch(CAPTURE) as capture:
+			page = new_page(draft_blocks=[ROOT_WITH_CHILD])
+
+		[props] = captured(capture, "builder_page_created")
+		self.assertEqual(props["page"], page.name)
+		self.assertEqual(props["block_count"], 2)
+		self.assertEqual(props["source"], "import")
+		self.assertIsNone(props["template_page"])
+
+	def test_page_with_only_a_root_block_is_blank(self):
+		with patch(CAPTURE) as capture:
+			new_page(draft_blocks=[ROOT])
+
+		[props] = captured(capture, "builder_page_created")
+		self.assertEqual(props["source"], "blank")
+
+	def test_template_and_duplicate_sources(self):
+		bundle = {"page": {"page_title": "From Template", "blocks": [ROOT_WITH_CHILD]}}
+		with patch(CAPTURE) as capture:
+			name = create_page_from_bundle(bundle, template_page="hub-page")
+			duplicate_page(name)
+
+		from_template, duplicated = captured(capture, "builder_page_created")
+		self.assertEqual(from_template["source"], "template")
+		self.assertEqual(from_template["template_page"], "hub-page")
+		self.assertEqual(duplicated["source"], "duplicate")
+		self.assertIsNone(duplicated["template_page"])
+
+	def test_publish_event_marks_the_first_publish(self):
+		page = new_page(draft_blocks=[ROOT_WITH_CHILD], page_data_script="data.update({})")
+		with patch(CAPTURE) as capture:
+			page.publish()
+			page.publish()
+
+		first, second = captured(capture, "builder_page_published")
+		self.assertEqual(first["page"], page.name)
+		self.assertTrue(first["is_first_publish"])
+		self.assertFalse(second["is_first_publish"])
+		self.assertEqual(first["block_count"], 2)
+		self.assertTrue(first["has_data_script"])
+		self.assertFalse(first["has_client_script"])
+		self.assertGreaterEqual(first["seconds_since_created"], 0)
+
+	def test_republishing_an_unpublished_page_is_not_a_first_publish(self):
+		page = new_page(draft_blocks=[ROOT])
+		page.publish()
+		page.published = 0
+		page.save()
+		with patch(CAPTURE) as capture:
+			page.publish()
+
+		[props] = captured(capture, "builder_page_published")
+		self.assertFalse(props["is_first_publish"])
+
+	def test_unpublish_event_fires_on_a_plain_field_update(self):
+		page = new_page(draft_blocks=[ROOT])
+		page.publish()
+		with patch(CAPTURE) as capture:
+			page.published = 0
+			page.save()
+
+		self.assertEqual(captured(capture, "builder_page_unpublished"), [{"page": page.name}])
+
+	def test_creating_an_unpublished_page_is_not_an_unpublish(self):
+		with patch(CAPTURE) as capture:
+			new_page(draft_blocks=[ROOT])
+
+		self.assertEqual(captured(capture, "builder_page_unpublished"), [])
+
+
+class TestIdentifyPersona(FrappeTestCase):
+	def test_sends_the_answers_to_the_site_profile(self):
+		with patch(IDENTIFY) as identify:
+			identify_persona(role="designer", use_case="portfolio", source="search")
+
+		identify.assert_called_once_with(
+			{"builder_role": "designer", "builder_use_case": "portfolio", "builder_source": "search"}
+		)
+
+	def test_a_skipped_survey_is_not_sent(self):
+		with patch(IDENTIFY) as identify:
+			identify_persona()
+
+		identify.assert_not_called()

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -567,6 +567,13 @@ def normalize_legacy_style_key(style):
 	return f"{state}:{kebab_to_camel_case(property_name)}"
 
 
+def count_blocks(blocks) -> int:
+	blocks = frappe.parse_json(blocks or "[]")
+	if isinstance(blocks, dict):
+		blocks = [blocks]
+	return sum(1 + count_blocks(block.get("children")) for block in blocks if isinstance(block, dict))
+
+
 def merge_raw_styles_into_base_styles(block):
 	raw_styles = block.pop("rawStyles", None)
 	if not raw_styles:

--- a/frontend/src/components/Templates/TemplateGallery.vue
+++ b/frontend/src/components/Templates/TemplateGallery.vue
@@ -196,6 +196,7 @@ const useTemplate = (page: TemplatePageSummary) => {
 		})
 		.then((newPageName: string) => {
 			capture("builder_page_template_used", {
+				page: newPageName,
 				template_page: page.name,
 				template_group: page.template_group,
 				source: page.live_url ? "hub" : "local",
@@ -227,6 +228,7 @@ const importAll = () => {
 		})
 		.then((pageNames: string[]) => {
 			capture("builder_template_group_imported", {
+				pages: pageNames,
 				template_group: activeGroup.value!.name,
 				page_count: pageNames.length,
 			});

--- a/frontend/src/pages/PagePersonaSurvey.vue
+++ b/frontend/src/pages/PagePersonaSurvey.vue
@@ -84,14 +84,15 @@ import { useDashboardState } from "@/composables/useDashboardState";
 import { builderSettings } from "@/data/builderSettings";
 import { sessionUser } from "@/router";
 import { getUserInfo } from "@/usersInfo";
-import { Button, Textarea } from "frappe-ui";
+import { Button, Textarea, call } from "frappe-ui";
 import { useTelemetry } from "frappe-ui/frappe";
 import { computed, nextTick, reactive, ref } from "vue";
 import LucideChevronLeft from "~icons/lucide/chevron-left";
 
-// Pulse is event-only (no person properties), but every event carries the
-// (anonymized, stable) user id, so this single event can be joined to the
-// rest of the user's funnel for persona-wise segmentation.
+// Every event carries the (anonymized, stable) user id, so this single event can
+// be joined to the rest of the user's funnel for persona-wise segmentation. The
+// answers are also attached to the site's Pulse profile (identify_persona) so
+// site-level metrics split by persona without a join.
 const telemetry = useTelemetry();
 const { templateCategoryFilter } = useDashboardState();
 // Dev benches have telemetry off; ?persona_survey=test logs the payload instead.
@@ -250,5 +251,12 @@ function finishQuestions(skipped = false) {
 	} catch (e) {
 		console.error("[persona-survey] failed to capture", e);
 	}
+	call("builder.api.identify_persona", {
+		role: props.role,
+		use_case: props.use_case,
+		source: props.source,
+	}).catch((e: unknown) => {
+		console.error("[persona-survey] failed to identify", e);
+	});
 }
 </script>

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -10,14 +10,18 @@ import { BuilderClientScript, BuilderPage } from "@/types/doctypes";
 import getBlockTemplate from "@/utils/blockTemplate";
 import {
 	confirm,
+	countBlocks,
 	generateId,
 	getBlockInstance,
 	getCopyWithoutParent,
 	getRouteVariables,
 } from "@/utils/helpers";
 import { createDocumentResource, createListResource, createResource, toast } from "frappe-ui";
+import { useTelemetry } from "frappe-ui/frappe";
 import { defineStore } from "pinia";
 import { nextTick } from "vue";
+
+const { capture } = useTelemetry();
 
 const usePageStore = defineStore("pageStore", {
 	state: () => ({
@@ -42,6 +46,7 @@ const usePageStore = defineStore("pageStore", {
 				return;
 			}
 
+			const switchingPage = pageName !== this.selectedPage;
 			this.selectedPage = pageName;
 			const pageLoadToken = ++this.pageLoadToken;
 
@@ -58,6 +63,13 @@ const usePageStore = defineStore("pageStore", {
 			this.activePage = page;
 
 			const blocks = JSON.parse(page.draft_blocks || page.blocks || "[]");
+			if (switchingPage) {
+				capture("builder_editor_opened", {
+					page: page.name,
+					block_count: countBlocks(blocks),
+					is_published: Boolean(page.published),
+				});
+			}
 			this.editPage(!resetCanvas);
 			if (!Array.isArray(blocks)) {
 				const canvasStore = useCanvasStore();

--- a/frontend/src/stores/pageStore.ts
+++ b/frontend/src/stores/pageStore.ts
@@ -46,7 +46,9 @@ const usePageStore = defineStore("pageStore", {
 				return;
 			}
 
-			const switchingPage = pageName !== this.selectedPage;
+			// against the last page that actually loaded, so a retry after a failed
+			// fetch still counts as opening it
+			const switchingPage = pageName !== this.activePage?.name;
 			this.selectedPage = pageName;
 			const pageLoadToken = ++this.pageLoadToken;
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -384,6 +384,11 @@ async function uploadBuilderAsset(file: File, silent = false) {
 	};
 }
 
+function countBlocks(blocks: BlockOptions | BlockOptions[]): number {
+	const list = Array.isArray(blocks) ? blocks : [blocks];
+	return list.reduce((count, block) => count + 1 + countBlocks(block.children || []), 0);
+}
+
 const MAX_INLINE_SVG_SIZE = 20 * 1024;
 
 // a token-painted SVG has to stay inline: an <img> cannot read CSS variables
@@ -971,6 +976,7 @@ export {
 	confirm,
 	copyToClipboard,
 	convertSVGBlockToImage,
+	countBlocks,
 	cssUrl,
 	dataURLFileName,
 	dataURLtoFile,


### PR DESCRIPTION
Refs #800. Covers items 1, 2, 5, the reachable half of 3, and the dead `builder_page_unpublished` from 7.

**What**

`builder_page_created` now carries `page`, `source` (`template` / `duplicate` / `blank` / `import`), `template_page` and `block_count`. The two known origins are stamped by their API entry points; anything else with more than the root block came in with content (paste, REST), so it reads as `import`. The capture moved from `before_insert` to `after_insert`: Frappe's naming discards whatever name `before_insert` saw, so the id the issue expected there was never the real one.

`builder_page_published` carries `page`, `is_first_publish`, `seconds_since_created`, `block_count`, `has_client_script`, `has_data_script`. First publish is read before `publish()` sets the flag, and `published_at` is checked too so an unpublish/republish cycle does not count as a second first.

`builder_page_unpublished` never fired because the editor unpublishes with a plain `set_value` on `published`, never the `unpublish` doc method. It now fires from `on_update` on the 1 → 0 transition, whichever path flips it, and carries `page`.

`builder_page_template_used` sends `page` (the new page's name) and `builder_template_group_imported` sends `pages`, both values the frontend already had in hand.

New `builder_editor_opened` event, fired from `pageStore.setPage` whenever the editor switches to a page other than the last one that loaded, with `page`, `block_count`, `is_published`. Reloads of the same page (restore, revert, unpublish) do not refire; a retry after a failed fetch does. This is the first in-editor trace for the 256 sites whose last event was `builder_page_created`.

Persona survey answers are attached to the site's Pulse profile through a new `builder.api.identify_persona` endpoint (`builder_role`, `builder_use_case`, `builder_source`). The existing `builder_persona_submitted` event stays. Argument types are enforced by `frappe.whitelist` (Builder sets `require_type_annotated_api_methods`), and the pulse import is local and guarded because `identify` only exists on frappe v16+.

Tests in `builder/builder/tests/test_telemetry.py` cover every property above plus the not-first-publish and not-an-unpublish-on-insert edges.

**Left out, and why**

- Item 6 (`user=` on hook events) changes nothing: the Pulse client already defaults `user` to `frappe.session.user`. What it does not do is anonymize `Administrator` (a standard user), so events published as Administrator carry a user the ingest side apparently drops. Builder cannot fix that from its call sites.
- Item 4 (failure events) needs a reason taxonomy first; wrapping `publish()` to emit exception class names felt premature.
- `builder_editor_closed` (item 3) is unreliable on tab close and would bias session length, so it is skipped.
- Item 7: the video and font upload paths are reachable (drop a video or font file on the canvas), so those look like low usage rather than dead code. The `schema_version` stamp and the dead-event test need Pulse data access, which a repo test does not have.
- Item 8 renames are left alone to keep dashboard continuity. `builder_editor_opened` supersedes `builder_page_opened`, which can be retired once it has data.
- The `source: page.live_url ? "hub" : "local"` key on the template events is always `hub` because every template now comes through the hub; left as is.

**Noticed, not touched**

`set_default_values` derives `route` from a name that naming then throws away, so a page's route hash and its name hash never match. Harmless, but surprising.
