### PR TITLE
fix: move the color token dropdown from the picker popover to the Background field

### DIFF
--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -3,26 +3,25 @@
 		<template #trigger>
 			<div
 				class="flex w-full items-center justify-between"
-				@focusin="updateActiveState"
+				@focusin="handleFocusIn"
 				@click.capture="onAnchorClick">
 				<StylePropertyControl
 					propertyKey="background"
-					:component="BackgroundInput"
+					:component="Autocomplete"
 					:label="__('Background')"
 					:enableStates="true"
 					:allowDynamicValue="true"
 					:placeholder="__('Set Background')"
-					readonly
-					:selectOnFocus="false"
-					class="[&_input]:cursor-pointer"
-					@focus="toggle"
-					:getModelValue="() => getDisplayValue(null)"
-					:getVariantValue="(v: string) => getDisplayValue(v)"
+					:getOptions="getColorOptions"
+					:allowArbitraryValue="false"
+					:getModelValue="() => getValue(null)"
+					:getVariantValue="(v: string) => getValue(v)"
+					:getControlAttrs="getControlAttrs"
 					:setVariantValue="handleSetVariant"
 					:setModelValue="(val: string) => setBGValue(val)">
 					<template #prefix="{ variant }">
 						<div
-							class="absolute left-2 top-[6px] size-4 cursor-pointer rounded shadow-md"
+							class="size-4 cursor-pointer rounded shadow-md"
 							@click="
 								() => {
 									activeState = variant;
@@ -141,52 +140,23 @@
 
 <script lang="ts" setup>
 import { __ } from "@/translation";
+import Autocomplete from "@/components/Controls/Autocomplete.vue";
 import ColorPicker from "@/components/Controls/ColorPicker.vue";
 import GradientEditor from "@/components/Controls/GradientEditor.vue";
 import ImageFocusInput from "@/components/Controls/ImageFocusInput.vue";
-import Input from "@/components/Controls/Input.vue";
 import StylePropertyControl from "@/components/Controls/StylePropertyControl.vue";
 import useBuilderStore from "@/stores/builderStore";
 import blockController from "@/utils/blockController";
+import { getColorVariableOptions } from "@/utils/colorOptions";
 import { cssUrl } from "@/utils/helpers";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { STRETCH_TABS } from "@/utils/tabButtons";
 import { useAnchoredPopover } from "@/utils/useAnchoredPopover";
 import { FileUploader, Popover, Switch, TabButtons } from "frappe-ui";
-import { computed, defineComponent, h, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 const builderStore = useBuilderStore();
 const { getVariableName, resolveVariableValue, variables } = useBuilderToken();
-
-// wraps Input to style the value like ColorInput does when it displays a variable name
-const BackgroundInput = defineComponent({
-	props: {
-		modelValue: { type: [String, Number, Boolean], default: "" },
-	},
-	setup(props, { attrs, slots }) {
-		const showsVariableName = computed(() => {
-			return (
-				!!props.modelValue &&
-				variables.value.some((builderToken) => builderToken.token_name === props.modelValue)
-			);
-		});
-		return () =>
-			h(
-				Input,
-				{
-					...attrs,
-					modelValue: props.modelValue,
-					class: [
-						attrs.class,
-						showsVariableName.value
-							? "[&_input]:font-mono [&_input]:text-sm [&_input]:text-ink-violet-6"
-							: "",
-					],
-				},
-				slots,
-			);
-	},
-});
 
 const activeState = ref<string | null>(null);
 const colorPickerRef = ref<InstanceType<typeof ColorPicker> | null>(null);
@@ -213,6 +183,14 @@ const updateActiveState = (e: FocusEvent) => {
 	}
 };
 
+// like ColorInput: a token value gets the token dropdown on focus, anything else the picker
+const handleFocusIn = (e: FocusEvent) => {
+	updateActiveState(e);
+	const target = e.target as HTMLElement;
+	if (target.tagName !== "INPUT" || target.closest(".background-popover-body")) return;
+	if (!getColorToken(activeState.value)) toggle();
+};
+
 const getStyleKey = (prop: string, state: string | null = activeState.value) => {
 	return state ? `${state}:${prop}` : prop;
 };
@@ -234,6 +212,23 @@ watch(
 	},
 	{ immediate: true },
 );
+
+const getColorToken = (state: string | null) => {
+	const color = blockController.getStyle(getStyleKey("backgroundColor", state)) as string;
+	const hasImage = Boolean(blockController.getStyle(getStyleKey("backgroundImage", state)));
+	return !hasImage && color?.startsWith("var(--") ? color : null;
+};
+
+// a token is handed over as its var() value so the dropdown can mark it as selected
+const getValue = (state: string | null) => getColorToken(state) ?? getDisplayValue(state);
+
+const getControlAttrs = (state: string | null) => ({
+	displayValue: getDisplayValue(state),
+	class: getColorToken(state) ? "[&>div>div>input]:text-sm [&>div>div>input]:text-ink-violet-6" : "",
+});
+
+const getColorOptions = async (query: string) =>
+	getColorVariableOptions(query, variables.value, resolveVariableValue, builderStore.canvasDarkMode);
 
 const getDisplayValue = (state: string | null) => {
 	const bg = blockController.getStyle(getStyleKey("backgroundImage", state)) as string;
@@ -339,7 +334,7 @@ const setBGValue = (value: string) => {
 	if (isValidHexValue(value)) {
 		blockController.setStyle(colorKey, `#${value}`);
 		blockController.setStyle(bgKey, null);
-	} else if (value?.startsWith("#") || value?.startsWith("rgb") || value?.startsWith("hsl")) {
+	} else if (/^(#|rgb|hsl|var\()/.test(value || "")) {
 		blockController.setStyle(colorKey, value);
 		blockController.setStyle(bgKey, null);
 	} else {
@@ -408,9 +403,15 @@ const handleSetVariant = (variantName: string, value: string | number | boolean 
 		}
 	});
 
-	// the trigger input is read-only, so a non-null value here can only come from
-	// the "copy current value to state" dropdown — copy the actual base styles
-	// instead of the display text (e.g. "Gradient", variable name, image file name)
+	if (typeof value === "string" && value.startsWith("var(--")) {
+		blockController.setStyle(colorKey, value);
+		blockController.setStyle(bgKey, null);
+		return;
+	}
+
+	// the input only picks tokens, so any other value comes from the "copy current
+	// value to state" dropdown: copy the actual base styles instead of the display
+	// text (e.g. "Gradient", image file name)
 	blockController.setStyle(bgKey, (blockController.getStyle("backgroundImage") as string) ?? null);
 	blockController.setStyle(colorKey, (blockController.getStyle("backgroundColor") as string) ?? null);
 };

--- a/frontend/src/components/Controls/ColorPicker.vue
+++ b/frontend/src/components/Controls/ColorPicker.vue
@@ -85,7 +85,6 @@ function togglePopover(open?: boolean | Event) {
 defineExpose({
 	togglePopover,
 	isOpen,
-	hideOptions: () => contentRef.value?.hideOptions(),
 	commitRecentColor: () => contentRef.value?.commitRecentColor(),
 });
 </script>

--- a/frontend/src/components/Controls/ColorPickerContent.vue
+++ b/frontend/src/components/Controls/ColorPickerContent.vue
@@ -42,23 +42,19 @@
 				:style="{ background: color }"></div>
 			<EyeDropperIcon v-if="isSupported" class="text-ink-gray-7" @click="() => open()" />
 		</div>
-		<Autocomplete
+		<Input
 			v-if="showInput"
-			ref="autocompleteRef"
+			type="text"
+			class="mt-2 [&_input]:text-sm"
 			:modelValue="displayValue"
-			class="mt-2 w-full text-sm [&>div>div>input]:text-sm"
 			:placeholder="__('Set Color')"
-			:getOptions="getOptions"
-			referenceElementSelector=".color-picker-container"
 			@update:modelValue="handleInputChange" />
 	</div>
 </template>
 <script setup lang="ts">
-import Autocomplete from "@/components/Controls/Autocomplete.vue";
+import Input from "@/components/Controls/Input.vue";
 import EyeDropperIcon from "@/components/Icons/EyeDropper.vue";
-import useBuilderStore from "@/stores/builderStore";
 import useCanvasStore from "@/stores/canvasStore";
-import { getColorVariableOptions } from "@/utils/colorOptions";
 import { HSVToHex, HexToHSV, getRGB } from "@/utils/helpers";
 import { useBuilderToken } from "@/utils/useBuilderToken";
 import { clamp, useElementBounding, useEyeDropper, useStorage } from "@vueuse/core";
@@ -66,14 +62,12 @@ import { Ref, StyleValue, computed, nextTick, onBeforeUnmount, ref, watch } from
 
 type CSSColorValue = HashString | RGBString | `var(--${string})`;
 
-const { variables, resolveVariableValue, getVariableName } = useBuilderToken();
-const builderStore = useBuilderStore();
+const { resolveVariableValue, getVariableName } = useBuilderToken();
 const canvasStore = useCanvasStore();
 
 const colorMap = ref(null) as unknown as Ref<HTMLDivElement>;
 const hueMap = ref(null) as unknown as Ref<HTMLDivElement>;
 const alphaMap = ref(null) as unknown as Ref<HTMLDivElement>;
-const autocompleteRef = ref<InstanceType<typeof Autocomplete> | null>(null);
 
 const {
 	width: colorMapWidth,
@@ -137,9 +131,6 @@ const displayValue = computed(() => {
 	}
 	return props.modelValue;
 });
-
-const getOptions = async (query: string) =>
-	getColorVariableOptions(query, variables.value, resolveVariableValue, builderStore.canvasDarkMode);
 
 const emit = defineEmits(["update:modelValue"]);
 
@@ -391,7 +382,6 @@ watch(
 
 defineExpose({
 	syncPositions: () => setSelectorPosition(modelColor.value),
-	hideOptions: () => autocompleteRef.value?.hideOptions(),
 	commitRecentColor,
 });
 </script>

--- a/frontend/src/components/Controls/GradientEditor.vue
+++ b/frontend/src/components/Controls/GradientEditor.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="select-none space-y-4">
+	<div class="select-none space-y-3">
 		<!-- Type & Angle -->
 		<div class="flex items-center gap-3">
 			<TabButtons
@@ -83,11 +83,11 @@
 		</div>
 
 		<!-- Recently used gradients, falling back to the built-in presets -->
-		<div class="flex flex-wrap gap-2">
+		<div class="flex flex-wrap gap-1.5">
 			<div
 				v-for="swatch in gradientSwatches"
 				:key="swatch.gradient"
-				class="size-6 cursor-pointer rounded-full border border-outline-gray-2 shadow-sm transition-colors hover:border-outline-gray-4"
+				class="size-5 cursor-pointer rounded-full shadow-sm"
 				:style="{ background: swatch.gradient }"
 				@click="applyPreset(swatch.gradient)"
 				:title="swatch.name" />

--- a/frontend/src/components/TextBlockBubbleMenu.vue
+++ b/frontend/src/components/TextBlockBubbleMenu.vue
@@ -171,14 +171,7 @@ const menuElement = computed(() => menu.value?.$el);
 
 const isCanvasMoving = computed(() => Boolean(props.canvasProps?.panning || props.canvasProps?.scaling));
 
-// the option list is teleported to <body> and cannot follow the menu out of sight
-watch(isRepositioning, (hidden) => hidden && colorPicker.value?.hideOptions());
-
-// opening the popover focuses its input, which auto-opens the option list
-const openColorPicker = () => {
-	colorPicker.value?.togglePopover();
-	nextTick(() => requestAnimationFrame(() => colorPicker.value?.hideOptions()));
-};
+const openColorPicker = () => colorPicker.value?.togglePopover();
 
 const editorRef = computed(() => props.editor);
 const bubbleMenuPluginKey = "bubbleMenu";


### PR DESCRIPTION
Focusing the input inside the color picker popover opened a token dropdown over the whole picker, while the Background field in the panel was read-only. The dropdown now lives on the field, the way Text Color already works, and the popover keeps a plain input.

- **Background field**: uses the same token `Autocomplete` as `ColorInput`. A token value opens the dropdown on focus and shows the token name in violet; any other value opens the picker. Picking a token sets `backgroundColor` and clears `backgroundImage`, for the base value and for state variants, so `setBGValue` and `handleSetVariant` learn the `var()` case. The field only accepts tokens from the list.
- **Picker popover**: the input is a plain `Input` for hex and rgb entry. `hideOptions` on `ColorPicker` and its two calls in the text bubble menu only existed to close the teleported dropdown, so they are gone.
- **Gradient presets**: 20px dots in two rows of seven instead of 24px dots in three rows, with the tab's row spacing tightened.

Background field with a token value, before and after:

![Background field before and after](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/background-token-dropdown/pr_field.png)

Picker popover with its input focused, before and after:

![Picker popover before and after](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/background-token-dropdown/pr_popover.png)

Gradient tab, before and after:

![Gradient tab before and after](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/background-token-dropdown/pr_gradient.png)
