### PR TITLE
fix: open color pickers from the swatch only, and show the value in the New Token dialog

### DIFF
--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -20,8 +20,10 @@
 					:setVariantValue="handleSetVariant"
 					:setModelValue="(val: string) => setBGValue(val)">
 					<template #prefix="{ variant }">
-						<div
-							class="size-4 cursor-pointer rounded shadow-md"
+						<button
+							type="button"
+							class="size-4 cursor-pointer rounded shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4"
+							:aria-label="__('Open background picker')"
 							@click="
 								() => {
 									activeState = variant;

--- a/frontend/src/components/BackgroundHandler.vue
+++ b/frontend/src/components/BackgroundHandler.vue
@@ -183,11 +183,12 @@ const updateActiveState = (e: FocusEvent) => {
 	}
 };
 
+// a gradient or image has no text worth editing, so focus goes straight to the picker
 const handleFocusIn = (e: FocusEvent) => {
 	updateActiveState(e);
 	const target = e.target as HTMLElement;
 	if (target.tagName !== "INPUT" || target.closest(".background-popover-body")) return;
-	if (!getColorToken(activeState.value)) toggle();
+	if (hasImage(activeState.value)) toggle();
 };
 
 const getStyleKey = (prop: string, state: string | null = activeState.value) => {
@@ -212,10 +213,12 @@ watch(
 	{ immediate: true },
 );
 
+const hasImage = (state: string | null) =>
+	Boolean(blockController.getStyle(getStyleKey("backgroundImage", state)));
+
 const getColorToken = (state: string | null) => {
 	const color = blockController.getStyle(getStyleKey("backgroundColor", state)) as string;
-	const hasImage = Boolean(blockController.getStyle(getStyleKey("backgroundImage", state)));
-	return !hasImage && color?.startsWith("var(--") ? color : null;
+	return !hasImage(state) && color?.startsWith("var(--") ? color : null;
 };
 
 // the var() value, not the name, so the dropdown marks it as selected

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -28,7 +28,6 @@
 								:selectOnFocus="true"
 								:referenceElementSelector="autocompleteReferenceElementSelector"
 								@keydown.enter="handleEnter"
-								@focus="() => !isCssVariable && togglePopover()"
 								:placeholder="displayPlaceholder"
 								:modelValue="modelValue"
 								:displayValue="displayValue"

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -43,14 +43,16 @@
 								"
 								@update:modelValue="handleColorUpdate">
 								<template #prefix>
-									<div
-										class="size-4 cursor-pointer rounded shadow-md"
+									<button
+										type="button"
+										class="size-4 cursor-pointer rounded shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4"
+										:aria-label="__('Open color picker')"
 										@click="togglePopover"
 										:style="{
 											background: modelValue
 												? resolvedColor
 												: `url(/assets/builder/images/color-circle.png) center / contain`,
-										}"></div>
+										}"></button>
 								</template>
 							</Autocomplete>
 						</Tooltip>

--- a/frontend/src/components/Controls/ColorInput.vue
+++ b/frontend/src/components/Controls/ColorInput.vue
@@ -231,9 +231,7 @@ const handleClose = () => {
 };
 
 const openVariableDialog = () => {
-	newVariable.value = {
-		value: props.modelValue || "",
-	};
+	newVariable.value = { type: "Color", value: props.modelValue || "" };
 	showVariableDialog.value = true;
 };
 

--- a/frontend/src/components/Modals/NewBuilderToken.vue
+++ b/frontend/src/components/Modals/NewBuilderToken.vue
@@ -22,7 +22,15 @@
 					:autofocus="true"
 					:placeholder="__('e.g., primary, accent, background')"
 					:hideClearButton="true" />
-				<div v-if="activeBuilderToken.type === 'Color'" class="flex flex-col gap-3">
+				<div v-if="dialogMode === 'add' && activeBuilderToken.value" class="flex flex-col gap-1.5">
+					<InputLabel>{{ __("Value") }}</InputLabel>
+					<BuilderInput type="text" :modelValue="activeBuilderToken.value" readonly :hideClearButton="true">
+						<template v-if="activeBuilderToken.type === 'Color'" #prefix>
+							<div class="size-4 rounded shadow-md" :style="{ background: activeBuilderToken.value }" />
+						</template>
+					</BuilderInput>
+				</div>
+				<div v-else-if="activeBuilderToken.type === 'Color'" class="flex flex-col gap-3">
 					<div class="flex flex-col gap-1.5">
 						<InputLabel>{{ __("Light Mode Color") }}</InputLabel>
 						<ColorInput
@@ -96,7 +104,8 @@ const handleSave = async () => {
 		emit("update:modelValue", false);
 	} catch (error) {
 		console.error("Failed to save variable:", error);
-		const fallbackMessage = dialogMode.value === "edit" ? __("Failed to update token") : __("Failed to create token");
+		const fallbackMessage =
+			dialogMode.value === "edit" ? __("Failed to update token") : __("Failed to create token");
 		toast.error((error as Error).message || fallbackMessage);
 	}
 };


### PR DESCRIPTION
Follow-ups to #816.

- **Color pickers open from the swatch only.** A color is editable text, so focusing any `ColorInput` (Text Color, Border Color, shadow color) or the Background field shows just the token dropdown with the text selected; the swatch opens the picker. The swatch is a real button now, with a focus ring, so Enter or Space opens the picker from the keyboard. Background still opens its picker on focus for a gradient or image, whose label is not worth editing.
- **Save as Token shows what it saves.** The dialog only rendered its color section when the partial token carried a `type`, and the color fields passed just the value, so it showed a bare name field. Create mode now shows the value read-only with its swatch (or the font family); edit mode keeps the light and dark inputs.

![New Token dialog with the value it saves](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/background-token-dropdown/pr_token_dialog.png)
