### PR TITLE
fix: clear editor console warnings and errors

### DIFF
--- a/frontend/src/components/ArrayInput.vue
+++ b/frontend/src/components/ArrayInput.vue
@@ -17,7 +17,7 @@
 				@click.stop
 				@mousedown.stop
 				class="flex max-h-60 w-60 flex-col gap-3 overflow-auto rounded-lg bg-surface-base p-4 shadow-lg">
-				<div class="text-sm text-ink-gray-8">{{ __("Array Items:") }}</div>
+				<div class="text-sm text-ink-gray-8">{{ __("Items") }}</div>
 				<ArrayEditor :arr @update:arr="updateModelValue" />
 			</div>
 		</template>

--- a/frontend/src/components/ArrayInput.vue
+++ b/frontend/src/components/ArrayInput.vue
@@ -1,6 +1,6 @@
 <template>
-	<Popover :offset="20" placement="left">
-		<template #target="{ open }">
+	<Popover :offset="20" side="left" align="center" bare>
+		<template #trigger>
 			<div class="relative flex w-full gap-2">
 				<div class="flex w-1/3 min-w-[88px] shrink-0 items-center">
 					<InputLabel class="w-full truncate">
@@ -8,11 +8,11 @@
 					</InputLabel>
 				</div>
 				<div class="relative w-full">
-					<Button class="w-full" variant="subtle" icon="lucide-pencil" @click.stop="open()" />
+					<Button class="w-full" variant="subtle" icon="lucide-pencil" />
 				</div>
 			</div>
 		</template>
-		<template #body="{ open, close }">
+		<template #default>
 			<div
 				@click.stop
 				@mousedown.stop

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -1,7 +1,10 @@
 <template>
-	<Popover placement="left" class="!block w-full" :offset="25" @update:open="handlePopoverToggle">
-		<template #target="{ togglePopover }">
-			<div class="flex w-full items-center justify-between" @focusin="updateActiveState">
+	<Popover side="left" align="center" :offset="25" bare :open="isOpen" @update:open="onUpdateOpen">
+		<template #trigger>
+			<div
+				class="flex w-full items-center justify-between"
+				@focusin="updateActiveState"
+				@click.capture="onAnchorClick">
 				<StylePropertyControl
 					propertyKey="background"
 					:component="BackgroundInput"
@@ -12,7 +15,7 @@
 					readonly
 					:selectOnFocus="false"
 					class="[&_input]:cursor-pointer"
-					@focus="togglePopover"
+					@focus="toggle"
 					:getModelValue="() => getDisplayValue(null)"
 					:getVariantValue="(v: string) => getDisplayValue(v)"
 					:setVariantValue="handleSetVariant"
@@ -23,7 +26,7 @@
 							@click="
 								() => {
 									activeState = variant;
-									togglePopover();
+									toggle();
 								}
 							"
 							:class="{ 'bg-surface-gray-4': !getHasBackground(variant) }"
@@ -32,7 +35,7 @@
 				</StylePropertyControl>
 			</div>
 		</template>
-		<template #body>
+		<template #default>
 			<div
 				class="background-popover-body w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
 				<TabButtons
@@ -148,6 +151,7 @@ import blockController from "@/utils/blockController";
 import { cssUrl } from "@/utils/helpers";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { STRETCH_TABS } from "@/utils/tabButtons";
+import { useAnchoredPopover } from "@/utils/useAnchoredPopover";
 import { FileUploader, Popover, Switch, TabButtons } from "frappe-ui";
 import { computed, defineComponent, h, ref, watch } from "vue";
 
@@ -191,6 +195,7 @@ const colorPickerRef = ref<InstanceType<typeof ColorPicker> | null>(null);
 const handlePopoverToggle = (open: boolean) => {
 	if (!open) colorPickerRef.value?.commitRecentColor();
 };
+const { isOpen, toggle, onAnchorClick, onUpdateOpen } = useAnchoredPopover(handlePopoverToggle);
 
 const updateActiveState = (e: FocusEvent) => {
 	const target = e.target as HTMLElement;

--- a/frontend/src/components/BlockPropertySections/StandardPropsInputSection.ts
+++ b/frontend/src/components/BlockPropertySections/StandardPropsInputSection.ts
@@ -52,6 +52,7 @@ const getPropsMap = (propName: string, propDetails: BlockProps[string]) => {
 			break;
 	}
 	map = {
+		propertyKey: propName,
 		label: propDetails.label || propName,
 		enableStates: false,
 		allowDynamicValue: true,
@@ -82,7 +83,8 @@ const getPropsMap = (propName: string, propDetails: BlockProps[string]) => {
 			return value;
 		},
 		getPlaceholder: () => {
-			return propDetails.propOptions?.options?.defaultValue || null;
+			const defaultValue = propDetails.propOptions?.options?.defaultValue;
+			return defaultValue == null || defaultValue === "" ? null : String(defaultValue);
 		},
 		defaultValue:
 			type == "boolean"

--- a/frontend/src/components/BorderRadiusHandler.vue
+++ b/frontend/src/components/BorderRadiusHandler.vue
@@ -3,6 +3,7 @@
 
 	<div
 		ref="handler"
+		v-bind="$attrs"
 		class="border-radius-resize pointer-events-auto absolute h-[10px] w-[10px] cursor-pointer rounded-full border-2 border-blue-400 bg-white"
 		:class="{
 			hidden: !isHandlerVisible,
@@ -25,6 +26,9 @@ const props = defineProps<{
 	targetBlock: Block;
 	target: HTMLElement | SVGElement;
 }>();
+
+// the tooltip renders beside the handle, so attributes go to the handle explicitly
+defineOptions({ inheritAttrs: false });
 
 const updating = ref(false);
 const cursorPosition = ref({ x: 0, y: 0 });

--- a/frontend/src/components/BuilderAIChatPanel.vue
+++ b/frontend/src/components/BuilderAIChatPanel.vue
@@ -9,21 +9,22 @@
 				</div>
 			</div>
 			<div v-if="builderStore.isAIEnabled" class="flex shrink-0 items-center gap-1">
-				<Tooltip text="New chat">
-					<Button variant="ghost" size="sm" icon="lucide-plus" :disabled="isSubmitting" @click="newSession" />
-				</Tooltip>
-				<!-- Button sits directly in the Dropdown slot: a Tooltip wrapper breaks
-				     the as-child trigger wiring (frappe-ui slot API). -->
+				<Button
+					variant="ghost"
+					size="sm"
+					icon="lucide-plus"
+					tooltip="New chat"
+					:disabled="isSubmitting"
+					@click="newSession" />
 				<Dropdown v-if="sessionOptions.length" :options="sessionOptions" :offset="6">
-					<Button variant="ghost" size="sm" icon="lucide-history" title="Chats on this page" />
+					<Button variant="ghost" size="sm" icon="lucide-history" tooltip="Chats on this page" />
 				</Dropdown>
-				<Tooltip text="AI settings">
-					<Button
-						variant="ghost"
-						size="sm"
-						icon="lucide-settings-2"
-						@click="builderStore.openBuilderSettings('global_ai')" />
-				</Tooltip>
+				<Button
+					variant="ghost"
+					size="sm"
+					icon="lucide-settings-2"
+					tooltip="AI settings"
+					@click="builderStore.openBuilderSettings('global_ai')" />
 			</div>
 		</div>
 
@@ -152,31 +153,32 @@
 								@select-block="selectBlockById"
 								@open-script="openScriptByName" />
 
-							<button
-								v-if="message.metadata?.revertSnapshot"
-								class="inline-flex items-center gap-1 transition-colors hover:text-ink-gray-7"
-								title="Revert the page to before this AI edit"
-								@click="revertTurn(message)">
-								<span class="lucide-rotate-ccw size-3" />
-								Revert
-							</button>
+							<Tooltip v-if="message.metadata?.revertSnapshot" text="Revert the page to before this AI edit">
+								<button
+									class="inline-flex items-center gap-1 transition-colors hover:text-ink-gray-7"
+									@click="revertTurn(message)">
+									<span class="lucide-rotate-ccw size-3" />
+									Revert
+								</button>
+							</Tooltip>
 							<!-- Time taken + debugger trigger (full breakdown lives in the debug panel) -->
 							<template v-if="message.metadata?.debug">
 								<div class="ml-auto flex items-center gap-2">
 									<span v-if="message.metadata.debug.elapsedMs">
 										took {{ formatDuration(message.metadata.debug.elapsedMs) }}
 									</span>
-									<button
-										class="inline-flex items-center transition-colors"
-										:class="
-											debugHasSignal(message.metadata.debug)
-												? 'text-ink-amber-8 hover:text-ink-amber-7'
-												: 'text-ink-gray-4 hover:text-ink-gray-7'
-										"
-										title="Inspect this turn (rounds, tools, tokens, why it stopped)"
-										@click="openDebug(message.metadata.debug)">
-										<span class="lucide-activity size-2.5" />
-									</button>
+									<Tooltip text="Inspect this turn (rounds, tools, tokens, why it stopped)">
+										<button
+											class="inline-flex items-center transition-colors"
+											:class="
+												debugHasSignal(message.metadata.debug)
+													? 'text-ink-amber-8 hover:text-ink-amber-7'
+													: 'text-ink-gray-4 hover:text-ink-gray-7'
+											"
+											@click="openDebug(message.metadata.debug)">
+											<span class="lucide-activity size-2.5" />
+										</button>
+									</Tooltip>
 								</div>
 							</template>
 						</div>
@@ -267,13 +269,14 @@
 						class="inline-flex items-center gap-1 rounded bg-surface-gray-2 px-1.5 py-0.5 text-xs text-ink-gray-7">
 						<span class="lucide-square-dashed h-3 w-3 shrink-0 text-ink-gray-5" />
 						<span class="block max-w-[8rem] truncate">{{ block.label }}</span>
-						<button
-							type="button"
-							class="ml-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
-							title="Remove from context"
-							@click="chat.detachBlock(block.id)">
-							<span class="lucide-x h-3 w-3" />
-						</button>
+						<Tooltip text="Remove from context">
+							<button
+								type="button"
+								class="ml-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
+								@click="chat.detachBlock(block.id)">
+								<span class="lucide-x h-3 w-3" />
+							</button>
+						</Tooltip>
 					</span>
 					<button
 						v-if="attachableBlocks.length"
@@ -296,13 +299,14 @@
 							class="inline-flex items-center gap-1 rounded bg-surface-gray-2 px-1.5 py-0.5 text-xs text-ink-gray-7">
 							<img :src="imagePreviewUrl" class="h-3 w-3 rounded object-cover" alt="" />
 							<span class="max-w-[120px] truncate">{{ imageFileName }}</span>
-							<button
-								type="button"
-								class="ml-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
-								title="Remove image"
-								@click="clearImage">
-								<span class="lucide-x h-3 w-3" />
-							</button>
+							<Tooltip text="Remove image">
+								<button
+									type="button"
+									class="ml-0.5 flex items-center text-ink-gray-4 hover:text-ink-red-7"
+									@click="clearImage">
+									<span class="lucide-x h-3 w-3" />
+								</button>
+							</Tooltip>
 						</span>
 					</div>
 				</Transition>
@@ -382,7 +386,7 @@
 						variant="solid"
 						icon="lucide-square"
 						:loading="isCancelling"
-						:title="isCancelling ? 'Cancelling…' : 'Cancel generation'"
+						:tooltip="isCancelling ? 'Cancelling…' : 'Cancel generation'"
 						@click="chat.cancel" />
 					<Button
 						v-else

--- a/frontend/src/components/ComponentUpdates.vue
+++ b/frontend/src/components/ComponentUpdates.vue
@@ -1,56 +1,63 @@
 <template>
-	<Popover v-if="outdated.length" placement="bottom-end">
-		<template #target="{ togglePopover }">
-			<Tooltip :text="__('Component updates available')" :hoverDelay="0.6" arrow-class="mb-3">
-				<button
-					class="relative flex h-7 w-7 items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-3"
-					@click="togglePopover">
-					<span class="lucide-arrow-up-circle h-4 w-4" aria-hidden="true" />
-					<span
-						class="pointer-events-none absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full bg-amber-100 px-0.5 text-[9px] font-medium text-amber-700">
-						{{ outdated.length }}
-					</span>
-				</button>
-			</Tooltip>
-		</template>
-		<template #body="{ close }">
-			<div class="w-72 rounded-lg bg-surface-base p-3 shadow-xl" @mouseleave="clearHighlight">
-				<div class="mb-2 flex items-center justify-between">
-					<span class="text-sm font-medium text-ink-gray-8">{{ __("Component updates") }}</span>
-					<Button
-						variant="subtle"
-						size="sm"
-						:label="__('Update all')"
-						:loading="updatingAll"
-						@click="updateAll" />
-				</div>
-				<p class="mb-3 text-xs text-ink-gray-5">
-					{{ __("These components changed since this page was last updated. Update to use the latest.") }}
-				</p>
-				<div class="flex max-h-72 flex-col overflow-y-auto">
-					<div
-						v-for="item in outdated"
-						:key="item.component_id"
-						class="flex cursor-pointer items-center justify-between gap-2 rounded border-b border-outline-gray-1 px-2 py-2 last:border-b-0 hover:bg-surface-gray-1"
-						@mouseenter="highlight(item.component_id)"
-						@mouseleave="clearHighlight">
-						<div class="flex min-w-0 flex-col">
-							<span class="truncate text-sm text-ink-gray-8">{{ item.component_name }}</span>
-							<span class="text-xs text-ink-gray-5">
-								{{ item.count === 1 ? __("{0} instance", [item.count]) : __("{0} instances", [item.count]) }}
-							</span>
+	<Tooltip
+		v-if="outdated.length"
+		:text="__('Component updates available')"
+		:hoverDelay="0.6"
+		arrow-class="mb-3">
+		<span class="inline-flex">
+			<Popover side="bottom" align="end" bare>
+				<template #trigger>
+					<button
+						class="relative flex h-7 w-7 items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-3">
+						<span class="lucide-arrow-up-circle h-4 w-4" aria-hidden="true" />
+						<span
+							class="pointer-events-none absolute -right-0.5 -top-0.5 grid h-3.5 min-w-3.5 place-items-center rounded-full bg-amber-100 px-0.5 text-[9px] font-medium text-amber-700">
+							{{ outdated.length }}
+						</span>
+					</button>
+				</template>
+				<template #default="{ close }">
+					<div class="w-72 rounded-lg bg-surface-base p-3 shadow-xl" @mouseleave="clearHighlight">
+						<div class="mb-2 flex items-center justify-between">
+							<span class="text-sm font-medium text-ink-gray-8">{{ __("Component updates") }}</span>
+							<Button
+								variant="subtle"
+								size="sm"
+								:label="__('Update all')"
+								:loading="updatingAll"
+								@click="updateAll" />
 						</div>
-						<Button
-							variant="ghost"
-							size="sm"
-							:label="__('Update')"
-							:loading="updating === item.component_id"
-							@click="update(item.component_id)" />
+						<p class="mb-3 text-xs text-ink-gray-5">
+							{{ __("These components changed since this page was last updated. Update to use the latest.") }}
+						</p>
+						<div class="flex max-h-72 flex-col overflow-y-auto">
+							<div
+								v-for="item in outdated"
+								:key="item.component_id"
+								class="flex cursor-pointer items-center justify-between gap-2 rounded border-b border-outline-gray-1 px-2 py-2 last:border-b-0 hover:bg-surface-gray-1"
+								@mouseenter="highlight(item.component_id)"
+								@mouseleave="clearHighlight">
+								<div class="flex min-w-0 flex-col">
+									<span class="truncate text-sm text-ink-gray-8">{{ item.component_name }}</span>
+									<span class="text-xs text-ink-gray-5">
+										{{
+											item.count === 1 ? __("{0} instance", [item.count]) : __("{0} instances", [item.count])
+										}}
+									</span>
+								</div>
+								<Button
+									variant="ghost"
+									size="sm"
+									:label="__('Update')"
+									:loading="updating === item.component_id"
+									@click="update(item.component_id)" />
+							</div>
+						</div>
 					</div>
-				</div>
-			</div>
-		</template>
-	</Popover>
+				</template>
+			</Popover>
+		</span>
+	</Tooltip>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/Controls/BasePropertyControl.vue
+++ b/frontend/src/components/Controls/BasePropertyControl.vue
@@ -121,7 +121,7 @@ const props = withDefaults(
 		maxValue?: number | null;
 		component?: Component;
 		events?: Record<string, unknown>;
-		defaultValue?: string | number;
+		defaultValue?: string | number | boolean;
 		allowDynamicValue?: boolean;
 		labelPlacement?: "left" | "top";
 		variants?: Array<{ name: string; property: string; label: string }>;

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -9,7 +9,7 @@
 		:open="isOpen"
 		@update:open="onUpdateOpen">
 		<template #trigger>
-			<div class="flex" v-bind="$attrs" @click.capture="onAnchorClick">
+			<div class="w-full" v-bind="$attrs" @click.capture="onAnchorClick">
 				<slot name="target" :togglePopover="togglePopover" :isOpen="isOpen"></slot>
 			</div>
 		</template>

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -1,26 +1,28 @@
 <template>
 	<Popover
-		ref="colorPickerPopover"
 		v-if="renderMode === 'popover'"
-		:placement="placement"
+		:side="side"
+		:align="align"
 		:offset="offset"
 		:portal-to="portalTo"
-		@update:open="handleOpenChange"
-		class="!block w-full">
-		<template #target>
-			<slot name="target" :togglePopover="togglePopover" :isOpen="isOpen"></slot>
+		bare
+		:open="isOpen"
+		@update:open="onUpdateOpen">
+		<template #trigger>
+			<div class="flex" v-bind="$attrs" @click.capture="onAnchorClick">
+				<slot name="target" :togglePopover="togglePopover" :isOpen="isOpen"></slot>
+			</div>
 		</template>
-		<template #body>
-			<ColorPickerContent
-				ref="contentRef"
-				:modelValue="modelValue"
-				:showInput="showInput"
-				renderMode="popover"
-				@update:modelValue="emit('update:modelValue', $event)" />
-		</template>
+		<ColorPickerContent
+			ref="contentRef"
+			:modelValue="modelValue"
+			:showInput="showInput"
+			renderMode="popover"
+			@update:modelValue="emit('update:modelValue', $event)" />
 	</Popover>
 	<ColorPickerContent
 		v-else
+		v-bind="$attrs"
 		ref="contentRef"
 		:modelValue="modelValue"
 		:showInput="showInput"
@@ -28,9 +30,13 @@
 		@update:modelValue="emit('update:modelValue', $event)" />
 </template>
 <script setup lang="ts">
+import { useAnchoredPopover } from "@/utils/useAnchoredPopover";
 import { Popover } from "frappe-ui";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import ColorPickerContent from "./ColorPickerContent.vue";
+
+// attributes belong on the trigger row (or the inline picker), never on the popover shell
+defineOptions({ inheritAttrs: false });
 
 type CSSColorValue = HashString | RGBString | `var(--${string})`;
 
@@ -58,26 +64,21 @@ const props = withDefaults(
 	{ modelValue: null, showInput: false, placement: "left-start", renderMode: "popover", offset: 10 },
 );
 
-const emit = defineEmits(["update:modelValue"]);
-const colorPickerPopover = ref<InstanceType<typeof Popover> | null>(null);
+const emit = defineEmits(["update:modelValue", "open", "close"]);
 const contentRef = ref<InstanceType<typeof ColorPickerContent> | null>(null);
-const isOpen = ref(false);
+
+const side = computed(() => props.placement.split("-")[0] as "top" | "bottom" | "left" | "right");
+const align = computed(() => (props.placement.split("-")[1] ?? "center") as "start" | "center" | "end");
 
 // bank the color the picker closed on into the recently used swatches
-function handleOpenChange(open: boolean) {
+const { isOpen, toggle, onAnchorClick, onUpdateOpen } = useAnchoredPopover((open) => {
 	if (!open) contentRef.value?.commitRecentColor();
-	isOpen.value = open;
-}
+	emit(open ? "open" : "close");
+});
 
 // event handlers bind this directly, so drop the event they pass
 function togglePopover(open?: boolean | Event) {
-	if (open instanceof Event) open = undefined;
-	if (open == null) open = !isOpen.value;
-	if (open) {
-		colorPickerPopover.value?.open();
-	} else {
-		colorPickerPopover.value?.close();
-	}
+	toggle(open);
 	contentRef.value?.syncPositions();
 }
 

--- a/frontend/src/components/Controls/GradientEditor.vue
+++ b/frontend/src/components/Controls/GradientEditor.vue
@@ -25,17 +25,19 @@
 					class="absolute top-1/2 z-10 -translate-x-1/2 -translate-y-1/2"
 					:style="{ left: stop.position + '%' }">
 					<Popover
-						placement="top"
+						side="top"
+						align="center"
 						:offset="10"
-						@update:open="(open: boolean) => handleStopPopoverToggle(open, index)">
-						<template #target="{ togglePopover }">
+						bare
+						:open="openStop === index"
+						@update:open="(open: boolean) => setStopOpen(index, open)">
+						<template #trigger>
 							<div
 								class="size-4 cursor-pointer rounded-full border-2 border-white shadow-md ring-1 ring-black/20 transition-transform hover:scale-110 focus:outline-none"
 								:style="{ backgroundColor: stop.color }"
-								@mousedown="handleStopMouseDown(index, $event)"
-								@click="(e) => !hasMoved && togglePopover()" />
+								@mousedown="handleStopMouseDown(index, $event)" />
 						</template>
-						<template #body="{ close }">
+						<template #default="{ close }">
 							<div class="w-52 rounded-lg border border-outline-gray-2 bg-surface-base p-3 shadow-xl">
 								<ColorPicker
 									:ref="(el) => (stopPickerRefs[index] = el)"
@@ -118,8 +120,17 @@ const hasMoved = ref(false);
 // the same way BackgroundHandler does for the background picker
 const stopPickerRefs: Record<number, any> = {};
 
-const handleStopPopoverToggle = (open: boolean, index: number) => {
-	if (!open) stopPickerRefs[index]?.commitRecentColor();
+const openStop = ref<number | null>(null);
+
+// a drag ends with a click on the handle; that click must not open the picker
+const setStopOpen = (index: number, open: boolean) => {
+	if (open && hasMoved.value) return;
+	if (open) {
+		openStop.value = index;
+		return;
+	}
+	if (openStop.value === index) openStop.value = null;
+	stopPickerRefs[index]?.commitRecentColor();
 };
 
 const { elementX } = useMouseInElement(barRef);

--- a/frontend/src/components/Controls/InputLabel.vue
+++ b/frontend/src/components/Controls/InputLabel.vue
@@ -1,10 +1,8 @@
 <template>
 	<span class="flex min-w-0 items-center truncate text-xs leading-5 text-ink-gray-6">
 		<span class="truncate"><slot /></span>
-		<Popover trigger="hover" v-if="description" placement="top">
-			<template #target>
-				<span class="lucide-info ml-1 h-[12px] w-[12px] text-gray-500" aria-hidden="true" />
-			</template>
+		<Tooltip v-if="description" placement="top">
+			<span class="lucide-info ml-1 h-[12px] w-[12px] text-gray-500" aria-hidden="true" />
 			<template #body>
 				<slot name="body">
 					<div
@@ -12,11 +10,11 @@
 						v-html="description"></div>
 				</slot>
 			</template>
-		</Popover>
+		</Tooltip>
 	</span>
 </template>
 <script lang="ts" setup>
-import { Popover } from "frappe-ui";
+import { Tooltip } from "frappe-ui";
 const props = withDefaults(
 	defineProps<{
 		description?: string;

--- a/frontend/src/components/Controls/OptionToggle.vue
+++ b/frontend/src/components/Controls/OptionToggle.vue
@@ -25,7 +25,7 @@ const props = withDefaults(
 			showTooltip?: boolean;
 		}[];
 		label?: string;
-		defaultValue?: string | number;
+		defaultValue?: string | number | boolean;
 	}>(),
 	{
 		options: () => [],

--- a/frontend/src/components/Controls/SearchBlock.vue
+++ b/frontend/src/components/Controls/SearchBlock.vue
@@ -19,10 +19,9 @@
 				@input="setQuery"
 				@keydown.enter="handlePrimaryAction" />
 
-			<Popover class="relative inline-block text-left">
-				<template #target="{ isOpen, togglePopover }">
+			<Popover bare>
+				<template #trigger="{ isOpen }">
 					<Button
-						@click="togglePopover"
 						icon="lucide-filter"
 						:label="__('Filters')"
 						:class="[
@@ -39,7 +38,7 @@
 							aria-hidden="true" />
 					</Button>
 				</template>
-				<template #body>
+				<template #default>
 					<div class="w-48 rounded-lg bg-surface-base py-2 shadow-lg ring-1 ring-black ring-opacity-5">
 						<div class="text-xs-medium px-3 py-2 text-ink-gray-5">{{ __("Filter search results by:") }}</div>
 						<div class="space-y-1 px-2">
@@ -392,7 +391,11 @@ const replaceAll = () => {
 	});
 
 	if (totalReplacements > 0) {
-		toast.success(totalReplacements === 1 ? __("Replaced in {0} block", [totalReplacements]) : __("Replaced in {0} blocks", [totalReplacements]));
+		toast.success(
+			totalReplacements === 1
+				? __("Replaced in {0} block", [totalReplacements])
+				: __("Replaced in {0} blocks", [totalReplacements]),
+		);
 		performSearch();
 	} else {
 		toast.error(__("No replacements made"));

--- a/frontend/src/components/ImageUploadInput.vue
+++ b/frontend/src/components/ImageUploadInput.vue
@@ -9,9 +9,15 @@
 			upload_endpoint: '/api/method/builder.api.upload_builder_asset',
 		}">
 		<template #default="{ openFileSelector }">
-			<Popover placement="left" class="!block w-full" :offset="popoverOffset">
-				<template #target="{ togglePopover }">
-					<div class="flex items-center justify-between">
+			<Popover
+				side="left"
+				align="center"
+				:offset="popoverOffset"
+				bare
+				:open="isOpen"
+				@update:open="onUpdateOpen">
+				<template #trigger>
+					<div class="flex w-full items-center justify-between" @click.capture="onAnchorClick">
 						<InputLabel v-if="label && labelPosition === 'left'" class="w-1/3 min-w-[88px] shrink-0">
 							{{ label }}
 						</InputLabel>
@@ -28,7 +34,7 @@
 									<img
 										:src="currentImageURL || '/assets/builder/images/fallback.png'"
 										alt=""
-										@click="togglePopover"
+										@click="toggle"
 										class="h-4 w-4 cursor-pointer rounded border border-outline-gray-3 shadow-sm"
 										:style="{
 											'object-fit': imageFit || 'contain',
@@ -45,7 +51,7 @@
 						</div>
 					</div>
 				</template>
-				<template #body>
+				<template #default>
 					<div class="w-64 rounded-lg bg-surface-base p-3 shadow-lg">
 						<div v-if="objectPosition !== undefined" class="mb-3 flex items-center">
 							<span class="text-sm font-semibold text-ink-gray-9">{{ __("Image") }}</span>
@@ -132,6 +138,7 @@ import InlineInput from "@/components/Controls/InlineInput.vue";
 import InputLabel from "@/components/Controls/InputLabel.vue";
 import useBuilderStore from "@/stores/builderStore";
 import { STRETCH_TABS } from "@/utils/tabButtons";
+import { useAnchoredPopover } from "@/utils/useAnchoredPopover";
 import { FileUploader, Popover, TabButtons } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
@@ -159,6 +166,7 @@ const props = withDefaults(
 );
 
 const builderStore = useBuilderStore();
+const { isOpen, toggle, onAnchorClick, onUpdateOpen } = useAnchoredPopover();
 const fileUploaderRef = ref<{ inputRef: () => HTMLInputElement } | null>(null);
 
 watch(

--- a/frontend/src/components/ObjectInput.vue
+++ b/frontend/src/components/ObjectInput.vue
@@ -1,6 +1,6 @@
 <template>
-	<Popover :offset="20" placement="left">
-		<template #target="{ open }">
+	<Popover :offset="20" side="left" align="center" bare>
+		<template #trigger>
 			<div class="relative flex w-full gap-2">
 				<div class="flex w-1/3 min-w-[88px] shrink-0 items-center">
 					<InputLabel class="w-full truncate">
@@ -8,11 +8,11 @@
 					</InputLabel>
 				</div>
 				<div class="relative w-full">
-					<Button class="w-full" variant="subtle" icon="lucide-pencil" @click.stop="open()" />
+					<Button class="w-full" variant="subtle" icon="lucide-pencil" />
 				</div>
 			</div>
 		</template>
-		<template #body="{ open, close }">
+		<template #default>
 			<div
 				@click.stop
 				@mousedown.stop

--- a/frontend/src/components/ObjectInput.vue
+++ b/frontend/src/components/ObjectInput.vue
@@ -17,7 +17,7 @@
 				@click.stop
 				@mousedown.stop
 				class="flex max-h-60 w-60 flex-col gap-3 overflow-auto rounded-lg bg-surface-base p-4 shadow-lg">
-				<div class="text-sm text-ink-gray-8">{{ __("Object Items:") }}</div>
+				<div class="text-sm text-ink-gray-8">{{ __("Items") }}</div>
 				<ObjectEditor :obj @update:obj="updateModelValue" />
 			</div>
 		</template>

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -19,7 +19,7 @@
 										keyBeingEdited = name as string;
 									}
 								">
-								<div class="flex w-fit max-w-[60%] items-center gap-2 pl-2">
+								<div class="flex min-w-0 flex-1 items-center gap-2 pl-2">
 									<div class="icon">
 										<component
 											v-if="value.propOptions?.type"
@@ -37,14 +37,14 @@
 											"
 											class="h-4 w-4 text-ink-gray-4" />
 									</div>
-									<div class="flex max-w-full flex-col gap-1">
+									<div class="flex min-w-0 flex-1 flex-col gap-1">
 										<p class="text-sm-medium">
 											{{ value.label || name }}
 										</p>
-										<p class="max-w-24 truncate text-ellipsis text-xs text-ink-gray-4">
+										<p class="truncate text-xs text-ink-gray-4">
 											{{
 												value.propOptions?.options?.defaultValue
-													? ["array", "object"].includes(value.propOptions.options.type)
+													? ["array", "object"].includes(value.propOptions.type)
 														? JSON.stringify(value.propOptions?.options?.defaultValue)
 														: value.propOptions?.options?.defaultValue
 													: __("No Default Value")

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -4,11 +4,11 @@
 			<template v-for="(value, name, index) in props.obj" :key="index">
 				<div
 					class="prop-list-item relative flex w-full flex-col rounded bg-surface-gray-1 p-2 text-ink-gray-6">
-					<Popover :offset="32" placement="right">
-						<template #target="{ open }">
+					<Popover :offset="32" side="right" align="center" bare>
+						<template #trigger>
 							<div
 								class="flex w-full cursor-pointer items-center justify-between"
-								@click.stop="
+								@click="
 									() => {
 										popupMode = 'edit';
 										popoverContentItemsRef[index]?.reset({
@@ -17,7 +17,6 @@
 											keepType: false,
 										});
 										keyBeingEdited = name as string;
-										open();
 									}
 								">
 								<div class="flex w-fit max-w-[60%] items-center gap-2 pl-2">
@@ -58,11 +57,11 @@
 										class="flex-shrink-0 bg-transparent text-xs text-ink-gray-6"
 										variant="subtle"
 										icon="lucide-x"
-										@click="deleteObjectKey(name as string)" />
+										@click.stop="deleteObjectKey(name as string)" />
 								</div>
 							</div>
 						</template>
-						<template #body="{ open, close }">
+						<template #default="{ close }">
 							<PropsPopoverContent
 								ref="popoverContentItemsRef"
 								mode="edit"
@@ -79,8 +78,8 @@
 				</div>
 			</template>
 		</div>
-		<Popover ref="popOverRef" :offset="24" placement="right">
-			<template #target="{ open }">
+		<Popover :offset="24" side="right" align="center" bare>
+			<template #trigger>
 				<Button
 					class="w-full"
 					variant="subtle"
@@ -94,11 +93,10 @@
 							});
 							keyBeingEdited = null;
 							popupMode = 'add';
-							open();
 						}
 					"></Button>
 			</template>
-			<template #body="{ open, close }">
+			<template #default="{ close }">
 				<PropsPopoverContent
 					ref="popoverContentAddRef"
 					:mode="popupMode"
@@ -144,7 +142,6 @@ const events = Object.fromEntries(
 const popupMode = ref<"add" | "edit">("add");
 const keyBeingEdited = ref<string | null>(null);
 const propDetailsOfKeyBeingEdited = ref<BlockProps[string] | null>(null);
-const popOverRef = ref<typeof Popover | null>(null);
 const popoverContentAddRef = ref<typeof PropsPopoverContent | null>(null);
 const popoverContentItemsRef = ref<Array<typeof PropsPopoverContent | null>>([]);
 

--- a/frontend/src/components/ShadowHandler.vue
+++ b/frontend/src/components/ShadowHandler.vue
@@ -1,7 +1,10 @@
 <template>
-	<Popover placement="left" class="!block w-full" :offset="25">
-		<template #target="{ togglePopover }">
-			<div class="flex w-full items-center justify-between" @focusin="updateActiveState">
+	<Popover side="left" align="center" :offset="25" bare :open="isOpen" @update:open="onUpdateOpen">
+		<template #trigger>
+			<div
+				class="flex w-full items-center justify-between"
+				@focusin="updateActiveState"
+				@click.capture="onAnchorClick">
 				<StylePropertyControl
 					propertyKey="boxShadow"
 					:component="Input"
@@ -9,7 +12,7 @@
 					:enableStates="true"
 					:allowDynamicValue="true"
 					:placeholder="__('None')"
-					@focus="togglePopover"
+					@focus="toggle"
 					:getModelValue="() => getBoxShadowValue(null)"
 					:getVariantValue="(v: string) => getBoxShadowValue(v)"
 					:setVariantValue="handleSetVariant"
@@ -20,7 +23,7 @@
 							@click="
 								() => {
 									activeState = variant;
-									togglePopover();
+									toggle();
 								}
 							"
 							:style="{
@@ -30,7 +33,7 @@
 				</StylePropertyControl>
 			</div>
 		</template>
-		<template #body>
+		<template #default>
 			<div
 				class="shadow-popover-body max-h-[80vh] w-64 select-none overflow-y-auto rounded-lg border border-outline-gray-1 bg-surface-base p-3 shadow-xl">
 				<div class="mb-3 space-y-3">
@@ -146,6 +149,7 @@ import OptionToggle from "@/components/Controls/OptionToggle.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import blockController from "@/utils/blockController";
 import { useEventListener } from "@vueuse/core";
+import { useAnchoredPopover } from "@/utils/useAnchoredPopover";
 import { Button, Popover, Tooltip } from "frappe-ui";
 import { computed, reactive, ref, watch } from "vue";
 
@@ -157,6 +161,7 @@ const SHADOW_CONTROLS = [
 ] as const;
 
 const activeState = ref<string | null>(null);
+const { isOpen, toggle, onAnchorClick, onUpdateOpen } = useAnchoredPopover();
 
 const updateActiveState = (e: FocusEvent) => {
 	const target = e.target as HTMLElement;

--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -1,11 +1,11 @@
 <template>
-	<Popover placement="bottom" :offset="20">
-		<template #target="{ togglePopover }">
+	<Popover side="bottom" align="center" :offset="20" bare>
+		<template #trigger>
 			<div class="flex cursor-pointer items-center gap-2 p-2 text-ink-gray-8">
 				<div class="flex h-6 items-center text-base text-ink-gray-6" v-if="!pageStore.activePage">
 					{{ __("Loading...") }}
 				</div>
-				<div @click="togglePopover" v-else class="flex items-center gap-1">
+				<div v-else class="flex items-center gap-1">
 					<Tooltip :text="__('This is the homepage for your site')" :hoverDelay="0.6">
 						<span
 							class="lucide-home h-[14px] w-4"
@@ -37,10 +37,10 @@
 					class="lucide-external-link h-[14px] w-[14px] !text-gray-700 dark:!text-gray-200"
 					aria-hidden="true"
 					v-if="pageStore.activePage && pageStore.activePage.published"
-					@click="pageStore.openPageInBrowser(pageStore.activePage as BuilderPage)" />
+					@click.stop="pageStore.openPageInBrowser(pageStore.activePage as BuilderPage)" />
 			</div>
 		</template>
-		<template #body>
+		<template #default>
 			<div class="flex w-72 flex-col gap-3 rounded bg-surface-base p-4 shadow-lg" v-if="pageStore.activePage">
 				<PageOptions></PageOptions>
 			</div>

--- a/frontend/src/utils/createRegistry.ts
+++ b/frontend/src/utils/createRegistry.ts
@@ -1,4 +1,22 @@
-import { computed, reactive, ref, toRaw } from "vue";
+import { computed, markRaw, reactive, ref, toRaw } from "vue";
+
+const isComponentLike = (value: unknown): value is object =>
+	Boolean(value) &&
+	typeof value === "object" &&
+	("render" in (value as object) || "setup" in (value as object) || "__name" in (value as object));
+
+// items live in a reactive Map, which would proxy the component definitions they
+// carry (a tab's panel, a control, an icon) and make Vue warn on every render
+function withRawComponents<T extends object>(item: T): T {
+	for (const [key, value] of Object.entries(item)) {
+		if (isComponentLike(value)) {
+			(item as Record<string, unknown>)[key] = markRaw(value);
+		} else if (Array.isArray(value)) {
+			value.forEach((entry) => entry && typeof entry === "object" && withRawComponents(entry));
+		}
+	}
+	return item;
+}
 
 /**
  * Every registry item needs a stable identity, and may ask for a position
@@ -61,7 +79,7 @@ export function createRegistry<T extends RegistryEntry>() {
 
 	// returns its own unregister, so a caller never has to track names
 	const register = (item: T) => {
-		const registered = { ...item };
+		const registered = withRawComponents({ ...item });
 		items.set(item.name, registered);
 		place(registered);
 		// a later registration under the same name owns the entry, so this must not delete it

--- a/frontend/src/utils/fontManager.ts
+++ b/frontend/src/utils/fontManager.ts
@@ -93,7 +93,16 @@ async function carriesWeight(font: string, weight: string): Promise<boolean> {
 	return entry.variants.includes(weight) || (weight === "400" && entry.variants.includes("regular"));
 }
 
+/** A system font (Arial, Comic Sans MS) or an unregistered custom family is not on
+ * Google Fonts; requesting it anyway costs a round trip that ends in a CORS error. */
+async function inGoogleCatalog(font: string): Promise<boolean> {
+	const items = fontListItems.value.length ? fontListItems.value : await loadFontList().catch(() => []);
+	// a catalog that failed to load must not block every font
+	return !items.length || items.some((item) => item.family === font);
+}
+
 async function loadGoogleFont(font: string, weight?: string): Promise<string> {
+	if (!(await inGoogleCatalog(font))) return font;
 	if (weight && !(await carriesWeight(font, weight))) weight = undefined;
 	return new Promise<string>((resolve) => {
 		const attempt = (withWeight: boolean) => {

--- a/frontend/src/utils/useAnchoredPopover.ts
+++ b/frontend/src/utils/useAnchoredPopover.ts
@@ -1,0 +1,43 @@
+import { ref } from "vue";
+
+/**
+ * State for a popover anchored to a whole control row (a swatch beside an input).
+ *
+ * frappe-ui's `#trigger` toggles on every click inside it, which for a row means
+ * focusing the input would open and close the panel. Bind `:open` and
+ * `@update:open` here instead: the row decides when it opens (a swatch click, a
+ * focus), while dismissals from outside the row still close it.
+ */
+export function useAnchoredPopover(onChange?: (open: boolean) => void) {
+	const isOpen = ref(false);
+	// true for the duration of a click inside the anchor: the toggle the trigger
+	// emits for that click is ignored, a dismissal (outside click, Escape) is not
+	let anchorClick = false;
+
+	const set = (value: boolean) => {
+		if (isOpen.value === value) return;
+		isOpen.value = value;
+		onChange?.(value);
+	};
+
+	const open = () => set(true);
+	const close = () => set(false);
+	const toggle = (value?: boolean | Event) => {
+		if (value instanceof Event || value == null) value = !isOpen.value;
+		set(value);
+	};
+
+	const onAnchorClick = () => {
+		anchorClick = true;
+		setTimeout(() => {
+			anchorClick = false;
+		});
+	};
+
+	const onUpdateOpen = (value: boolean) => {
+		if (value || anchorClick) return;
+		close();
+	};
+
+	return { isOpen, open, close, toggle, onAnchorClick, onUpdateOpen };
+}


### PR DESCRIPTION
Opening any page in the editor logged 8 errors and ~200 warnings, all from the editor itself. After this, the console is clean.

- **Registry components made reactive**: `createRegistry` keeps items in a reactive Map, so the components they carry (tab panels, property controls, icons) were proxied. Component-valued fields are now marked raw at registration.
- **Component prop controls**: the component-props section now passes `propertyKey`, `BasePropertyControl` and `OptionToggle` accept boolean defaults, and number defaults are stringified for the placeholder.
- **Font CORS errors**: the font loader requested every Font token family from Google Fonts, system and custom ones included. It now consults the bundled catalog first; User Fonts still load through their own path.
- **`BorderRadiusHandler`** renders a fragment, so `data-block-id` now goes to the handle explicitly.
- **frappe-ui Popover deprecations**: twelve call sites moved from `#target`/`#body` and `placement` to `#trigger`/`#default` with `bare`, `side` and `align`; the label description tooltip moved to `Tooltip`. The v1 trigger toggles on any click inside it, so popovers anchored to a whole property row (color picker, background, shadow, image) go through `useAnchoredPopover`: controlled open where the row decides, dismissals still close. Gradient stop pickers are controlled too, so the click that ends a drag no longer opens one.

Also on the way: the color picker anchor keeps its full width, component prop rows use the panel width, the array and object editors are labelled "Items", and every chat panel control uses the same tooltip.
