### PR TITLE
fix: mark a published page with a Live badge instead of the globe icon

### DIFF
--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -8,7 +8,7 @@
 				<div v-else class="flex items-center gap-1">
 					<Tooltip :text="__('This is the homepage for your site')" :hoverDelay="0.6">
 						<span
-							class="lucide-home h-[14px] w-4"
+							class="lucide-home size-4"
 							aria-hidden="true"
 							v-if="pageStore.isHomePage(pageStore.activePage)" />
 					</Tooltip>
@@ -19,7 +19,7 @@
 					</Tooltip>
 					<Tooltip :text="__('Publicly accessible')" :hoverDelay="0.6">
 						<span
-							class="lucide-globe mr-1 h-[14px] w-[14px] !text-gray-700 dark:!text-gray-200"
+							class="lucide-globe size-4"
 							v-if="
 								pageStore.activePage?.published &&
 								!pageStore.activePage?.authenticated_access &&

--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -17,17 +17,6 @@
 							class="lucide-shield-user size-4 text-ink-amber-6"
 							v-if="pageStore.activePage?.published && pageStore.activePage?.authenticated_access" />
 					</Tooltip>
-					<Tooltip :text="__('Currently live')" :hoverDelay="0.6">
-						<span
-							class="flex size-4 items-center justify-center"
-							v-if="
-								pageStore.activePage?.published &&
-								!pageStore.activePage?.authenticated_access &&
-								!pageStore.isHomePage(pageStore.activePage)
-							">
-							<span class="size-2 rounded-full bg-green-500" />
-						</span>
-					</Tooltip>
 					<span
 						class="max-w-48 truncate text-base text-ink-gray-8"
 						:title="pageStore?.activePage?.page_title || __('My Page')">
@@ -39,6 +28,13 @@
 						v-html="routeString"
 						:title="getTextContent(routeString)"></span>
 				</div>
+				<Badge
+					theme="green"
+					size="sm"
+					v-if="pageStore.activePage?.published"
+					class="dark:bg-green-900 dark:text-green-400">
+					{{ __("Live") }}
+				</Badge>
 				<span
 					class="lucide-external-link h-[14px] w-[14px] !text-gray-700 dark:!text-gray-200"
 					aria-hidden="true"
@@ -60,7 +56,7 @@ import useBuilderStore from "@/stores/builderStore";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import { getTextContent } from "@/utils/helpers";
-import { Popover, Tooltip } from "frappe-ui";
+import { Badge, Popover, Tooltip } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
 const pageStore = usePageStore();

--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -17,14 +17,16 @@
 							class="lucide-shield-user size-4 text-ink-amber-6"
 							v-if="pageStore.activePage?.published && pageStore.activePage?.authenticated_access" />
 					</Tooltip>
-					<Tooltip :text="__('Publicly accessible')" :hoverDelay="0.6">
+					<Tooltip :text="__('Currently live')" :hoverDelay="0.6">
 						<span
-							class="lucide-globe size-4"
+							class="flex size-4 items-center justify-center"
 							v-if="
 								pageStore.activePage?.published &&
 								!pageStore.activePage?.authenticated_access &&
 								!pageStore.isHomePage(pageStore.activePage)
-							" />
+							">
+							<span class="size-2 rounded-full bg-green-500" />
+						</span>
 					</Tooltip>
 					<span
 						class="max-w-48 truncate text-base text-ink-gray-8"

--- a/frontend/src/components/ToolbarItems/PageTitlePopover.vue
+++ b/frontend/src/components/ToolbarItems/PageTitlePopover.vue
@@ -20,7 +20,11 @@
 					<Tooltip :text="__('Publicly accessible')" :hoverDelay="0.6">
 						<span
 							class="lucide-globe mr-1 h-[14px] w-[14px] !text-gray-700 dark:!text-gray-200"
-							v-if="pageStore.activePage?.published && !pageStore.activePage?.authenticated_access" />
+							v-if="
+								pageStore.activePage?.published &&
+								!pageStore.activePage?.authenticated_access &&
+								!pageStore.isHomePage(pageStore.activePage)
+							" />
 					</Tooltip>
 					<span
 						class="max-w-48 truncate text-base text-ink-gray-8"


### PR DESCRIPTION
The page title marked a published page with a globe and the tooltip "Publicly accessible". It crowded the house icon on the home page, and it described the wrong thing: what matters at a glance is that the page is live.

A green `Live` badge now sits on the right of the title, just before the open-in-browser icon, for any published page. It reuses frappe-ui's `Badge theme="green"`, the same one the dashboard list already shows for published pages.

The remaining status icons also sized themselves differently, so the gap between icon and title moved with the icon. The house and the limited-access shield are both `size-4` now, and the row's own gap does the spacing.

Home page, a published page, and an unpublished page:

![Page title states](https://raw.githubusercontent.com/surajshetty3416/builder/pr-assets/background-token-dropdown/pr_title_icons.png)
