### PR TITLE
fix: duplicate a standard page as a plain page

### DIFF
--- a/builder/api.py
+++ b/builder/api.py
@@ -439,6 +439,8 @@ def duplicate_page(page_name: str):
 	new_page = frappe.copy_doc(page)
 	del new_page.page_name
 	new_page.route = None
+	new_page.is_standard = 0
+	new_page.app = None
 	clone_client_scripts(page, new_page)
 	new_page.flags.source = "duplicate"
 	new_page.insert()

--- a/builder/builder/tests/test_api.py
+++ b/builder/builder/tests/test_api.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from PIL import Image
 
-from builder.api import import_remote_assets, import_remote_fonts
+from builder.api import duplicate_page, import_remote_assets, import_remote_fonts
 
 FONT = "https://cdn.example.com/inter.woff2"
 
@@ -173,3 +173,16 @@ class TestImportRemoteFonts(FrappeTestCase):
 			imported = import_remote_fonts(fonts)
 
 		self.assertEqual(len(imported), 2)
+
+
+class TestDuplicatePage(FrappeTestCase):
+	def test_duplicate_of_a_standard_page_is_a_plain_page(self):
+		# developer mode off so the standard page is not exported to disk
+		with patch.dict(frappe.conf, {"developer_mode": 0}):
+			page = frappe.get_doc(
+				{"doctype": "Builder Page", "page_title": "Standard", "is_standard": 1, "app": "builder"}
+			).insert()
+			duplicate = duplicate_page(page.name)
+
+		self.assertFalse(duplicate.is_standard)
+		self.assertFalse(duplicate.app)


### PR DESCRIPTION
Fixes #597

`frappe.copy_doc` keeps `no_copy` fields unless told otherwise, so duplicating a standard page carried `is_standard` and `app` over. Outside developer mode the copy then opened read-only, and inside it a second export was written for the same app. The duplicate now starts as a plain page: not standard, no app.
