### PR TITLE
fix: render form controls in the canvas as real but inert elements, and align property control label widths

### DIFF
--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -50,6 +50,7 @@ const TEXT_ELEMENTS = new Set([
 	"i",
 	"blockquote",
 	"summary",
+	"option",
 ]);
 
 const CONTAINER_ELEMENTS = new Set(["section", "div"]);

--- a/frontend/src/block.ts
+++ b/frontend/src/block.ts
@@ -50,7 +50,6 @@ const TEXT_ELEMENTS = new Set([
 	"i",
 	"blockquote",
 	"summary",
-	"option",
 ]);
 
 const CONTAINER_ELEMENTS = new Set(["section", "div"]);

--- a/frontend/src/components/ArrayInput.vue
+++ b/frontend/src/components/ArrayInput.vue
@@ -2,8 +2,8 @@
 	<Popover :offset="20" placement="left">
 		<template #target="{ open }">
 			<div class="relative flex w-full gap-2">
-				<div class="flex w-[88px] shrink-0 items-center">
-					<InputLabel class="truncate">
+				<div class="flex w-1/3 min-w-[88px] shrink-0 items-center">
+					<InputLabel class="w-full truncate">
 						{{ label }}
 					</InputLabel>
 				</div>

--- a/frontend/src/components/BuilderBlock.vue
+++ b/frontend/src/components/BuilderBlock.vue
@@ -11,6 +11,7 @@
 		:readonly="readonly"
 		:style="styles"
 		ref="component">
+		<template v-if="optionText != null">{{ optionText }}</template>
 		<BuilderBlock
 			:data="data"
 			:componentData="resolvedComponentData"
@@ -50,7 +51,7 @@ import usePageStore from "@/stores/pageStore";
 import { BlockValueResolver } from "@/utils/blockValueResolver";
 import componentController from "@/utils/componentController.js";
 import { setFont } from "@/utils/fontManager";
-import { extractComponentId } from "@/utils/helpers";
+import { extractComponentId, getTextContent } from "@/utils/helpers";
 import type { BlockClientScriptEmulator } from "@/utils/scriptSandbox";
 import { useDraggableBlock } from "@/utils/useDraggableBlock";
 import {
@@ -180,6 +181,13 @@ const valueResolver = new BlockValueResolver({
 	data: () => props.data ?? null,
 	componentData: () => resolvedComponentData.value ?? null,
 	defaultProps: () => props.defaultProps ?? null,
+});
+
+// option supports only text content, so its label renders as a text node instead of going through TextBlock
+const optionText = computed(() => {
+	if (props.block.getElement() !== "option") return null;
+	const resolved = valueResolver.applyDynamicValues("key", { innerHTML: null }).innerHTML;
+	return getTextContent(String(resolved ?? props.block.getInnerHTML() ?? ""));
 });
 
 const attributes = computed(() => {

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -14,7 +14,7 @@
 			">
 			<template #target="{ togglePopover, isOpen }">
 				<div class="flex items-center justify-between">
-					<InputLabel v-if="label">{{ label }}</InputLabel>
+					<InputLabel v-if="label" class="w-1/3 min-w-[88px] shrink-0">{{ label }}</InputLabel>
 					<div class="relative w-full">
 						<Tooltip :text="isCssVariable ? resolvedColor : undefined">
 							<Autocomplete

--- a/frontend/src/components/Controls/InputLabel.vue
+++ b/frontend/src/components/Controls/InputLabel.vue
@@ -1,5 +1,5 @@
 <template>
-	<span class="flex w-[88px] min-w-16 items-center truncate text-xs leading-5 text-ink-gray-6">
+	<span class="flex min-w-0 items-center truncate text-xs leading-5 text-ink-gray-6">
 		<span class="truncate"><slot /></span>
 		<Popover trigger="hover" v-if="description" placement="top">
 			<template #target>

--- a/frontend/src/components/Controls/OptionToggle.vue
+++ b/frontend/src/components/Controls/OptionToggle.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex w-full items-center justify-between">
-		<InputLabel v-if="label">{{ label }}</InputLabel>
+		<InputLabel v-if="label" class="w-1/3 min-w-[88px] shrink-0">{{ label }}</InputLabel>
 		<TabButtons
 			:class="['w-full min-w-[150px]', STRETCH_TABS]"
 			:options="tabOptions"

--- a/frontend/src/components/Controls/PropertyLabel.vue
+++ b/frontend/src/components/Controls/PropertyLabel.vue
@@ -7,7 +7,7 @@
 				aria-hidden="true" />
 		</Dropdown>
 		<InputLabel
-			class="truncate"
+			class="w-full truncate"
 			:title="label"
 			:class="{ 'cursor-ns-resize': enableSlider }"
 			@mousedown="$emit('mousedown', $event)">

--- a/frontend/src/components/Controls/RangeInput.vue
+++ b/frontend/src/components/Controls/RangeInput.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex items-center gap-2">
-		<InputLabel v-if="label">{{ label }}</InputLabel>
+		<InputLabel v-if="label" class="w-1/3 min-w-[88px] shrink-0">{{ label }}</InputLabel>
 		<BuilderInput
 			v-if="!hideInput"
 			:modelValue="modelValue"

--- a/frontend/src/components/Controls/VariantControl.vue
+++ b/frontend/src/components/Controls/VariantControl.vue
@@ -45,7 +45,10 @@
 					<span class="lucide-x size-3" aria-hidden="true" />
 				</button>
 			</span>
-			<InputLabel :class="{ 'cursor-ns-resize': enableSlider }" @mousedown="$emit('labelMousedown', $event)">
+			<InputLabel
+				class="w-full"
+				:class="{ 'cursor-ns-resize': enableSlider }"
+				@mousedown="$emit('labelMousedown', $event)">
 				{{ label }}
 			</InputLabel>
 		</div>

--- a/frontend/src/components/DataLoaderBlock.vue
+++ b/frontend/src/components/DataLoaderBlock.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="component">
+	<component :is="block.getTag()" ref="component">
 		<div
 			v-if="!block.hasChildren()"
 			class="pointer-events-none flex h-full w-full items-center justify-center font-semibold">
@@ -17,7 +17,7 @@
 			:isChildOfComponent="block.isExtendedFromComponent()"
 			:repeater-index="getRepeaterIndex(index)"
 			v-for="(_data, index) in blockRepeaterData" />
-	</div>
+	</component>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -12,7 +12,9 @@
 			<Popover placement="left" class="!block w-full" :offset="popoverOffset">
 				<template #target="{ togglePopover }">
 					<div class="flex items-center justify-between">
-						<InputLabel v-if="label && labelPosition === 'left'">{{ label }}</InputLabel>
+						<InputLabel v-if="label && labelPosition === 'left'" class="w-1/3 min-w-[88px] shrink-0">
+							{{ label }}
+						</InputLabel>
 						<div class="relative w-full [&>div>div>div>div]:pe-0">
 							<BuilderInput
 								type="text"

--- a/frontend/src/components/ObjectInput.vue
+++ b/frontend/src/components/ObjectInput.vue
@@ -2,8 +2,8 @@
 	<Popover :offset="20" placement="left">
 		<template #target="{ open }">
 			<div class="relative flex w-full gap-2">
-				<div class="flex w-[88px] shrink-0 items-center">
-					<InputLabel class="truncate">
+				<div class="flex w-1/3 min-w-[88px] shrink-0 items-center">
+					<InputLabel class="w-full truncate">
 						{{ label }}
 					</InputLabel>
 				</div>

--- a/frontend/src/utils/useBlockEventHandlers.ts
+++ b/frontend/src/utils/useBlockEventHandlers.ts
@@ -9,11 +9,28 @@ import { nextTick } from "vue";
 const builderStore = useBuilderStore();
 const canvasStore = useCanvasStore();
 
+// Native form controls in blocks are preview-only in the canvas; interactions are tested via /preview.
+const NATIVE_CONTROL_SELECTOR = "select, input, textarea, audio, video";
+
 export function useBlockEventHandlers(target: HTMLElement) {
+	useEventListener(target, "mousedown", suppressNativeControlActivation, { capture: true });
+	useEventListener(target, "focusin", blurNativeControls);
 	useEventListener(target, "mousedown", handleMouseDown);
 	useEventListener(target, "click", handleClick);
 	useEventListener(target, "dblclick", handleDoubleClick);
 	useEventListener(target, "contextmenu", triggerContextMenu);
+
+	// A select opens its picker on mousedown, before click-phase selection runs.
+	function suppressNativeControlActivation(e: MouseEvent) {
+		if (!isBlock(e) || isEditable(e)) return;
+		const el = e.target as HTMLElement;
+		if (el.closest(NATIVE_CONTROL_SELECTOR)) e.preventDefault();
+	}
+
+	function blurNativeControls(e: FocusEvent) {
+		const el = e.target as HTMLElement;
+		if (el.matches?.(NATIVE_CONTROL_SELECTOR) && el.closest(".__builder_component__")) el.blur();
+	}
 
 	// Press-and-drag any block to reorder it in one gesture (no need to select
 	// first). The threshold inside startBlockReorder means a plain click still


### PR DESCRIPTION
## Native form controls in the canvas

- A repeater rendered as a hardcoded `div` in the canvas, so a `select`-as-repeater previewed as an empty box. `DataLoaderBlock` now renders the repeater's own tag.
- `option` elements ignored their `innerHTML` bindings in the canvas. Since option supports only text content, its label now renders as a resolved text node in `BuilderBlock` (not through `TextBlock`, which would nest a div and the rich-text editor inside the option); option labels are edited through bindings and the properties panel, not inline.
- Bringing real controls into the canvas exposed that they were interactable: a select opens its native picker on **mousedown**, before click-phase selection runs (the reorder guard only covers reorderable blocks, so component children leaked through). Native controls (`select, input, textarea, audio, video`) are now inert in the canvas: a capture-phase mousedown guard plus a focus guard (Tab can't reach them either). Interactions are tested on `/preview`, which is unaffected.

Verified: canvas previews a data-driven select with its options exactly as published (each option holds a single text node); a real click selects the block and opens the properties panel without focusing the control; zero console errors.

## One label-column recipe for property controls

Property rows mixed three label-column widths: `InputLabel`'s own fixed `w-[88px]`, a fixed 88px column in `ArrayInput`/`ObjectInput`, and `w-1/3 min-w-[88px]` on the main controls. At the default panel width they roughly line up; widen the panel and every control starts at a different x, while `PropertyLabel`'s inner 88px cap truncates labels even with room to spare.

`InputLabel` is now width-neutral, and every property-row label column uses the same `w-1/3 min-w-[88px] shrink-0` recipe — including `ImageUploadInput`'s left-positioned label (compact popovers keep their explicit widths). Verified at default and widened panel: all controls share one left edge across Component Options, Layout, Style, Dimension, Spacing, Options and Data Key sections, and labels use the full column before truncating.