### PR TITLE
fix: show creation timestamp when sorting pages by Last Created

### DIFF
--- a/frontend/src/components/PageCard.vue
+++ b/frontend/src/components/PageCard.vue
@@ -18,9 +18,9 @@
 							{{ page.page_title || page.page_name }}
 						</p>
 					</div>
-					<UseTimeAgo v-slot="{ timeAgo }" :time="page.modified">
+					<UseTimeAgo v-slot="{ timeAgo }" :time="timestamp">
 						<p class="mt-1 block text-sm text-ink-gray-5 group-hover:text-ink-gray-6">
-							{{ __("Edited {0}", [timeAgo]) }}
+							{{ sortedByCreation ? __("Created {0}", [timeAgo]) : __("Edited {0}", [timeAgo]) }}
 						</p>
 					</UseTimeAgo>
 				</span>
@@ -50,15 +50,18 @@
 <script setup lang="ts">
 import { __ } from "@/translation";
 import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
+import { useDashboardState } from "@/composables/useDashboardState";
 import { BuilderPage } from "@/types/doctypes";
-import { getUserInfo } from "@/usersInfo";
 import { UseTimeAgo } from "@vueuse/components";
 import { Tooltip } from "frappe-ui";
+import { computed } from "vue";
 
 const props = defineProps<{
 	page: BuilderPage;
 	selected: boolean;
 }>();
 
-const user = getUserInfo(props.page.modified_by);
+const { orderBy } = useDashboardState();
+const sortedByCreation = computed(() => orderBy.value === "creation");
+const timestamp = computed(() => (sortedByCreation.value ? props.page.creation : props.page.modified));
 </script>

--- a/frontend/src/components/PageListItem.vue
+++ b/frontend/src/components/PageListItem.vue
@@ -34,9 +34,13 @@
 							</div>
 						</div>
 						<div class="flex items-baseline gap-2 text-ink-gray-6">
-							<UseTimeAgo v-slot="{ timeAgo }" :time="page.modified">
+							<UseTimeAgo v-slot="{ timeAgo }" :time="timestamp">
 								<p class="mt-1 block text-sm">
-									{{ __("Last updated {0} by {1}", [timeAgo, modifiedBy.fullname]) }}
+									{{
+										sortedByCreation
+											? __("Created {0} by {1}", [timeAgo, owner.fullname])
+											: __("Last updated {0} by {1}", [timeAgo, modifiedBy.fullname])
+									}}
 								</p>
 							</UseTimeAgo>
 						</div>
@@ -68,11 +72,13 @@
 <script setup lang="ts">
 import { __ } from "@/translation";
 import PageActionsDropdown from "@/components/PageActionsDropdown.vue";
+import { useDashboardState } from "@/composables/useDashboardState";
 import usePageStore from "@/stores/pageStore";
 import { BuilderPage } from "@/types/doctypes";
 import { getUserInfo } from "@/usersInfo";
 import { UseTimeAgo } from "@vueuse/components";
 import { Avatar, Badge } from "frappe-ui";
+import { computed } from "vue";
 
 const pageStore = usePageStore();
 
@@ -83,4 +89,7 @@ const props = defineProps<{
 
 const modifiedBy = getUserInfo(props.page.modified_by);
 const owner = getUserInfo(props.page.owner);
+const { orderBy } = useDashboardState();
+const sortedByCreation = computed(() => orderBy.value === "creation");
+const timestamp = computed(() => (sortedByCreation.value ? props.page.creation : props.page.modified));
 </script>


### PR DESCRIPTION
## Problem

Selecting **Last Created** in the dashboard sort dropdown reorders the list
by creation date, but every page card keeps showing its *last modified*
timestamp

Before :
<img width="941" height="658" alt="image" src="https://github.com/user-attachments/assets/b34a0dc6-69b8-4e36-a422-d456a44521c0" />

Now:
<img width="1300" height="596" alt="image" src="https://github.com/user-attachments/assets/e95dd1ed-7310-4a78-8333-5e1a7e3e575b" />
