### PR TITLE
fix: render dotted data keys whose root is missing

### DIFF
--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -952,21 +952,25 @@ def interpret_prop_value(prop_config: dict, data_key: dict | None) -> Any:
 	return value if not is_empty else "undefined"
 
 
+def get_binding_key(key: str, comes_from: str, data_key: dict | None) -> str:
+	"""Jinja expression for a bound key that survives a missing root."""
+	if comes_from == "props":
+		return jinja_safe_key(f"props.{key}")
+	if comes_from == "componentData":
+		return jinja_safe_key(f"component.{key}")
+	if data_key:
+		return jinja_safe_key(f"{extract_data_key(data_key)}.{key}")
+	# a flat key keeps 0 and "" as-is; only a dotted path raises when its root is undefined
+	if is_safe_data_key(key) and "." not in key:
+		return key
+	return jinja_safe_key(key)
+
+
 def get_dynamic_props_template(
 	prop_value: str, comes_from: str, data_key: dict | None, default_value: Any
 ) -> str:
 	"""Get a Jinja template reference for dynamic properties."""
-	if comes_from == "props":
-		key = jinja_safe_key(f"props.{prop_value}")
-	elif comes_from == "componentData":
-		key = jinja_safe_key(f"component.{prop_value}")
-	else:  # dataScript
-		if data_key:
-			base_key = extract_data_key(data_key)
-			key = jinja_safe_key(f"{base_key}.{prop_value}")
-		else:
-			key = prop_value
-
+	key = get_binding_key(prop_value, comes_from, data_key)
 	fallback = escape_single_quotes(default_value) if default_value is not None else "undefined"
 	return f"{{{{ {key} if {key} is defined else '{fallback}' }}}}"
 
@@ -1265,15 +1269,7 @@ def get_visibility_condition_key(block: dict, data_key: dict | None) -> str | No
 	if not key:
 		return None
 
-	# Get key based on source
-	if comes_from == "props":
-		return jinja_safe_key(f"props.{key}")
-	elif comes_from == "componentData":
-		return jinja_safe_key(f"component.{key}")
-	else:  # dataScript
-		if data_key:
-			return f"{extract_data_key(data_key)}.{key}"
-		return key
+	return get_binding_key(key, comes_from, data_key)
 
 
 def escape_raw_text_end_tag(content: str, tag: str) -> str:
@@ -1400,7 +1396,7 @@ def set_dynamic_content_placeholders(block: dict, data_key: dict | None = None):
 		if not dynamic_value_doc or not dynamic_value_doc.get("key"):
 			continue
 
-		key = get_dynamic_value_key(dynamic_value_doc, original_key, data_key)
+		key = get_binding_key(original_key, dynamic_value_doc.get("comesFrom", "dataScript"), data_key)
 
 		property_name = dynamic_value_doc.get("property")
 		value_type = dynamic_value_doc.get("type")
@@ -1433,22 +1429,6 @@ def set_dynamic_content_placeholders(block: dict, data_key: dict | None = None):
 			block[property_name] = (
 				f"{{{{ {key} if {key} or {key} in ['', 0] else '{escape_single_quotes(current_value)}' }}}}"
 			)
-
-
-def get_dynamic_value_key(dynamic_value_doc: dict, original_key: str, data_key: dict | None) -> str:
-	"""Get the Jinja key for a dynamic value."""
-	comes_from = dynamic_value_doc.get("comesFrom", "dataScript")
-
-	if comes_from == "props":
-		return jinja_safe_key(f"props.{original_key}")
-	elif comes_from == "componentData":
-		return jinja_safe_key(f"component.{original_key}")
-	else:  # dataScript
-		key = dynamic_value_doc.get("key")
-		if data_key:
-			key = f"{extract_data_key(data_key)}.{key}"
-			return jinja_safe_key(key)
-		return key
 
 
 def wrap_html_with_context(html: str, context: dict) -> str:

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -952,28 +952,28 @@ def interpret_prop_value(prop_config: dict, data_key: dict | None) -> Any:
 	return value if not is_empty else "undefined"
 
 
-def get_binding_key(key: str, comes_from: str, data_key: dict | None) -> str:
+def get_binding_key(key: str, comes_from: str, data_key: dict | None, missing: str = "{}") -> str:
 	"""Jinja expression for a bound key that survives a missing root."""
 	if comes_from == "props":
-		return jinja_safe_key(f"props.{key}")
+		return jinja_safe_key(f"props.{key}", missing)
 	if comes_from == "componentData":
-		return jinja_safe_key(f"component.{key}")
+		return jinja_safe_key(f"component.{key}", missing)
 	if data_key:
-		return jinja_safe_key(f"{extract_data_key(data_key)}.{key}")
+		return jinja_safe_key(f"{extract_data_key(data_key)}.{key}", missing)
 	# a flat key keeps 0 and "" as-is; only a dotted path raises when its root is undefined
 	if is_safe_data_key(key) and "." not in key:
 		return key
-	return jinja_safe_key(key)
+	return jinja_safe_key(key, missing)
 
 
 def get_dynamic_props_template(
 	prop_value: str, comes_from: str, data_key: dict | None, default_value: Any
 ) -> str:
 	"""Get a Jinja template reference for dynamic properties."""
-	key = get_binding_key(prop_value, comes_from, data_key)
+	# props tell a missing path apart from an empty object, so the chain ends in none
+	key = get_binding_key(prop_value, comes_from, data_key, missing="none")
 	fallback = escape_single_quotes(default_value) if default_value is not None else "undefined"
-	# a guarded chain yields {} for a missing binding, which still counts as defined
-	return f"{{{{ {key} if {key} is defined and {key} != {{}} else '{fallback}' }}}}"
+	return f"{{{{ {key} if {key} is defined and {key} is not none else '{fallback}' }}}}"
 
 
 def create_html_tag(block: dict, state: dict, ancestor_font: str | None = None) -> bs.Tag:
@@ -1833,17 +1833,19 @@ def is_safe_data_key(key) -> bool:
 	return isinstance(key, str) and bool(SAFE_DATA_KEY.match(key))
 
 
-def jinja_safe_key(key):
-	# convert a.b to (a or {}).get('b', {})
-	# to avoid undefined error in jinja
+def jinja_safe_key(key, missing="{}"):
+	# convert a.b to (a or {}).get('b', {}) to avoid undefined error in jinja;
+	# the last segment falls back to `missing`
 	if not is_safe_data_key(key):
 		# render nothing rather than emitting a broken Jinja expression
-		return "{}"
-	keys = (key or "").split(".")
-	key = f"({keys[0]} or {{}})"
-	for k in keys[1:]:
-		key = f"{key}.get('{k}', {{}})"
-	return key
+		return missing
+	keys = key.split(".")
+	expr = f"({keys[0]} or {{}})"
+	for k in keys[1:-1]:
+		expr = f"{expr}.get('{k}', {{}})"
+	if len(keys) > 1:
+		expr = f"{expr}.get('{keys[-1]}', {missing})"
+	return expr
 
 
 def to_jinja_literal(obj):

--- a/builder/builder/doctype/builder_page/builder_page.py
+++ b/builder/builder/doctype/builder_page/builder_page.py
@@ -972,7 +972,8 @@ def get_dynamic_props_template(
 	"""Get a Jinja template reference for dynamic properties."""
 	key = get_binding_key(prop_value, comes_from, data_key)
 	fallback = escape_single_quotes(default_value) if default_value is not None else "undefined"
-	return f"{{{{ {key} if {key} is defined else '{fallback}' }}}}"
+	# a guarded chain yields {} for a missing binding, which still counts as defined
+	return f"{{{{ {key} if {key} is defined and {key} != {{}} else '{fallback}' }}}}"
 
 
 def create_html_tag(block: dict, state: dict, ancestor_font: str | None = None) -> bs.Tag:

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -267,6 +267,60 @@ class TestBuilderPage(FrappeTestCase):
 		finally:
 			page.delete()
 
+	def dotted_key_blocks(self):
+		body = Block(element="div", originalElement="body")
+		heading = Block(element="h1", innerHTML="Fallback title")
+		heading.set_dynamic_value("hero.title", "key", "innerHTML")
+		link = Block(element="a", innerHTML="Link", attributes={"href": "/fallback"})
+		link.set_dynamic_value("hero.link", "attribute", "href")
+		note = Block(element="p", innerHTML="Only with hero")
+		note.visibilityCondition = {"key": "hero.show", "comesFrom": "dataScript"}
+		body.attach_children(heading, link, note)
+		return body
+
+	def test_dotted_keys_without_their_root_fall_back(self):
+		"""Blocks pasted from another page keep bindings like `hero.title`. A page whose
+		data script does not define `hero` must render the fallbacks, not fail."""
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Dotted Keys Fallback Test",
+				"published": 1,
+				"route": "/dotted-keys-fallback-test",
+				"blocks": self.dotted_key_blocks().as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/dotted-keys-fallback-test")
+			self.assertEqual("Fallback title", get_html_for(content, "tag", "h1", only_content=True))
+			self.assertIn('href="/fallback"', get_html_for(content, "tag", "a"))
+			self.assertNotIn("Only with hero", content)
+		finally:
+			page.delete()
+
+	def test_dotted_keys_resolve_from_page_data(self):
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Dotted Keys Test",
+				"published": 1,
+				"route": "/dotted-keys-test",
+				"page_data_script": (
+					'data.update({"hero": {"title": "Real title", "link": "https://example.com", "show": True}})'
+				),
+				"blocks": self.dotted_key_blocks().as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/dotted-keys-test")
+			self.assertEqual("Real title", get_html_for(content, "tag", "h1", only_content=True))
+			self.assertIn('href="https://example.com"', get_html_for(content, "tag", "a"))
+			self.assertIn("Only with hero", content)
+		finally:
+			page.delete()
+
 	def test_repeater_block_dynamic_values(self):
 		body = Block(
 			element="div",

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -388,6 +388,28 @@ class TestBuilderPage(FrappeTestCase):
 			page.delete()
 			component.delete()
 
+	def test_dynamic_prop_keeps_an_empty_object(self):
+		component, instance = self.component_with_dynamic_title("hero.meta")
+		body = Block(element="div", originalElement="body")
+		body.attach_children(instance)
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Dynamic Prop Empty Object Test",
+				"published": 1,
+				"route": "/dynamic-prop-empty-object-test",
+				"page_data_script": 'data.update({"hero": {"meta": {}}})',
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/dynamic-prop-empty-object-test")
+			self.assertIn('"title": {}', content)
+		finally:
+			page.delete()
+			component.delete()
+
 	def test_repeater_block_dynamic_values(self):
 		body = Block(
 			element="div",

--- a/builder/builder/doctype/builder_page/test_builder_page.py
+++ b/builder/builder/doctype/builder_page/test_builder_page.py
@@ -321,6 +321,73 @@ class TestBuilderPage(FrappeTestCase):
 		finally:
 			page.delete()
 
+	def component_with_dynamic_title(self, key):
+		prop = {
+			"label": "Title",
+			"isStandard": True,
+			"isDynamic": False,
+			"isPassedDown": False,
+			"comesFrom": None,
+			"value": "Default Title",
+			"propOptions": {
+				"isRequired": False,
+				"type": "string",
+				"options": {"defaultValue": "Default Title"},
+			},
+		}
+		root = Block(
+			element="div", blockId="dynamic-prop-root", clientScript={"js": "void 0;"}, props={"title": prop}
+		)
+		component = frappe.get_doc({"doctype": "Builder Component", "block": root.as_json()}).insert()
+		instance = Block(
+			extendedFromComponent=component.name,
+			props={"title": {**prop, "isDynamic": True, "comesFrom": "dataScript", "value": key}},
+		)
+		return component, instance
+
+	def test_dynamic_prop_without_its_root_uses_the_default(self):
+		component, instance = self.component_with_dynamic_title("hero.title")
+		body = Block(element="div", originalElement="body")
+		body.attach_children(instance)
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Dynamic Prop Fallback Test",
+				"published": 1,
+				"route": "/dynamic-prop-fallback-test",
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/dynamic-prop-fallback-test")
+			self.assertIn('"title": "Default Title"', content)
+		finally:
+			page.delete()
+			component.delete()
+
+	def test_dynamic_prop_resolves_from_page_data(self):
+		component, instance = self.component_with_dynamic_title("hero.title")
+		body = Block(element="div", originalElement="body")
+		body.attach_children(instance)
+		page = frappe.get_doc(
+			{
+				"doctype": "Builder Page",
+				"page_title": "Dynamic Prop Test",
+				"published": 1,
+				"route": "/dynamic-prop-test",
+				"page_data_script": 'data.update({"hero": {"title": "Real title"}})',
+				"blocks": body.as_json(wrap_in_array=True),
+			}
+		).insert()
+
+		try:
+			content = get_response_content("/dynamic-prop-test")
+			self.assertIn('"title": "Real title"', content)
+		finally:
+			page.delete()
+			component.delete()
+
 	def test_repeater_block_dynamic_values(self):
 		body = Block(
 			element="div",


### PR DESCRIPTION
Fixes #288

Blocks copied from one page to another keep their bindings, for example `hero.title`. When the target page's data script does not define `hero`, the raw key was emitted into the template and Jinja raised on the attribute read, so the whole page failed with a server error.

Dynamic values, dynamic props and visibility conditions each had their own copy of the key resolution. They now share `get_binding_key`, which guards a dotted path with the same `(a or {}).get('b', {})` chain that repeaters and component props already use. Flat keys stay raw so `0` and `""` still render as-is, and a key that is not a safe identifier renders nothing instead of broken Jinja.

For dynamic props the chain ends in `none` instead of `{}` and the template tests `is not none`, so a missing binding gets the prop's configured default while an empty object, `""`, `0`, `[]` and `False` pass through unchanged.
