### PR TITLE
fix: paste blocks copied in another browser, and copy blocks nested in a component

### DIFF
--- a/frontend/src/components/TextBlock.vue
+++ b/frontend/src/components/TextBlock.vue
@@ -34,6 +34,7 @@ import TextBlockBubbleMenu from "@/components/TextBlockBubbleMenu.vue";
 import useCanvasStore from "@/stores/canvasStore";
 import blockController from "@/utils/blockController";
 import { BlockValueResolver } from "@/utils/blockValueResolver";
+import { hasBuilderClipboardPayload } from "@/utils/builderBlockCopyPaste";
 import { setFontFromHTML } from "@/utils/fontManager";
 import type { PauseId } from "@/utils/useCanvasHistory";
 import { Color } from "@tiptap/extension-color";
@@ -278,6 +279,10 @@ if (!props.preview) {
 						Selection,
 					],
 					enablePasteRules: false,
+					// copied blocks carry an empty text/html mirror that would replace the selection
+					editorProps: {
+						handlePaste: (_view, event) => hasBuilderClipboardPayload(event),
+					},
 					onUpdate({ editor }) {
 						let innerHTML = getInnerHTML(editor as Editor);
 						if (props.block.getInnerHTML() === innerHTML) {

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -100,7 +100,8 @@ export function copyBuilderBlocks(
 		// Handle component children and create copy
 		let blockCopy = null;
 		if (!Boolean(block.extendedFromComponent) && block.isChildOfComponent) {
-			blockCopy = detachBlockFromComponent(block, null);
+			// the detached copy is a live Block whose children point back at it
+			blockCopy = getCopyWithoutParent(detachBlockFromComponent(block, null));
 		} else {
 			blockCopy = getCopyWithoutParent(block);
 		}

--- a/frontend/src/utils/builderBlockCopyPaste.ts
+++ b/frontend/src/utils/builderBlockCopyPaste.ts
@@ -150,7 +150,7 @@ export function copyBuilderBlocks(
 		};
 		dataToCopy.pageScripts = pageStore.activePageScripts;
 	}
-	copyToClipboard(dataToCopy, e, "builder-copied-blocks");
+	writeClipboardPayload(e, dataToCopy);
 	copyEntirePage && toast.success(__("Page Copied"));
 }
 
@@ -158,10 +158,11 @@ export function copyBuilderBlocks(
  * The "builder-copied-blocks" clipboard type and the shape below are a public
  * contract: the Copy to Frappe Builder browser extension writes this payload from
  * any web page (github.com/surajshetty3416/copy-to-builder, see its CONTRACT.md).
+ * The JSON is also mirrored into text/html, so a copy pastes across browsers.
  * Adding keys is safe, renaming or removing the ones it writes is not.
  */
 export async function pasteBuilderBlocks(e: ClipboardEvent, currentSiteURL: string): Promise<void> {
-	const data = e.clipboardData?.getData("builder-copied-blocks") as string;
+	const data = readClipboardPayload(e);
 	if (!data || !isJSONString(data)) return;
 
 	const clipboardData = JSON.parse(data) as BuilderClipboardData;
@@ -594,4 +595,32 @@ function generateHash(initialId: string, siteURL: string, appendHash = false): s
 		const shortHash = Math.abs(hash).toString(36).slice(0, 8);
 		return `${initialId}_${shortHash}`;
 	}
+}
+
+// Chrome and Firefox keep custom clipboard types in private formats the other can't
+// read, so the payload is mirrored into text/html, which both share.
+const HTML_PAYLOAD_ATTRIBUTE = "data-builder-copied-blocks";
+
+function writeClipboardPayload(e: ClipboardEvent, data: BuilderClipboardData) {
+	const payload = JSON.stringify(data);
+	const holder = document.createElement("span");
+	holder.setAttribute(HTML_PAYLOAD_ATTRIBUTE, payload);
+	copyToClipboard(payload, e, "builder-copied-blocks");
+	copyToClipboard(holder.outerHTML, e, "text/html");
+}
+
+function readClipboardPayload(e: ClipboardEvent): string {
+	const data = e.clipboardData?.getData("builder-copied-blocks");
+	if (data) return data;
+	const html = e.clipboardData?.getData("text/html");
+	if (!html?.includes(HTML_PAYLOAD_ATTRIBUTE)) return "";
+	const holder = new DOMParser()
+		.parseFromString(html, "text/html")
+		.querySelector(`[${HTML_PAYLOAD_ATTRIBUTE}]`);
+	return holder?.getAttribute(HTML_PAYLOAD_ATTRIBUTE) || "";
+}
+
+// a rich-text editor would paste the empty text/html mirror over its selection
+export function hasBuilderClipboardPayload(e: ClipboardEvent): boolean {
+	return Boolean(readClipboardPayload(e));
 }


### PR DESCRIPTION
## Problem

Blocks copied in Chrome pasted nothing into Builder in Firefox, and the other way round. Builder puts copied blocks on the clipboard only under a custom type, `builder-copied-blocks`, and each browser stores custom types in its own private format that the other can't read. The same happens for blocks copied from the Figma desktop app or from the Copy to Frappe Builder extension in Chrome.

Copying a block inside a component was also broken, in every browser. The copy threw a circular JSON error and left the clipboard empty.

## Changes

- Copying also writes the blocks as HTML: an empty `<span>` with the JSON in a `data-builder-copied-blocks` attribute. Both browsers can read each other's HTML, so paste falls back to it when the custom type is missing. Plain text stays empty, because Builder pastes plain text as a new block.
- The text editor ignores pastes that contain copied blocks. Otherwise it would paste the empty span over the selected text and wipe it.
- A block copied from inside a component now goes through `getCopyWithoutParent`, like every other copied block, so it can be turned into JSON.

## Testing

Checked in Chrome and Firefox on macOS. Pasting between browsers and pasting images used the real system clipboard; the other cases ran in headless browsers.

| Paste | Before | After |
| --- | --- | --- |
| Blocks, same browser | ✅ | ✅ |
| Blocks, Chrome → Firefox | ❌ nothing pasted | ✅ |
| Blocks, Firefox → Chrome | ❌ nothing pasted | ✅ |
| Block inside a component | ❌ circular JSON error | ✅ |
| Copied blocks pasted over selected text in a text block | text kept | text kept |
| Plain text or rich HTML into a text block | ✅ | ✅ |
| Images, SVG, HTML, Figma CSS styles | ✅ | ✅ |

## Follow-up

The Copy to Frappe Builder extension and the Figma plugin need to write the same HTML before their copies paste into Firefox.
