### PR TITLE
fix: type colors into the Background field and keep its label in sync

### DIFF
--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -183,7 +183,6 @@ const updateActiveState = (e: FocusEvent) => {
 	}
 };
 
-// like ColorInput: a token value gets the token dropdown on focus, anything else the picker
 const handleFocusIn = (e: FocusEvent) => {
 	updateActiveState(e);
 	const target = e.target as HTMLElement;
@@ -219,7 +218,7 @@ const getColorToken = (state: string | null) => {
 	return !hasImage && color?.startsWith("var(--") ? color : null;
 };
 
-// a token is handed over as its var() value so the dropdown can mark it as selected
+// the var() value, not the name, so the dropdown marks it as selected
 const getValue = (state: string | null) => getColorToken(state) ?? getDisplayValue(state);
 
 const getControlAttrs = (state: string | null) => ({
@@ -322,7 +321,6 @@ const setBGImage = (file: { file_url: string }) => {
 	}
 };
 
-// what the field was given: a colour the browser accepts, an image, or nothing usable
 const parseBackground = (value: string) => {
 	const color = /^([0-9A-F]{3}){1,2}$/i.test(value) ? `#${value}` : value;
 	if (CSS.supports("color", color)) return { color };
@@ -404,8 +402,7 @@ const handleSetVariant = (variantName: string, value: string | number | boolean 
 
 	if (typeof value === "string" && parseBackground(value)) return setBackground(bgKey, colorKey, value);
 
-	// anything else is display text from the "copy current value to state" dropdown
-	// (e.g. "Gradient", image file name): copy the actual base styles instead
+	// display text from the "copy current value to state" dropdown: copy the real base styles
 	blockController.setStyle(bgKey, (blockController.getStyle("backgroundImage") as string) ?? null);
 	blockController.setStyle(colorKey, (blockController.getStyle("backgroundColor") as string) ?? null);
 };

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -13,7 +13,7 @@
 					:allowDynamicValue="true"
 					:placeholder="__('Set Background')"
 					:getOptions="getColorOptions"
-					:allowArbitraryValue="false"
+					:selectOnFocus="true"
 					:getModelValue="() => getValue(null)"
 					:getVariantValue="(v: string) => getValue(v)"
 					:getControlAttrs="getControlAttrs"
@@ -322,26 +322,25 @@ const setBGImage = (file: { file_url: string }) => {
 	}
 };
 
-const setBGValue = (value: string) => {
-	const bgKey = getStyleKey("backgroundImage");
-	const colorKey = getStyleKey("backgroundColor");
-	const isValidHexValue = (value: string) => /^([0-9A-F]{3}){1,2}$/i.test(value);
-
-	let cleanURL = value;
-	if (value?.startsWith("url(")) {
-		cleanURL = value.replace(/^url\(['"]?|['"]?\)$/g, "");
+// what the field was given: a colour, an image, or nothing usable
+const parseBackground = (value: string) => {
+	if (/^([0-9A-F]{3}){1,2}$/i.test(value)) return { color: `#${value}` };
+	if (/^(#|rgb|hsl|var\()/.test(value)) return { color: value };
+	if (/^(url\(|https?:\/\/|\/|data:)/.test(value)) {
+		return { image: cssUrl(value.replace(/^url\(['"]?|['"]?\)$/g, "")) };
 	}
-	if (isValidHexValue(value)) {
-		blockController.setStyle(colorKey, `#${value}`);
-		blockController.setStyle(bgKey, null);
-	} else if (/^(#|rgb|hsl|var\()/.test(value || "")) {
-		blockController.setStyle(colorKey, value);
-		blockController.setStyle(bgKey, null);
-	} else {
-		blockController.setStyle(bgKey, cleanURL ? cssUrl(cleanURL) : null);
-		blockController.setStyle(colorKey, null);
-	}
+	return null;
 };
+
+const setBackground = (bgKey: string, colorKey: string, value: string | null) => {
+	const parsed = value ? parseBackground(value) : null;
+	if (value && !parsed) return;
+	blockController.setStyle(colorKey, parsed?.color ?? null);
+	blockController.setStyle(bgKey, parsed?.image ?? null);
+};
+
+const setBGValue = (value: string | null) =>
+	setBackground(getStyleKey("backgroundImage"), getStyleKey("backgroundColor"), value);
 
 const setBGColor = (color: string | null) => {
 	blockController.setStyle(getStyleKey("backgroundColor"), color);
@@ -403,15 +402,10 @@ const handleSetVariant = (variantName: string, value: string | number | boolean 
 		}
 	});
 
-	if (typeof value === "string" && value.startsWith("var(--")) {
-		blockController.setStyle(colorKey, value);
-		blockController.setStyle(bgKey, null);
-		return;
-	}
+	if (typeof value === "string" && parseBackground(value)) return setBackground(bgKey, colorKey, value);
 
-	// the input only picks tokens, so any other value comes from the "copy current
-	// value to state" dropdown: copy the actual base styles instead of the display
-	// text (e.g. "Gradient", image file name)
+	// anything else is display text from the "copy current value to state" dropdown
+	// (e.g. "Gradient", image file name): copy the actual base styles instead
 	blockController.setStyle(bgKey, (blockController.getStyle("backgroundImage") as string) ?? null);
 	blockController.setStyle(colorKey, (blockController.getStyle("backgroundColor") as string) ?? null);
 };

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -322,10 +322,10 @@ const setBGImage = (file: { file_url: string }) => {
 	}
 };
 
-// what the field was given: a colour, an image, or nothing usable
+// what the field was given: a colour the browser accepts, an image, or nothing usable
 const parseBackground = (value: string) => {
-	if (/^([0-9A-F]{3}){1,2}$/i.test(value)) return { color: `#${value}` };
-	if (/^(#|rgb|hsl|var\()/.test(value)) return { color: value };
+	const color = /^([0-9A-F]{3}){1,2}$/i.test(value) ? `#${value}` : value;
+	if (CSS.supports("color", color)) return { color };
 	if (/^(url\(|https?:\/\/|\/|data:)/.test(value)) {
 		return { image: cssUrl(value.replace(/^url\(['"]?|['"]?\)$/g, "")) };
 	}

--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -277,7 +277,7 @@ const handleFocus = (event: FocusEvent) => {
 	emit("focus");
 };
 
-// the owner may reject what was submitted, so the input goes back to showing the model
+// a rejected submission leaves the model as is, so the text resyncs to it
 const submitArbitraryValue = (inputValue: string) => {
 	if (!inputValue) return;
 	const matchingOption = allOptions.value.find((opt) => opt.label.toLowerCase() === inputValue.toLowerCase());
@@ -326,10 +326,9 @@ watch(searchQuery, (query) => props.getOptions && refreshOptions(query));
 watch([searchQuery, () => props.modelValue, allOptions], () => nextTick(checkOverflow), { flush: "post" });
 // seed the search term with the option's label, not the raw value: it is what the
 // input shows, what filterOptions windows the list around, and what Enter compares
-// against (a value like "700" would otherwise read as text typed over "Bold").
-// a model change always wins, even under an open list (a popover may have set it);
-// options refreshing under an open list must not clobber what is being typed
+// against (a value like "700" would otherwise read as text typed over "Bold")
 watch(() => props.modelValue, syncSearchQuery, { immediate: true });
+// refreshed options must not clobber what is being typed
 watch(allOptions, () => !isOpen.value && syncSearchQuery());
 
 const setOptionsPosition = () => {

--- a/frontend/src/components/Controls/Autocomplete.vue
+++ b/frontend/src/components/Controls/Autocomplete.vue
@@ -18,12 +18,7 @@
 					ref="comboboxInput"
 					v-model="searchQuery"
 					autocomplete="off"
-					@focus="
-						() => {
-							emit('focus');
-							return false;
-						}
-					"
+					@focus="handleFocus"
 					@blur="handleBlur"
 					@keydown.enter="handleEnter"
 					:display-value="getDisplayValue"
@@ -169,6 +164,7 @@ interface Props {
 	actionButton?: ActionButton;
 	referenceElementSelector?: string;
 	allowArbitraryValue?: boolean;
+	selectOnFocus?: boolean;
 	disabled?: boolean;
 	// floor for the options width, so a narrow input doesn't force truncated labels
 	optionsMinWidth?: number;
@@ -272,11 +268,22 @@ const clearSelection = () => emit("update:modelValue", null);
 
 const getInputValue = (event: Event) => (event.target as HTMLInputElement)?.value?.trim();
 
+const syncSearchQuery = () => (searchQuery.value = getDisplayValue(props.modelValue));
+
+// select() also focuses, so skip it once a popover opened on this focus and took it
+const handleFocus = (event: FocusEvent) => {
+	const input = event.target as HTMLInputElement;
+	if (props.selectOnFocus) setTimeout(() => document.activeElement === input && input.select());
+	emit("focus");
+};
+
+// the owner may reject what was submitted, so the input goes back to showing the model
 const submitArbitraryValue = (inputValue: string) => {
 	if (!inputValue) return;
 	const matchingOption = allOptions.value.find((opt) => opt.label.toLowerCase() === inputValue.toLowerCase());
 	emit("update:modelValue", matchingOption?.value ?? inputValue);
 	isOpen.value = false;
+	nextTick(syncSearchQuery);
 };
 
 // the input still shows the current selection, i.e. nothing was typed over it
@@ -319,15 +326,11 @@ watch(searchQuery, (query) => props.getOptions && refreshOptions(query));
 watch([searchQuery, () => props.modelValue, allOptions], () => nextTick(checkOverflow), { flush: "post" });
 // seed the search term with the option's label, not the raw value: it is what the
 // input shows, what filterOptions windows the list around, and what Enter compares
-// against (a value like "700" would otherwise read as text typed over "Bold")
-watch(
-	[() => props.modelValue, allOptions],
-	() => {
-		if (isOpen.value) return;
-		searchQuery.value = getDisplayValue(props.modelValue);
-	},
-	{ immediate: true },
-);
+// against (a value like "700" would otherwise read as text typed over "Bold").
+// a model change always wins, even under an open list (a popover may have set it);
+// options refreshing under an open list must not clobber what is being typed
+watch(() => props.modelValue, syncSearchQuery, { immediate: true });
+watch(allOptions, () => !isOpen.value && syncSearchQuery());
 
 const setOptionsPosition = () => {
 	// nextTick flushes the DOM but not layout; the anchored position can still move

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -25,6 +25,7 @@
 								}"
 								v-bind="events"
 								ref="colorInput"
+								:selectOnFocus="true"
 								:referenceElementSelector="autocompleteReferenceElementSelector"
 								@keydown.enter="handleEnter"
 								@focus="() => !isCssVariable && togglePopover()"


### PR DESCRIPTION
Follow-ups to #813 for the Background field.

- **Text selects on focus**, for Background and Text Color. `Autocomplete` gains `selectOnFocus`; `select()` is skipped when a popover already took the focus on that same focus, since it would hand it back and toggle the popover shut.
- **Typed colors apply.** A hex (with or without `#`), rgb, hsl or image path typed into the field sets the background; anything else is ignored and the label restored. `parseBackground` decides what a value means, for the base value and for state variants, while the "copy current value to state" path still copies the real base styles.
- **The label follows the popup.** `Autocomplete` skipped syncing its text while its list was open, and the list never closed once the picker popover took the focus, so a color picked there left "Gradient" in the field. Model changes now always sync the text; only option refreshes wait for the list to close.
