### PR TITLE
fix: reserve mono for code literals in the AI debug UI

### DIFF
--- a/frontend/src/components/AIDebugPanel.vue
+++ b/frontend/src/components/AIDebugPanel.vue
@@ -13,7 +13,7 @@
 			<div class="grid grid-cols-2 divide-x divide-y divide-outline-gray-2 sm:grid-cols-4">
 				<div v-for="s in primaryStats" :key="s.label" class="flex flex-col gap-1 p-3.5">
 					<span class="text-[10px] font-medium uppercase tracking-wide text-ink-gray-5">{{ s.label }}</span>
-					<span class="font-mono text-lg font-medium leading-none text-ink-gray-9">{{ s.value }}</span>
+					<span class="text-lg font-medium tabular-nums leading-none text-ink-gray-9">{{ s.value }}</span>
 					<span v-if="s.sub" class="text-[11px] leading-none" :class="s.subTone || 'text-ink-gray-5'">
 						{{ s.sub }}
 					</span>
@@ -24,7 +24,7 @@
 			<div v-if="context" class="flex flex-col gap-1.5 border-t border-outline-gray-2 px-4 py-3">
 				<div class="flex items-center justify-between text-[11px] text-ink-gray-5">
 					<span class="font-medium uppercase tracking-wide">Context window</span>
-					<span class="font-mono">{{ context.used }} / {{ context.total }} · {{ context.pct }}%</span>
+					<span class="tabular-nums">{{ context.used }} / {{ context.total }} · {{ context.pct }}%</span>
 				</div>
 				<div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-gray-3">
 					<div
@@ -73,7 +73,7 @@
 				<div v-for="(round, idx) in trace" :key="idx" class="relative flex gap-3 pb-4 last:pb-0">
 					<div class="flex flex-col items-center">
 						<span
-							class="z-10 grid size-5 shrink-0 place-items-center rounded-full bg-surface-gray-3 font-mono text-[10px] font-semibold text-ink-gray-6">
+							class="z-10 grid size-5 shrink-0 place-items-center rounded-full bg-surface-gray-3 text-[10px] font-semibold text-ink-gray-6">
 							{{ (round.round ?? idx) + 1 }}
 						</span>
 						<span v-if="idx < trace.length - 1" class="bg-outline-gray-2 -mb-4 mt-1 w-px flex-1" />

--- a/frontend/src/components/BuilderAIChatPanel.vue
+++ b/frontend/src/components/BuilderAIChatPanel.vue
@@ -163,7 +163,7 @@
 							<!-- Time taken + debugger trigger (full breakdown lives in the debug panel) -->
 							<template v-if="message.metadata?.debug">
 								<div class="ml-auto flex items-center gap-2">
-									<span v-if="message.metadata.debug.elapsedMs" class="font-mono">
+									<span v-if="message.metadata.debug.elapsedMs">
 										took {{ formatDuration(message.metadata.debug.elapsedMs) }}
 									</span>
 									<button


### PR DESCRIPTION
Audit of `font-mono` across the editor: mono should mark code-like literals, not numbers or labels.

**Removed** (with `tabular-nums` where numeric alignment matters):
- AI debug panel stat-tile values and the context-window meter — numbers, not code
- the trace round-number badge
- the "took 3.4s" elapsed-time note in the chat panel

**Kept, deliberately** — genuine code literals: tool-name chips and args, raw log/transcript panes and tool-failure output, the model id slug, CSS property names (styles search), route segments (page tree), redirect patterns, DNS record values, `var()`/hex color inputs, regex toggles in the code-editor search panel, and dynamic-value keys.